### PR TITLE
Add FastAPI eligibility service

### DIFF
--- a/eligibility-engine/api.py
+++ b/eligibility-engine/api.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, Request
+from engine import analyze_eligibility
+
+app = FastAPI()
+
+@app.post("/check")
+async def check_eligibility(request: Request):
+    try:
+        data = await request.json()
+        result = analyze_eligibility(data)
+        return {"eligible_grants": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("api:app", host="0.0.0.0", port=4001, reload=True)

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI wrapper to expose `analyze_eligibility()` via `/check`
- specify `fastapi` and `uvicorn` in service requirements

## Testing
- `python -m py_compile eligibility-engine/api.py`
- `pytest` *(no tests found)*
- `pip install fastapi uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6883aca62f78832eab86249a9001070f