### PR TITLE
Integrate GPT completions and chat

### DIFF
--- a/ai-agent/reasoning_generator.py
+++ b/ai-agent/reasoning_generator.py
@@ -1,6 +1,8 @@
 """Generate human readable reasoning steps for grant results."""
 from typing import Dict, Any, List
 
+from nlp_utils import llm_complete
+
 
 def generate_reasoning_steps(grant: Dict[str, Any], user_data: Dict[str, Any], result: Dict[str, Any]) -> List[str]:
     steps: List[str] = []
@@ -66,3 +68,18 @@ def generate_audit_log(results: List[Dict[str, Any]]) -> List[str]:
         for step in r.get("reasoning_steps", []):
             log.append(f" - {step}")
     return log
+
+
+def generate_reasoning_explanation(
+    grant: Dict[str, Any], user_data: Dict[str, Any], result: Dict[str, Any]
+) -> str:
+    """Create a plain language explanation of the eligibility reasoning."""
+    if not result.get("reasoning_steps"):
+        result["reasoning_steps"] = generate_reasoning_steps(grant, user_data, result)
+    steps = result.get("reasoning_steps", [])
+    text = " ".join(steps)
+    if not text:
+        text = "Eligibility could not be determined."
+    prompt = "Explain to a user why they are or are not eligible based on: " + text
+    explanation = llm_complete(prompt)
+    return explanation or text

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -3,3 +3,5 @@ pydantic
 uvicorn
 pytesseract
 pdfplumber
+python-dotenv
+openai

--- a/ai-agent/test_agent_check.py
+++ b/ai-agent/test_agent_check.py
@@ -108,3 +108,15 @@ def test_freeform_notes():
 
     data = asyncio.run(check(DummyRequest({"notes": notes}), explain=True))
     assert any(r.get("reasoning_steps") is not None for r in data)
+
+
+def test_form_fill_gpt_prompt():
+    payload = {"business_id": "999"}
+    data = asyncio.run(form_fill({"grant": "sba_microloan_form", "data": payload}))
+    form = data["filled_form"]
+    assert form["fields"].get("business_description") != ""
+
+
+def test_chat_llm():
+    resp = asyncio.run(chat({"session_id": "test1", "text": "Hello"}))
+    assert isinstance(resp.get("response"), str) and resp["response"] != ""


### PR DESCRIPTION
## Summary
- connect OpenAI via `.env` with graceful fallbacks
- use `llm_complete` helper for text generation in form filling
- provide natural‐language reasoning explanation
- enable LLM backed conversation in `/chat`
- expand tests for GPT form fill and chat

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878f8e7108832eb4bd0b903b2cc5d7