### PR TITLE
Improve AI agent reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains three microservices used to test a grant eligibility wo
 - **server/** – Express API for authentication, file uploads and analysis forwarding
 - **ai-analyzer/** – FastAPI service that performs stub OCR/NLP processing
 - **eligibility-engine/** – Pure Python rules engine for grant logic
+- **ai-agent/** – LLM-ready service with conversational endpoints and smart form filling
 
 ## Running locally
 
@@ -26,3 +27,11 @@ This repository contains three microservices used to test a grant eligibility wo
    cd eligibility-engine
    python -m pytest
    ```
+
+The `ai-agent` service can parse free-form notes and uploaded documents, infer missing fields
+and provide human readable summaries:
+
+```bash
+curl -X POST http://localhost:5001/check -H "Content-Type: application/json" \
+    -d '{"notes": "We started around 2021 and are women-led in biotech"}'
+```

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -12,11 +12,13 @@ uvicorn main:app --reload
 
 ## Endpoints
 
-- `POST /check` – submit user data or an uploaded document. Data is merged and
-  evaluated with the eligibility engine.
+- `POST /check` – submit user data, notes or an uploaded document. Free-form
+  text is semantically parsed and merged with the eligibility engine. Results
+  include `llm_summary`, `clarifying_questions` and richer `reasoning_steps`.
 - `POST /form-fill` – provide a grant key and user data to receive a filled form
-  from `form_templates/`.
-- `POST /chat` – placeholder endpoint for future LLM powered conversations.
+  from `form_templates/`. Conditional and computed fields will be evaluated.
+- `POST /chat` – simple conversational endpoint that stores context in
+  `session_id` records.
 
 ## Adding Forms
 
@@ -30,5 +32,6 @@ by the demo OCR parser.
 
 ## Future GPT/LLM Capabilities
 
-The API responses include placeholder `llm_summary` and `reasoning_steps` fields
-ready for richer explanations from a language model.
+The service includes helper functions for semantic inference and session
+tracking so a future LLM can generate summaries, request additional documents or
+even create dashboard tickets automatically.

--- a/ai-agent/agent_actions.py
+++ b/ai-agent/agent_actions.py
@@ -1,0 +1,19 @@
+"""Placeholder action helpers for a future autonomous agent."""
+
+from typing import Any
+
+
+def create_dashboard_ticket(user_id: str, grant_id: str) -> None:
+    """Stub for ticket creation."""
+    # In a real system this would create a ticket in an external dashboard
+    pass
+
+
+def request_document(doc_id: str, type: str = "") -> None:
+    """Stub for requesting a user document."""
+    pass
+
+
+def prepare_submission_form(grant_key: str) -> Any:
+    """Stub for preparing a grant submission form."""
+    return None

--- a/ai-agent/form_filler.py
+++ b/ai-agent/form_filler.py
@@ -3,27 +3,58 @@ import json
 from pathlib import Path
 from typing import Dict, Any
 from datetime import datetime
+from document_utils import extract_fields
+import re
 
 FORM_DIR = Path(__file__).parent / "form_templates"
+
+ZIP_STATE = {
+    "9": "CA",
+    "1": "NY",
+    "6": "IL",
+}
 
 
 def _fill_template(template: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
     fields = template.get("fields", {})
     optional = template.get("optional_fields", {})
     computed = template.get("computed_fields", {})
+    conditional = template.get("conditional_fields", {})
 
     # evaluate computed fields in the context of data
     for key, expr in computed.items():
         try:
             ctx = dict(data)
             ctx["current_year"] = datetime.utcnow().year
-            data[key] = eval(expr, {"__builtins__": {}}, ctx)
+            safe = {"__builtins__": {}, "int": int, "float": float}
+            data[key] = eval(expr, safe, ctx)
         except Exception:
             data[key] = ""
+
+    # derive state from zip if missing
+    if "state" not in data and "zip" in data:
+        z = str(data["zip"])
+        for prefix, state in ZIP_STATE.items():
+            if z.startswith(prefix):
+                data["state"] = state
+                break
+
+    # simple conditional logic
+    for key, rule in conditional.items():
+        expr = rule.get("if")
+        val = rule.get("value", True)
+        try:
+            if eval(expr, {"__builtins__": {}}, data):
+                data[key] = val
+        except Exception:
+            pass
 
     merged = {}
     for k, default in fields.items():
         merged[k] = data.get(k, optional.get(k, "Unknown"))
+    for k in conditional.keys():
+        if k in data:
+            merged[k] = data[k]
 
     template["fields"] = merged
 
@@ -33,8 +64,10 @@ def _fill_template(template: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, 
     return template
 
 
-def fill_form(form_key: str, data: Dict[str, Any]) -> Dict[str, Any]:
+def fill_form(form_key: str, data: Dict[str, Any], file_bytes: bytes | None = None) -> Dict[str, Any]:
     """Load ``form_key`` template and merge ``data`` into the fields."""
+    if file_bytes:
+        data.update(extract_fields(file_bytes))
     path = FORM_DIR / f"{form_key}.json"
     with path.open("r", encoding="utf-8") as f:
         template = json.load(f)

--- a/ai-agent/form_templates/tech_startup_credit_form.json
+++ b/ai-agent/form_templates/tech_startup_credit_form.json
@@ -4,6 +4,16 @@
     "business_id": "",
     "owner_name": "",
     "startup_year": "",
-    "payroll_total": ""
+    "payroll_total": "",
+    "state": ""
+  },
+  "optional_fields": {
+    "employees": 0
+  },
+  "computed_fields": {
+    "business_age_years": "current_year - int(startup_year) if startup_year else 0"
+  },
+  "conditional_fields": {
+    "is_new_tech": {"if": "industry == 'technology' and business_age_years < 5", "value": true}
   }
 }

--- a/ai-agent/reasoning_generator.py
+++ b/ai-agent/reasoning_generator.py
@@ -27,3 +27,29 @@ def generate_reasoning_steps(grant: Dict[str, Any], user_data: Dict[str, Any], r
     elif not steps:
         steps.append("One or more eligibility criteria not met")
     return steps
+
+
+def generate_llm_summary(results: List[Dict[str, Any]], user_data: Dict[str, Any]) -> str:
+    """Return a human readable summary of the overall eligibility."""
+    if not results:
+        return "No grants were evaluated."
+
+    passed = [r for r in results if r.get("eligible")]
+    if passed:
+        top = passed[0]
+        return (
+            f"You appear eligible for {top['name']} with an estimated award of ${top.get('estimated_amount',0)}."
+        )
+
+    top = max(results, key=lambda r: r.get("score", 0))
+    return (
+        f"No full eligibility found. Highest score is {top.get('score',0)}% for {top['name']}."
+    )
+
+
+def generate_clarifying_questions(results: List[Dict[str, Any]]) -> List[str]:
+    """Create follow-up questions based on missing fields."""
+    missing: set[str] = set()
+    for res in results:
+        missing.update(res.get("debug", {}).get("missing_fields", []))
+    return [f"Please provide your {field}" for field in sorted(missing)]

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -21,3 +21,19 @@ def append_memory(session_id: str, record: Dict[str, Any]) -> None:
     path = MEM_DIR / f"{session_id}.json"
     with path.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+
+
+def get_missing_fields(session_id: str) -> List[str]:
+    """Aggregate missing fields from stored eligibility results."""
+    missing: List[str] = []
+    for entry in load_memory(session_id):
+        res = entry.get("results")
+        if isinstance(res, list):
+            for r in res:
+                missing.extend(r.get("debug", {}).get("missing_fields", []))
+    return sorted(set(missing))
+
+
+def get_conversation(session_id: str) -> List[Dict[str, Any]]:
+    """Return full conversation history for this session."""
+    return load_memory(session_id)


### PR DESCRIPTION
## Summary
- extend NLP utilities with synonym, phrase and semantic inference helpers
- provide LLM-style reasoning, clarifying questions and summaries
- track session memory and derive missing fields
- upgrade form filler with computed, conditional and derived fields
- add placeholder agent action helpers
- enhance templates, docs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840cd0b65c832eb6e4add36bfbf486