### PR TITLE
Add AI Analyzer microservice scaffolding

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI, File, UploadFile
+from ocr_utils import extract_text
+from nlp_parser import parse_fields
+
+app = FastAPI()
+
+@app.post('/analyze')
+async def analyze(file: UploadFile = File(...)):
+    # Read the uploaded file
+    content = await file.read()
+    # Call OCR utility (stub)
+    text = extract_text(content)
+    # Call NLP parser (stub)
+    data = parse_fields(text)
+    # For now, return dummy data merged with parsed fields
+    response = {
+        "revenue": data.get("revenue", "N/A"),
+        "employees": data.get("employees", "N/A"),
+        "year_founded": data.get("year_founded", "N/A"),
+    }
+    return response

--- a/ai-analyzer/nlp_parser.py
+++ b/ai-analyzer/nlp_parser.py
@@ -1,0 +1,4 @@
+def parse_fields(text):
+    """Stub function to parse business fields from text."""
+    # TODO: Implement NLP parsing
+    return {}

--- a/ai-analyzer/ocr_utils.py
+++ b/ai-analyzer/ocr_utils.py
@@ -1,0 +1,4 @@
+def extract_text(file_bytes):
+    """Stub function to extract text from uploaded file bytes."""
+    # TODO: Implement OCR processing
+    return ""

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+nginx


### PR DESCRIPTION
## Summary
- set up `ai-analyzer` microservice
- scaffold FastAPI endpoint `/analyze`
- add placeholder OCR and NLP helpers
- include a Python `requirements.txt`

## Testing
- `npm test` *(fails: no test specified)*
- `pip install -r ai-analyzer/requirements.txt` *(fails: cannot access pypi)*
- `python3 -m uvicorn ai-analyzer.main:app --port 8000` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6882c7bd9f9c832eb44b9842ef55ae64