### PR TITLE
Fix form-fill schema

### DIFF
--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -15,8 +15,9 @@ uvicorn main:app --reload
 - `POST /check` – submit user data, notes or an uploaded document. Free-form
   text is semantically parsed and merged with the eligibility engine. Results
   include `llm_summary`, `clarifying_questions` and richer `reasoning_steps`.
-- `POST /form-fill` – provide a grant key and user data to receive a filled form
-  from `form_templates/`. Conditional and computed fields will be evaluated.
+- `POST /form-fill` – submit `form_name` and `user_payload` as JSON to receive a
+  filled form from `form_templates/`. Conditional and computed fields will be
+  evaluated.
 - `POST /chat` – simple conversational endpoint that stores context in
   `session_id` records.
 

--- a/ai-agent/fastapi/__init__.py
+++ b/ai-agent/fastapi/__init__.py
@@ -28,6 +28,10 @@ def Form(default=None):
     return default
 
 
+def Body(default=None, *, example=None):
+    return default
+
+
 class FastAPI:
     def __init__(self, title: str | None = None):
         self.routes: Dict[str, Callable] = {}


### PR DESCRIPTION
## Summary
- fix OpenAPI spec for `/form-fill` endpoint
- keep compatibility for direct test calls
- document request fields in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6887976d9dc0832e9a38928e075c13b7