### PR TITLE
Add eligibility engine microservice scaffold

### DIFF
--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -1,0 +1,8 @@
+# Eligibility Engine
+
+This microservice will evaluate business data against government grant
+criteria and return a list of programs that the business qualifies for.
+Future versions will load rule definitions from `grants_config.json` and
+use them to determine eligibility. The goal is to keep the service
+modular so it can be expanded with more sophisticated logic and easily
+integrated with other components of the platform.

--- a/eligibility-engine/engine.py
+++ b/eligibility-engine/engine.py
@@ -1,0 +1,19 @@
+"""Eligibility Engine module."""
+
+from typing import List, Dict
+
+
+def analyze_eligibility(data: Dict) -> List:
+    """Analyze input data and return a list of eligible grants.
+
+    Currently returns an empty list as a placeholder.
+    """
+    print(f"analyze_eligibility called with data: {data}")
+    # Placeholder logic; will evaluate rules based on grants_config in future
+    return []
+
+
+if __name__ == "__main__":
+    sample = {"company_name": "Acme Corp", "revenue": 1000000}
+    result = analyze_eligibility(sample)
+    print("Eligibility result:", result)

--- a/eligibility-engine/grants_config.json
+++ b/eligibility-engine/grants_config.json
@@ -1,0 +1,2 @@
+// Configuration mapping of grant rules for eligibility checks
+{}


### PR DESCRIPTION
## Summary
- initialize `eligibility-engine` microservice
- add placeholder `engine.py` with a simple `analyze_eligibility` function
- document the service in `README.md`
- include empty JSON config file with comment header

## Testing
- `python3 eligibility-engine/engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6882d6323f30832eb123bc34419558c5