### PR TITLE
Intelligent form filling upgrade

### DIFF
--- a/ai-agent/fastapi/__init__.py
+++ b/ai-agent/fastapi/__init__.py
@@ -39,6 +39,9 @@ class FastAPI:
 
         return decorator
 
+    def get(self, path: str):
+        return self.post(path)
+
 
 class Response:
     def __init__(self, json_data: Any):

--- a/ai-agent/form_templates/sba_microloan_form.json
+++ b/ai-agent/form_templates/sba_microloan_form.json
@@ -1,13 +1,21 @@
 {
   "name": "SBA Microloan Application",
   "fields": {
-    "business_id": {"type": "text", "required": true},
-    "owner_name": {"type": "text", "required": true},
-    "owner_gender": {"type": "dropdown", "required": false, "options": ["male", "female", "other"]},
-    "annual_income": {"type": "number", "required": true},
-    "business_description": {"type": "text", "required": true, "prompt": "Describe your business"},
-    "veteran": {"type": "checkbox", "required": false},
-    "branch_of_service": {"type": "text", "required": false, "depends_on": "veteran"},
-    "tax_document": {"type": "file_upload", "required": true, "expected": "pdf"}
-  }
+    "business_id": {"type": "text", "required": true, "ai_fillable": true},
+    "owner_name": {"type": "text", "required": true, "ai_fillable": true},
+    "owner_gender": {"type": "dropdown", "required": false, "options": ["male", "female", "other"], "ai_fillable": true},
+    "annual_income": {"type": "number", "required": true, "ai_fillable": true},
+    "business_description": {"type": "textarea", "required": true, "prompt": "Describe your business", "example": "We manufacture eco-friendly products.", "ai_fillable": true},
+    "veteran": {"type": "checkbox", "required": false, "ai_fillable": true},
+    "branch_of_service": {"type": "text", "required": false, "depends_on": "veteran", "ai_fillable": true, "show_if": "veteran"},
+    "tax_document": {"type": "file_upload", "required": true, "expected_file": "tax_return.pdf", "ai_fillable": true}
+  },
+  "sections": [
+    {
+      "name": "Additional",
+      "fields": {
+        "references": {"type": "textarea", "required": false, "ai_fillable": true, "example": "References available upon request."}
+      }
+    }
+  ]
 }

--- a/ai-agent/form_templates/tech_startup_credit_form.json
+++ b/ai-agent/form_templates/tech_startup_credit_form.json
@@ -1,13 +1,13 @@
 {
   "name": "Tech Startup Credit Application",
   "fields": {
-    "business_id": {"type": "text", "required": true},
-    "owner_name": {"type": "text", "required": true},
-    "startup_year": {"type": "number", "required": true},
-    "payroll_total": {"type": "number", "required": true},
-    "state": {"type": "text", "required": true},
-    "pitch_deck": {"type": "file_upload", "required": false, "expected": "pdf"},
-    "mission": {"type": "text", "required": false, "prompt": "What is your mission?"}
+    "business_id": {"type": "text", "required": true, "ai_fillable": true},
+    "owner_name": {"type": "text", "required": true, "ai_fillable": true},
+    "startup_year": {"type": "number", "required": true, "ai_fillable": true},
+    "payroll_total": {"type": "number", "required": true, "ai_fillable": true},
+    "state": {"type": "text", "required": true, "ai_fillable": true},
+    "pitch_deck": {"type": "file_upload", "required": false, "expected_file": "pitch_deck.pdf", "ai_fillable": true},
+    "mission": {"type": "textarea", "required": false, "prompt": "What is your mission?", "example": "Our company helps modernize agriculture.", "ai_fillable": true}
   },
   "optional_fields": {
     "employees": 0
@@ -17,5 +17,13 @@
   },
   "conditional_fields": {
     "is_new_tech": {"if": "industry == 'technology' and business_age_years < 5", "value": true}
-  }
+  },
+  "sections": [
+    {
+      "name": "Owner Info",
+      "fields": {
+        "owner_bio": {"type": "textarea", "required": false, "ai_fillable": true, "example": "Jane Doe founded the company in 2020."}
+      }
+    }
+  ]
 }

--- a/ai-agent/reasoning_generator.py
+++ b/ai-agent/reasoning_generator.py
@@ -8,6 +8,8 @@ def generate_reasoning_steps(grant: Dict[str, Any], user_data: Dict[str, Any], r
     missing = debug.get("missing_fields", [])
     for field in missing:
         steps.append(f"Missing required field: {field}")
+    if missing:
+        steps.append("Some information is still needed to fully verify eligibility.")
 
     checked = debug.get("checked_rules", {})
     for rule, info in checked.items():
@@ -53,3 +55,14 @@ def generate_clarifying_questions(results: List[Dict[str, Any]]) -> List[str]:
     for res in results:
         missing.update(res.get("debug", {}).get("missing_fields", []))
     return [f"Please provide your {field}" for field in sorted(missing)]
+
+
+def generate_audit_log(results: List[Dict[str, Any]]) -> List[str]:
+    """Return a detailed reasoning log for auditing."""
+    log: List[str] = []
+    for r in results:
+        name = r.get("name", "")
+        log.append(f"Result for {name}:")
+        for step in r.get("reasoning_steps", []):
+            log.append(f" - {step}")
+    return log

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -23,6 +23,11 @@ def append_memory(session_id: str, record: Dict[str, Any]) -> None:
         json.dump(data, f, indent=2)
 
 
+def save_draft_form(session_id: str, form_key: str, fields: Dict[str, Any]) -> None:
+    """Store draft form content for later review."""
+    append_memory(session_id, {"draft_form": form_key, "fields": fields})
+
+
 def get_missing_fields(session_id: str) -> List[str]:
     """Aggregate missing fields from stored eligibility results."""
     missing: List[str] = []


### PR DESCRIPTION
## Summary
- allow FastAPI stub to handle GET endpoints
- greatly expand NLP helpers with state inference and defaults
- improve form filling with conditional logic, more types and better text
- generate fuller reasoning logs
- store draft forms in session memory
- add preview-form and llm-debug endpoints
- enrich form templates with AI metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688416e7a3ec832e9a428c4cf7b1ab7e