### PR TITLE
Finalize auth system with user hashing

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -1,0 +1,30 @@
+# Postman Test Examples
+
+## Register
+```http
+POST http://localhost:5000/api/auth/register
+Content-Type: application/json
+
+{
+  "name": "John Doe",
+  "email": "john@example.com",
+  "password": "secret123"
+}
+```
+
+## Login
+```http
+POST http://localhost:5000/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "john@example.com",
+  "password": "secret123"
+}
+```
+
+## Protected Route
+```http
+GET http://localhost:5000/api/users
+Authorization: Bearer <JWT_TOKEN>
+```

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 
-module.exports = function(req, res, next) {
-  const authHeader = req.headers.authorization;
+module.exports = function (req, res, next) {
+  const authHeader = req.headers.authorization || req.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ message: 'No token, authorization denied' });
   }
@@ -10,7 +10,7 @@ module.exports = function(req, res, next) {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.userId = decoded.userId;
+    req.user = { id: decoded.userId };
     next();
   } catch (err) {
     return res.status(401).json({ message: 'Token is not valid' });


### PR DESCRIPTION
## Summary
- secure User model with password hashing and compare helper
- clean up auth routes and use model utilities
- improve auth middleware to attach `req.user`
- add Postman examples for quick manual testing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68829d86a2a8832e88744ed24036e530