### PR TITLE
Connect Express server to FastAPI analyzer

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,7 @@ app.use('/api/auth', require('./routes/auth'));
 console.log('✅ Auth routes registered');
 app.use('/api/users', require('./routes/users'));
 app.use('/api/files', require('./routes/files'));
+app.use('/api/analyze', require('./routes/analyze'));
 
 // === Connect to DB and start server ===
 const PORT = process.env.PORT || 5000;

--- a/server/routes/analyze.js
+++ b/server/routes/analyze.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const multer = require('multer');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const FormData = require('form-data');
+
+const router = express.Router();
+const upload = multer({ dest: 'uploads/' });
+
+// @route   POST /api/analyze
+// @desc    Upload a file and forward it to the AI analyzer
+router.post('/', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ message: 'No file uploaded' });
+  }
+
+  const form = new FormData();
+  form.append('file', fs.createReadStream(req.file.path), req.file.originalname);
+
+  try {
+    const response = await fetch('http://localhost:8000/analyze', {
+      method: 'POST',
+      body: form,
+      headers: form.getHeaders(),
+    });
+
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Error calling AI analyzer:', err);
+    res.status(500).json({ message: 'Failed to analyze file' });
+  } finally {
+    fs.unlink(req.file.path, () => {});
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `/api/analyze` route to upload a file and forward it to the FastAPI analyzer
- mount the analyze route in `server/index.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882d04f79c4832eb035707e4a57bf00