### PR TITLE
Add new 2025 grant eligibility engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ This repository contains three microservices used to test a grant eligibility wo
 3. Run the eligibility engine tests
    ```bash
    cd eligibility-engine
-   python engine.py
+   python -m pytest
    ```

--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -1,8 +1,19 @@
 # Eligibility Engine
 
-This microservice will evaluate business data against government grant
-criteria and return a list of programs that the business qualifies for.
-Future versions will load rule definitions from `grants_config.json` and
-use them to determine eligibility. The goal is to keep the service
-modular so it can be expanded with more sophisticated logic and easily
-integrated with other components of the platform.
+This engine loads grant definitions from the `grants/` directory and matches
+user business data against each program. Grants are described in simple JSON
+files so new programs can be added without changing the code.
+
+## Usage
+
+Run the engine directly to see a basic example:
+
+```bash
+python engine.py
+```
+
+Or run the test suite:
+
+```bash
+python -m pytest
+```

--- a/eligibility-engine/engine.py
+++ b/eligibility-engine/engine.py
@@ -1,190 +1,60 @@
-"""Eligibility Engine module.
-
-This module evaluates business data against grant rules defined in
-``grants_config.json``. The goal is to keep the logic self contained so it
-can be reused by the backend API or CLI tools.
-"""
-
-from __future__ import annotations
-
-from typing import List, Dict, Any
-import json
 from pathlib import Path
