### PR TITLE
Backend refactor and cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+MONGO_URI=mongodb://localhost:27017/grants
+JWT_SECRET=your_jwt_secret
+ANALYZER_URL=http://localhost:8000/analyze

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# Grant AI Platform – Backend
+# Grant AI Platform Backend
 
-This is the backend of the AI-driven grant eligibility platform.
+This repository contains three microservices used to test a grant eligibility workflow.
 
-## How to run
+- **server/** – Express API for authentication, file uploads and analysis forwarding
+- **ai-analyzer/** – FastAPI service that performs stub OCR/NLP processing
+- **eligibility-engine/** – Pure Python rules engine for grant logic
 
-```bash
-cd server
-npm install
-npm run dev
+## Running locally
+
+1. Install Node dependencies and start the API server
+   ```bash
+   npm install
+   node server/index.js
+   ```
+   Environment variables should be placed in a `.env` file. See `.env.example` for required keys.
+
+2. Start the AI analyzer
+   ```bash
+   cd ai-analyzer
+   python -m uvicorn main:app --port 8000
+   ```
+
+3. Run the eligibility engine tests
+   ```bash
+   cd eligibility-engine
+   python engine.py
+   ```

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -6,16 +6,21 @@ app = FastAPI()
 
 @app.post('/analyze')
 async def analyze(file: UploadFile = File(...)):
-    # Read the uploaded file
+    if file.content_type not in {"application/pdf", "image/png", "image/jpeg"}:
+        print(f"Unsupported file type received: {file.content_type}")
+
     content = await file.read()
-    # Call OCR utility (stub)
     text = extract_text(content)
-    # Call NLP parser (stub)
     data = parse_fields(text)
-    # For now, return dummy data merged with parsed fields
+
     response = {
         "revenue": data.get("revenue", "N/A"),
         "employees": data.get("employees", "N/A"),
         "year_founded": data.get("year_founded", "N/A"),
     }
     return response
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ai-analyzer/nlp_parser.py
+++ b/ai-analyzer/nlp_parser.py
@@ -1,4 +1,4 @@
 def parse_fields(text):
-    """Stub function to parse business fields from text."""
-    # TODO: Implement NLP parsing
-    return {}
+    """Return dummy structured data extracted from text."""
+    # In a real implementation NLP would parse ``text`` here.
+    return {"revenue": 100000, "employees": 10, "year_founded": 2018}

--- a/ai-analyzer/ocr_utils.py
+++ b/ai-analyzer/ocr_utils.py
@@ -1,4 +1,4 @@
 def extract_text(file_bytes):
-    """Stub function to extract text from uploaded file bytes."""
-    # TODO: Implement OCR processing
-    return ""
+    """Return placeholder text for demo purposes."""
+    # In a real implementation this would perform OCR on ``file_bytes``.
+    return "sample extracted text"

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -1,3 +1,2 @@
 fastapi
 uvicorn
-nginx

--- a/eligibility-engine/engine.py
+++ b/eligibility-engine/engine.py
@@ -139,3 +139,10 @@ if __name__ == "__main__":
         "startup_date": "2020-06-01",
     }
     print("Example 3:", analyze_eligibility(example3))
+
+    # Example 4: Missing required fields (should return empty list)
+    example4 = {
+        "business_type": "llc",
+        "covid_orders": [],
+    }
+    print("Example 4:", analyze_eligibility(example4))

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "morgan": "^1.10.1",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^1.4.5"
+    "multer": "^1.4.5",
+    "form-data": "^4.0.0"
   }
 }

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const multer = require('multer');
 
+const auth = require('../middleware/authMiddleware');
+
 const router = express.Router();
 const upload = multer({ dest: 'uploads/' });
 
 // @route   POST /api/files
 // @desc    Upload a file
-router.post('/', upload.single('file'), (req, res) => {
+router.post('/', auth, upload.single('file'), (req, res) => {
   if (!req.file) {
     return res.status(400).json({ message: 'No file uploaded' });
   }


### PR DESCRIPTION
## Summary
- add .env example and update README
- secure file upload and analyzer routes with auth
- allow analyzer URL to be configured via env
- stub out analyzer service with placeholder logic
- add invalid-case example in eligibility engine tests

## Testing
- `python engine.py`
- `node server/index.js` *(fails: Cannot find module 'jsonwebtoken')*
- `python main.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883a1cdad50832e88de5ec88d565df2