### PR TITLE
Fix form-fill JSON body

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ and provide human readable summaries:
 curl -X POST http://localhost:5001/check -H "Content-Type: application/json" \
     -d '{"notes": "We started around 2021 and are women-led in biotech"}'
 ```
+
+To fill a grant application form, send JSON directly to `/form-fill`:
+
+```bash
+curl -X POST http://localhost:5001/form-fill \
+    -H "Content-Type: application/json" \
+    -d '{
+        "form_name": "sba_microloan_form",
+        "user_payload": {
+            "business_name": "Tech Boosters",
+            "annual_revenue": 250000,
+            "zipcode": "10001",
+            "minority_owned": true
+        }
+    }'
+```

--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI, Request, Body, UploadFile, File, Form
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from typing import Any
 from pathlib import Path
 import json
 import sys
-import os
 
 # ensure local imports work regardless of working directory
 CURRENT_DIR = Path(__file__).resolve().parent
@@ -31,12 +31,9 @@ from grants_loader import load_grants
 class FormFillRequest(BaseModel):
     """Schema for the /form-fill endpoint."""
 
-    form_name: str = Field(..., alias="grant")
-    user_payload: dict = Field(default_factory=dict, alias="data")
+    form_name: str
+    user_payload: dict[str, Any]
     session_id: str | None = None
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 app = FastAPI(title="AI Agent Service")
@@ -102,7 +99,8 @@ async def check(
 @app.post("/form-fill")
 async def form_fill(
     request_model: FormFillRequest = Body(
-        ..., example={"form_name": "tech_startup_credit_form", "user_payload": {"zip": "94110"}}
+        ..., embed=False,
+        example={"form_name": "tech_startup_credit_form", "user_payload": {"zip": "94110"}}
     )
 ):
     """Fill a grant form template with provided user data."""


### PR DESCRIPTION
## Summary
- simplify `FormFillRequest` to accept JSON body directly
- update example usage in README
- adjust `/form-fill` route definition
- adapt unit tests and add checks for JSON example and invalid payload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68879f00be6c832e8150bf84eb7c64dc