-from datetime import datetime
+import json
+from typing import List, Dict, Any
+
+from grants_loader import load_grants
+from rules_utils import check_rules, estimate_award
 
 
-def estimate_rd_credit(data: Dict[str, Any]) -> float:
-    """Estimate the potential R&D credit based on QRE totals."""
-    qre = data.get("qre_total", 0)
-    if data.get("has_prior_rd"):
-        return 0.14 * max(qre - data.get("qre_avg_prev_3", 0), 0)
-    else:
-        return 0.06 * qre
-
-
-def check_r_and_d_eligibility(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Determine if the business qualifies for the R&D tax credit."""
-    conditions = [
-        data.get("has_product_or_process_dev") is True,
-        data.get("is_tech_based") is True,
-        data.get("has_technical_uncertainty") is True,
-        data.get("uses_experimentation") is True,
-    ]
-    if all(conditions):
-        return {
-            "eligible": True,
-            "credit_type": "R&D",
-            "estimated_amount": estimate_rd_credit(data),
-        }
-    return {"eligible": False}
-
-
-def analyze_eligibility(data: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Analyze input data and return a list of eligible grants.
-
-    Parameters
-    ----------
-    data:
-        Dictionary of business information. Expected keys are defined in
-        ``grants_config.json`` and include revenue figures and dates.
-    """
-
-    print(f"analyze_eligibility called with data: {data}")
-
-    config_path = Path(__file__).with_name("grants_config.json")
-    raw_lines = config_path.read_text().splitlines()
-    json_lines = [line for line in raw_lines if not line.strip().startswith("//")]
-    grants_config = json.loads("\n".join(json_lines) or "{}")
-
-    eligible: List[Dict[str, Any]] = []
-
-    # --- ERC eligibility check -------------------------------------------------
-    if "erc" in grants_config:
-        print("Checking ERC eligibility...")
-        erc_rule = grants_config["erc"]
-
-        required = erc_rule.get("required_fields", [])
-        missing = [field for field in required if field not in data]
+def analyze_eligibility(user_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Validate user data against all grant definitions."""
+    grants = load_grants()
+    results: List[Dict[str, Any]] = []
+    for grant in grants:
+        missing = [f for f in grant.get("required_fields", []) if f not in user_data]
         if missing:
-            print(f"Required fields missing for ERC: {missing}")
+            results.append({
+                "name": grant.get("name"),
+                "eligible": False,
+                "reason": f"Missing: {missing}"
+            })
+            continue
+
+        passed, reason = check_rules(user_data, grant.get("eligibility_rules", {}))
+        if passed:
+            amount = estimate_award(user_data, grant.get("estimated_award", {}))
+            results.append({
+                "name": grant.get("name"),
+                "eligible": True,
+                "estimated_amount": amount,
+                "reason": reason,
+            })
         else:
-            revenue = data.get("revenue_by_quarter", {})
-            covid_orders = set(data.get("covid_orders", []))
-            startup_date_str = data.get("startup_date")
-            startup_date = (
-                datetime.fromisoformat(startup_date_str).date()
-                if startup_date_str
-                else None
-            )
-
-            qualified_quarters = set()
-            qualification_path = None
-
-            # --- Revenue drop path -------------------------------------------
-            for year, threshold in [(2020, 50), (2021, 20)]:
-                for q in range(1, 5):
-                    current_key = f"{year}-Q{q}"
-                    base_key = f"2019-Q{q}"
-                    if (
-                        current_key in revenue
-                        and base_key in revenue
-                        and revenue[base_key] > 0
-                    ):
-                        drop = (revenue[base_key] - revenue[current_key]) / revenue[
-                            base_key
-                        ] * 100
-                        if drop >= threshold:
-                            qualified_quarters.add(current_key)
-                            if qualification_path is None:
-                                qualification_path = "revenue_drop"
-
-            # --- Government shutdown path ------------------------------------
-            for quarter in covid_orders:
-                if quarter.startswith("2020") or quarter.startswith("2021"):
-                    qualified_quarters.add(quarter)
-                    if qualification_path is None:
-                        qualification_path = "government_shutdown"
-
-            # --- Recovery Startup path ---------------------------------------
-            if not qualified_quarters and startup_date:
-                if startup_date > datetime(2020, 2, 15).date():
-                    qualified_quarters.update(["2021-Q3", "2021-Q4"])
-                    qualification_path = "startup"
-
-            if qualified_quarters:
-                result = {
-                    "grant": "erc",
-                    "qualified_quarters": sorted(qualified_quarters),
-                    "qualification_path": qualification_path,
-                }
-                eligible.append(result)
-                print(f"✅ ERC eligible via {qualification_path}")
-
-    # --- R&D Tax Credit eligibility check ------------------------------------
-    if "r_and_d" in grants_config:
-        print("Checking R&D eligibility...")
-        rd_rule = grants_config["r_and_d"]
-
-        required = rd_rule.get("required_fields", [])
-        missing = [field for field in required if field not in data]
-        if missing:
-            print(f"Required fields missing for R&D: {missing}")
-        else:
-            rd_result = check_r_and_d_eligibility(data)
-            if rd_result.get("eligible"):
-                rd_result["grant"] = "r_and_d"
-                eligible.append(rd_result)
-                print("✅ R&D credit eligible")
-
-    return eligible
+            results.append({
+                "name": grant.get("name"),
+                "eligible": False,
+                "reason": reason,
+            })
+    return results
 
 
 if __name__ == "__main__":
-    # Example 1: Eligible for 2020 via revenue drop of 55% in Q2
-    example1 = {
-        "revenue_by_quarter": {
-            "2019-Q2": 100000,
-            "2020-Q2": 45000,
-        },
-        "business_type": "s-corp",
-        "covid_orders": [],
-        "payroll_data": True,
-        "ppp_received": False,
-        "startup_date": "2019-01-01",
+    example = {
+        "has_product_or_process_dev": True,
+        "is_tech_based": True,
+        "qre_total": 120000,
+        "revenue_drop": 30,
+        "government_shutdown": True,
+        "qualified_wages": 80000,
+        "business_age_years": 3,
+        "owner_credit_score": 700,
+        "state": "CA",
+        "employees": 10,
+        "owner_gender": "female",
+        "industry": "technology",
+        "city": "New York",
+        "owner_minority": True,
+        "rural_area": False,
     }
-    print("Example 1:", analyze_eligibility(example1))
-
-    # Example 2: Eligible for 2021 via government shutdown in Q2
-    example2 = {
-        "revenue_by_quarter": {
-            "2019-Q2": 100000,
-            "2021-Q2": 98000,
-        },
-        "business_type": "llc",
-        "covid_orders": ["2021-Q2"],
-        "payroll_data": True,
-        "ppp_received": False,
-        "startup_date": "2018-05-01",
-    }
-    print("Example 2:", analyze_eligibility(example2))
-
-    # Example 3: Recovery startup eligible for Q3/Q4 2021
-    example3 = {
-        "revenue_by_quarter": {
-            "2019-Q3": 80000,
-            "2021-Q3": 79000,
-        },
-        "business_type": "c-corp",
-        "covid_orders": [],
-        "payroll_data": True,
-        "ppp_received": False,
-        "startup_date": "2020-06-01",
-    }
-    print("Example 3:", analyze_eligibility(example3))
-
-    # Example 4: Missing required fields (should return empty list)
-    example4 = {
-        "business_type": "llc",
-        "covid_orders": [],
-    }
-    print("Example 4:", analyze_eligibility(example4))
+    for result in analyze_eligibility(example):
+        print(result)

--- a/eligibility-engine/grants/california_smallbiz.json
+++ b/eligibility-engine/grants/california_smallbiz.json
@@ -1,0 +1,20 @@
+{
+  "name": "California Small Business Grant",
+  "year": 2025,
+  "description": "State grant for California-based small businesses",
+  "required_fields": ["state", "employees"],
+  "eligibility_rules": {
+    "state": ["CA"],
+    "employees_min": 1,
+    "employees_max": 100
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 10000
+  },
+  "tags": ["state", "california"],
+  "ui_questions": [
+    "Which state is your business located in?",
+    "How many employees do you have?"
+  ]
+}

--- a/eligibility-engine/grants/erc.json
+++ b/eligibility-engine/grants/erc.json
@@ -1,0 +1,21 @@
+{
+  "name": "Employee Retention Credit",
+  "year": 2021,
+  "description": "Refundable payroll tax credit for COVID-19 impacted businesses",
+  "required_fields": ["revenue_drop", "government_shutdown"],
+  "eligibility_rules": {
+    "revenue_drop_min": 20,
+    "government_shutdown": true
+  },
+  "estimated_award": {
+    "type": "percentage",
+    "percent": 70,
+    "based_on": "qualified_wages"
+  },
+  "tags": ["federal", "payroll", "covid"],
+  "ui_questions": [
+    "Did your revenue drop compared to 2019?",
+    "Were you ordered to fully or partially shutdown?",
+    "What were your qualified wages?"
+  ]
+}

--- a/eligibility-engine/grants/nyc_minority_grant.json
+++ b/eligibility-engine/grants/nyc_minority_grant.json
@@ -1,0 +1,19 @@
+{
+  "name": "NYC Minority Business Grant",
+  "year": 2025,
+  "description": "Support for minority-owned businesses in NYC",
+  "required_fields": ["city", "owner_minority"],
+  "eligibility_rules": {
+    "city": ["New York"],
+    "owner_minority": true
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 15000
+  },
+  "tags": ["city", "minority"],
+  "ui_questions": [
+    "Is your business located in New York City?",
+    "Is the owner part of a minority group?"
+  ]
+}

--- a/eligibility-engine/grants/r_and_d.json
+++ b/eligibility-engine/grants/r_and_d.json
@@ -1,0 +1,22 @@
+{
+  "name": "R&D Tax Credit",
+  "year": 2025,
+  "description": "Federal credit for qualifying R&D expenditures",
+  "required_fields": ["has_product_or_process_dev", "is_tech_based", "qre_total"],
+  "eligibility_rules": {
+    "has_product_or_process_dev": true,
+    "is_tech_based": true,
+    "qre_total_min": 50000
+  },
+  "estimated_award": {
+    "type": "percentage",
+    "percent": 6,
+    "based_on": "qre_total"
+  },
+  "tags": ["federal", "tax_credit", "innovation"],
+  "ui_questions": [
+    "Are you developing or improving a product or process?",
+    "Is your activity based on technology or science?",
+    "How much have you spent on R&D?"
+  ]
+}

--- a/eligibility-engine/grants/rural_dev_grant.json
+++ b/eligibility-engine/grants/rural_dev_grant.json
@@ -1,0 +1,19 @@
+{
+  "name": "Rural Development Grant",
+  "year": 2025,
+  "description": "Funding for businesses operating in rural areas",
+  "required_fields": ["rural_area", "employees"],
+  "eligibility_rules": {
+    "rural_area": true,
+    "employees_max": 50
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 25000
+  },
+  "tags": ["federal", "rural"],
+  "ui_questions": [
+    "Is your business located in a rural area?",
+    "How many employees do you have?"
+  ]
+}

--- a/eligibility-engine/grants/sba_microloan.json
+++ b/eligibility-engine/grants/sba_microloan.json
@@ -1,0 +1,19 @@
+{
+  "name": "SBA Microloan Program",
+  "year": 2025,
+  "description": "Loans up to $50,000 for small businesses",
+  "required_fields": ["business_age_years", "owner_credit_score"],
+  "eligibility_rules": {
+    "business_age_years_min": 1,
+    "owner_credit_score_min": 620
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 50000
+  },
+  "tags": ["federal", "loan"],
+  "ui_questions": [
+    "How long has your business been operating?",
+    "What is the owner's credit score?"
+  ]
+}

--- a/eligibility-engine/grants/women_owned_tech.json
+++ b/eligibility-engine/grants/women_owned_tech.json
@@ -1,0 +1,19 @@
+{
+  "name": "Women-Owned Tech Grant",
+  "year": 2025,
+  "description": "Support for tech companies owned by women",
+  "required_fields": ["owner_gender", "industry"],
+  "eligibility_rules": {
+    "owner_gender": "female",
+    "industry": ["technology", "software"]
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 20000
+  },
+  "tags": ["federal", "women", "technology"],
+  "ui_questions": [
+    "Is your business majority owned by women?",
+    "What industry are you in?"
+  ]
+}

--- a/eligibility-engine/grants_loader.py
+++ b/eligibility-engine/grants_loader.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import json
+from typing import List, Dict, Any
+
+
+GRANTS_DIR = Path(__file__).parent / "grants"
+
+
+def load_grants() -> List[Dict[str, Any]]:
+    """Load all grant JSON files from the grants directory."""
+    grants: List[Dict[str, Any]] = []
+    for path in GRANTS_DIR.glob("*.json"):
+        with path.open("r", encoding="utf-8") as f:
+            grants.append(json.load(f))
+    return grants

--- a/eligibility-engine/rules_utils.py
+++ b/eligibility-engine/rules_utils.py
@@ -1,0 +1,20 @@
+def check_rules(data, rules):
+    for key, val in rules.items():
+        if key.endswith("_min"):
+            if data.get(key.replace("_min", ""), 0) < val:
+                return False, f"{key.replace('_min', '')} is below minimum"
+        elif key.endswith("_max"):
+            if data.get(key.replace("_max", ""), 0) > val:
+                return False, f"{key.replace('_max', '')} is above maximum"
+        elif isinstance(val, list):
+            if data.get(key) not in val:
+                return False, f"{key} not in accepted values"
+        elif data.get(key) != val:
+            return False, f"{key} mismatch"
+    return True, "All rules passed"
+
+
+def estimate_award(data, rule):
+    if rule.get("type") == "percentage":
+        return int(data.get(rule.get("based_on", ""), 0) * (rule.get("percent", 0) / 100))
+    return rule.get("base", 0)

--- a/eligibility-engine/test_sample.py
+++ b/eligibility-engine/test_sample.py
@@ -1,0 +1,23 @@
+from engine import analyze_eligibility
+
+
+def test_engine():
+    user = {
+        "has_product_or_process_dev": True,
+        "is_tech_based": True,
+        "qre_total": 60000,
+        "revenue_drop": 25,
+        "government_shutdown": True,
+        "qualified_wages": 50000,
+        "business_age_years": 2,
+        "owner_credit_score": 680,
+        "state": "CA",
+        "employees": 5,
+        "owner_gender": "female",
+        "industry": "technology",
+        "city": "New York",
+        "owner_minority": True,
+        "rural_area": False,
+    }
+    results = analyze_eligibility(user)
+    assert any(r["eligible"] for r in results)


### PR DESCRIPTION
## Summary
- rewrite eligibility engine to load grants from JSON
- add helper rule utilities and grant loader
- include several sample grant configs
- update documentation and tests

## Testing
- `python engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c698811c832eb5af1dd67158714a