### PR TITLE
Add grant eligibility engine enhancements

### DIFF
--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -1,18 +1,52 @@
-# Eligibility Engine
+# Grant Eligibility Engine
 
-This engine loads grant definitions from the `grants/` directory and matches
-user business data against each program. Grants are described in simple JSON
-files so new programs can be added without changing the code.
+This package contains a lightweight rules engine used to determine business eligibility for a variety of grant and credit programs. Grants are defined as JSON files under `grants/` so new programs can be added without touching the code.
 
-## Usage
+## Running the Engine
 
-Run the engine directly to see a basic example:
+Install dependencies (FastAPI is only required for the optional API service):
 
 ```bash
-python engine.py
+pip install -r requirements.txt  # if running outside Codex environment
 ```
 
-Or run the test suite:
+Run a sample eligibility check using the CLI helper:
+
+```bash
+python run_check.py test_payload.json
+```
+
+### API Service
+
+Start the FastAPI service to expose the engine over HTTP:
+
+```bash
+uvicorn api:app --reload --port 4001
+```
+
+Available endpoints:
+
+- `POST /check` – submit user data and receive eligibility results.
+- `GET /grants` – list available grant configurations.
+- `GET /grants/{key}` – retrieve a specific grant definition.
+
+The API includes automatic OpenAPI docs at `/docs` when running.
+
+## Adding New Grants
+
+1. Create a JSON file in `grants/` following the existing examples. Include:
+   - `name`, `year`, and `description`.
+   - `required_fields` a list of data keys needed.
+   - `eligibility_rules` describing the logic. Supports `any_of`, `all_of`, range checks, and conditional blocks.
+   - `estimated_award` describing how to calculate the potential amount.
+   - `tags` and `ui_questions` to help the UI.
+2. The file name becomes the grant `key` used by the API.
+
+## Sample Payload
+
+See `test_payload.json` for a sample business profile. Running the engine with this payload returns a list of grants with eligibility status and estimated award values.
+
+## Testing
 
 ```bash
 python -m pytest

--- a/eligibility-engine/api.py
+++ b/eligibility-engine/api.py
@@ -1,17 +1,48 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from engine import analyze_eligibility
+from grants_loader import load_grants
 
-app = FastAPI()
+app = FastAPI(title="Grant Eligibility Engine")
+
+GRANTS = load_grants()
+
 
 @app.post("/check")
 async def check_eligibility(request: Request):
+    """Check grant eligibility for provided user data."""
     try:
         data = await request.json()
-        result = analyze_eligibility(data)
+        result = analyze_eligibility(data, explain=True)
         return {"eligible_grants": result}
     except Exception as e:
         return {"error": str(e)}
 
+
+@app.get("/grants")
+def list_grants():
+    """List all available grants with metadata."""
+    return [
+        {
+            "key": g["key"],
+            "name": g.get("name"),
+            "tags": g.get("tags", []),
+            "ui_questions": g.get("ui_questions", []),
+            "description": g.get("description", ""),
+        }
+        for g in GRANTS
+    ]
+
+
+@app.get("/grants/{grant_key}")
+def get_grant(grant_key: str):
+    """Retrieve a single grant configuration by key."""
+    for g in GRANTS:
+        if g["key"] == grant_key:
+            return g
+    raise HTTPException(status_code=404, detail="Grant not found")
+
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("api:app", host="0.0.0.0", port=4001, reload=True)

--- a/eligibility-engine/grants/covid_recovery_city_program.json
+++ b/eligibility-engine/grants/covid_recovery_city_program.json
@@ -1,0 +1,21 @@
+{
+  "name": "City COVID Recovery Program",
+  "year": 2025,
+  "description": "Local relief for businesses still recovering from the pandemic",
+  "required_fields": ["city", "revenue_drop"],
+  "eligibility_rules": {
+    "city": ["New York", "Los Angeles", "Chicago"],
+    "revenue_drop_min": 30
+  },
+  "estimated_award": {
+    "type": "percentage",
+    "percent": 5,
+    "based_on": "revenue_drop_amount"
+  },
+  "tags": ["city", "covid"],
+  "ui_questions": [
+    "Which city is your business located in?",
+    "What percentage did revenue drop during COVID?",
+    "What was the dollar amount of that drop?"
+  ]
+}

--- a/eligibility-engine/grants/green_energy_state_incentive.json
+++ b/eligibility-engine/grants/green_energy_state_incentive.json
@@ -1,0 +1,23 @@
+{
+  "name": "Green Energy State Incentive",
+  "year": 2025,
+  "description": "Rebate for businesses investing in renewable energy upgrades",
+  "required_fields": ["state", "energy_expenses"],
+  "eligibility_rules": {
+    "state": ["CA", "NY", "TX"],
+    "energy_expenses_min": 10000
+  },
+  "estimated_award": {
+    "type": "tiered",
+    "based_on": "energy_expenses",
+    "tiers": [
+      {"upto": 50000, "percent": 20},
+      {"percent": 10}
+    ]
+  },
+  "tags": ["state", "green", "energy"],
+  "ui_questions": [
+    "Which state is the project located in?",
+    "How much have you spent on energy improvements?"
+  ]
+}

--- a/eligibility-engine/grants/minority_female_founder_grant.json
+++ b/eligibility-engine/grants/minority_female_founder_grant.json
@@ -1,0 +1,22 @@
+{
+  "name": "Minority Female Founder Grant",
+  "year": 2025,
+  "description": "Grant for early stage companies led by minority women",
+  "required_fields": ["owner_gender", "owner_minority", "business_age_years"],
+  "eligibility_rules": {
+    "owner_gender": "female",
+    "owner_minority": true,
+    "business_age_years_max": 5
+  },
+  "estimated_award": {
+    "type": "base",
+    "base": 20000
+  },
+  "tags": ["federal", "women", "minority"],
+  "ui_questions": [
+    "Is the founder a woman?",
+    "Does the founder belong to a minority group?",
+    "How many years has the business been in operation?"
+  ],
+  "notes": "Founder must own at least 51% of the company"
+}

--- a/eligibility-engine/grants/tech_startup_irs_credit.json
+++ b/eligibility-engine/grants/tech_startup_irs_credit.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tech Startup Payroll Credit",
+  "year": 2025,
+  "description": "IRS payroll tax credit for young technology startups",
+  "required_fields": ["startup_year", "payroll_total", "industry"],
+  "eligibility_rules": {
+    "industry": ["technology", "software"],
+    "startup_year_min": 2020
+  },
+  "estimated_award": {
+    "type": "percentage",
+    "percent": 10,
+    "based_on": "payroll_total"
+  },
+  "tags": ["federal", "tech", "startup"],
+  "ui_questions": [
+    "What year did your company start operations?",
+    "What is your total payroll spend this year?",
+    "What industry best describes your business?"
+  ]
+}

--- a/eligibility-engine/grants/veteran_owned_grant.json
+++ b/eligibility-engine/grants/veteran_owned_grant.json
@@ -1,0 +1,22 @@
+{
+  "name": "Veteran Owned Business Grant",
+  "year": 2025,
+  "description": "Federal grant for businesses majority-owned by U.S. veterans",
+  "required_fields": ["owner_is_veteran", "business_age_years"],
+  "eligibility_rules": {
+    "owner_is_veteran": true,
+    "business_age_years_min": 1
+  },
+  "estimated_award": {
+    "type": "flat_per_unit",
+    "per": "employees",
+    "amount": 1000
+  },
+  "tags": ["federal", "veteran", "startup"],
+  "ui_questions": [
+    "Is the primary owner a U.S. military veteran?",
+    "How many years has the business operated?",
+    "How many employees do you currently have?"
+  ],
+  "notes": "Proof of honorable discharge is required"
+}

--- a/eligibility-engine/grants_loader.py
+++ b/eligibility-engine/grants_loader.py
@@ -11,5 +11,7 @@ def load_grants() -> List[Dict[str, Any]]:
     grants: List[Dict[str, Any]] = []
     for path in GRANTS_DIR.glob("*.json"):
         with path.open("r", encoding="utf-8") as f:
-            grants.append(json.load(f))
+            grant = json.load(f)
+            grant["key"] = path.stem
+            grants.append(grant)
     return grants

--- a/eligibility-engine/rules_utils.py
+++ b/eligibility-engine/rules_utils.py
@@ -1,20 +1,122 @@
-def check_rules(data, rules):
-    for key, val in rules.items():
-        if key.endswith("_min"):
-            if data.get(key.replace("_min", ""), 0) < val:
-                return False, f"{key.replace('_min', '')} is below minimum"
-        elif key.endswith("_max"):
-            if data.get(key.replace("_max", ""), 0) > val:
-                return False, f"{key.replace('_max', '')} is above maximum"
-        elif isinstance(val, list):
-            if data.get(key) not in val:
-                return False, f"{key} not in accepted values"
-        elif data.get(key) != val:
-            return False, f"{key} mismatch"
-    return True, "All rules passed"
+"""Utility helpers to evaluate eligibility rules and estimate award amounts."""
+
+from typing import Any, Dict, Tuple, List
 
 
-def estimate_award(data, rule):
-    if rule.get("type") == "percentage":
-        return int(data.get(rule.get("based_on", ""), 0) * (rule.get("percent", 0) / 100))
-    return rule.get("base", 0)
+def _check_value(data: Dict[str, Any], key: str, rule_val: Any) -> Tuple[bool, str]:
+    """Check an individual value rule."""
+    if isinstance(rule_val, dict):
+        if "min" in rule_val and data.get(key, 0) < rule_val["min"]:
+            return False, f"{key} below minimum {rule_val['min']}"
+        if "max" in rule_val and data.get(key, 0) > rule_val["max"]:
+            return False, f"{key} above maximum {rule_val['max']}"
+        if "one_of" in rule_val and data.get(key) not in rule_val["one_of"]:
+            return False, f"{key} not in accepted values"
+        return True, "ok"
+
+    if key.endswith("_min"):
+        base = key.replace("_min", "")
+        if data.get(base, 0) < rule_val:
+            return False, f"{base} below minimum {rule_val}"
+        return True, "ok"
+    if key.endswith("_max"):
+        base = key.replace("_max", "")
+        if data.get(base, 0) > rule_val:
+            return False, f"{base} above maximum {rule_val}"
+        return True, "ok"
+
+    if isinstance(rule_val, list):
+        if data.get(key) not in rule_val:
+            return False, f"{key} not in accepted values"
+    elif data.get(key) != rule_val:
+        return False, f"{key} must be {rule_val}"
+    return True, "ok"
+
+
+def _eval_rules(data: Dict[str, Any], rules: Any) -> Tuple[bool, str]:
+    """Recursively evaluate rules supporting AND/OR/IF logic."""
+    if not rules:
+        return True, "no rules"
+
+    if isinstance(rules, list):
+        for sub in rules:
+            ok, reason = _eval_rules(data, sub)
+            if not ok:
+                return False, reason
+        return True, "list passed"
+
+    if isinstance(rules, dict):
+        if "any_of" in rules:
+            reasons: List[str] = []
+            for sub in rules["any_of"]:
+                ok, reason = _eval_rules(data, sub)
+                reasons.append(reason)
+                if ok:
+                    return True, f"any_of passed: {reason}"
+            return False, " or ".join(reasons)
+
+        if "all_of" in rules:
+            for sub in rules["all_of"]:
+                ok, reason = _eval_rules(data, sub)
+                if not ok:
+                    return False, reason
+            return True, "all_of passed"
+
+        if "if" in rules and "then" in rules:
+            cond, _ = _eval_rules(data, rules["if"])
+            if cond:
+                ok, reason = _eval_rules(data, rules["then"])
+                if not ok:
+                    return False, f"conditional failed: {reason}"
+            return True, "conditional passed"
+
+        for k, v in rules.items():
+            ok, reason = _check_value(data, k, v)
+            if not ok:
+                return False, reason
+        return True, "rules passed"
+
+    return True, "unknown rule type"
+
+
+def check_rules(data: Dict[str, Any], rules: Dict[str, Any]) -> Tuple[bool, str]:
+    """Public wrapper returning whether data satisfies the given rules."""
+    return _eval_rules(data, rules)
+
+
+def estimate_award(data: Dict[str, Any], rule: Dict[str, Any]) -> int:
+    """Estimate the award based on the rule definition."""
+    if not rule:
+        return 0
+
+    rtype = rule.get("type", "base")
+
+    if rtype == "percentage":
+        base = data.get(rule.get("based_on", ""), 0)
+        return int(base * (rule.get("percent", 0) / 100))
+
+    if rtype == "flat_per_unit":
+        units = data.get(rule.get("per", ""), 0)
+        return int(units * rule.get("amount", 0))
+
+    if rtype == "tiered":
+        base = data.get(rule.get("based_on", ""), 0)
+        tiers = rule.get("tiers", [])
+        remaining = base
+        total = 0
+        for tier in tiers:
+            rate = tier.get("percent", 0) / 100
+            upto = tier.get("upto")
+            if upto is None:
+                total += remaining * rate
+                remaining = 0
+                break
+            amt = min(remaining, upto)
+            total += amt * rate
+            remaining -= amt
+            if remaining <= 0:
+                break
+        return int(total)
+
+    # default to base amount
+    return int(rule.get("base", 0))

--- a/eligibility-engine/run_check.py
+++ b/eligibility-engine/run_check.py
@@ -1,0 +1,19 @@
+import json
+import sys
+from pathlib import Path
+from engine import analyze_eligibility
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python run_check.py <payload.json>")
+        sys.exit(1)
+    payload_path = Path(sys.argv[1])
+    with payload_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    results = analyze_eligibility(data, explain=True)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/eligibility-engine/test_payload.json
+++ b/eligibility-engine/test_payload.json
@@ -1,0 +1,18 @@
+{
+  "has_product_or_process_dev": true,
+  "is_tech_based": true,
+  "qre_total": 60000,
+  "revenue_drop": 25,
+  "government_shutdown": true,
+  "qualified_wages": 50000,
+  "business_age_years": 2,
+  "owner_credit_score": 680,
+  "state": "CA",
+  "employees": 5,
+  "owner_gender": "female",
+  "industry": "technology",
+  "city": "New York",
+  "owner_minority": true,
+  "rural_area": false,
+  "tags": ["technology", "startup"]
+}

--- a/eligibility-engine/test_sample.py
+++ b/eligibility-engine/test_sample.py
@@ -18,6 +18,7 @@ def test_engine():
         "city": "New York",
         "owner_minority": True,
         "rural_area": False,
+        "tags": ["technology", "startup"],
     }
-    results = analyze_eligibility(user)
+    results = analyze_eligibility(user, explain=True)
     assert any(r["eligible"] for r in results)


### PR DESCRIPTION
## Summary
- upgrade `rules_utils` with advanced rule logic and award calculations
- add tag sorting and reasoning placeholders to `analyze_eligibility`
- expose grant metadata in the API
- provide CLI helper and sample payload
- create multiple new grant definitions
- refresh README with usage and API docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883c9198304832ea371ebaa67a60add