### PR TITLE
Add frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .env
 uploads
+# Frontend build outputs
+/frontend/.next
+/frontend/node_modules

--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ curl -X POST http://localhost:5001/form-fill \
         }
     }'
 ```
+
+## Frontend
+
+The **frontend/** directory contains a Next.js application used for end-user registration, login and document uploads.
+
+To start the frontend locally:
+
+```bash
+cd frontend
+npm install # install dependencies (requires internet access)
+npm run dev
+```
+
+Environment variables should be placed in a `.env.local` file. See `.env.local.example` for the API base URL.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE=https://localhost:8000

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "grant-platform-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "axios": "^1.6.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "typescript": "^5.3.2",
+    "@types/react": "^18.2.0",
+    "@types/node": "^20.9.0",
+    "eslint": "^8.56.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import Protected from '@/components/Protected';
+import { useAuth } from '@/hooks/useAuth';
+import Link from 'next/link';
+
+export default function Dashboard() {
+  const { user } = useAuth();
+
+  return (
+    <Protected>
+      <div>
+        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+        <p>Welcome, {user?.email}!</p>
+        <div className="mt-4 space-x-2">
+          <Link href="/upload" className="px-4 py-2 bg-blue-600 text-white rounded">Upload Documents</Link>
+          <Link href="/eligibility-report" className="px-4 py-2 border rounded">Eligibility Report</Link>
+        </div>
+      </div>
+    </Protected>
+  );
+}

--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import Protected from '@/components/Protected';
+import { useEffect, useState } from 'react';
+import api from '@/lib/api';
+
+export default function EligibilityReport() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    api.get('/eligibility-report').then(res => setData(res.data));
+  }, []);
+
+  return (
+    <Protected>
+      <div className="py-10">
+        <h1 className="text-2xl font-bold mb-4">Eligibility Report</h1>
+        {data ? (
+          <pre className="whitespace-pre-wrap bg-gray-100 p-4 rounded">{JSON.stringify(data, null, 2)}</pre>
+        ) : (
+          <p>Loading...</p>
+        )}
+      </div>
+    </Protected>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export const metadata: Metadata = {
+  title: 'Grant Platform',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Header />
+        <main className="min-h-screen container mx-auto p-4">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import FormInput from '@/components/FormInput';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(email, password);
+    router.push('/dashboard');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-6">Login</h1>
+      <FormInput label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+      <FormInput label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Login</button>
+    </form>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,12 @@
+export default function Home() {
+  return (
+    <section className="text-center py-20">
+      <h1 className="text-4xl font-bold mb-4">Grant Application Platform</h1>
+      <p className="mb-8">Accelerate your funding process with AI-powered tools.</p>
+      <div className="space-x-4">
+        <a href="/register" className="px-4 py-2 bg-blue-600 text-white rounded">Get Started</a>
+        <a href="/login" className="px-4 py-2 border rounded">Login</a>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import FormInput from '@/components/FormInput';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { register } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await register({ email, password });
+    router.push('/dashboard');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-6">Register</h1>
+      <FormInput label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+      <FormInput label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Register</button>
+    </form>
+  );
+}

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import Protected from '@/components/Protected';
+import api from '@/lib/api';
+
+export default function Upload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [message, setMessage] = useState('');
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await api.post('/upload-doc', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    setMessage(res.data.message || 'Uploaded');
+  };
+
+  return (
+    <Protected>
+      <div className="max-w-md mx-auto py-10">
+        <h1 className="text-2xl font-bold mb-4">Upload Documents</h1>
+        <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} className="mb-4" />
+        <button onClick={handleUpload} className="px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
+        {message && <p className="mt-4">{message}</p>}
+      </div>
+    </Protected>
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 py-6 text-center text-sm">
+      <p>&copy; {new Date().getFullYear()} Grant Platform</p>
+    </footer>
+  );
+}

--- a/frontend/src/components/FormInput.tsx
+++ b/frontend/src/components/FormInput.tsx
@@ -1,0 +1,15 @@
+'use client';
+import { InputHTMLAttributes } from 'react';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export default function FormInput({ label, ...props }: Props) {
+  return (
+    <div className="mb-4">
+      <label className="block mb-1 font-medium">{label}</label>
+      <input {...props} className="w-full rounded border px-3 py-2" />
+    </div>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,28 @@
+'use client';
+import Link from 'next/link';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function Header() {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className="bg-white shadow">
+      <div className="container mx-auto flex items-center justify-between p-4">
+        <Link href="/" className="text-lg font-bold">Grant Platform</Link>
+        <nav className="space-x-4">
+          {user ? (
+            <>
+              <Link href="/dashboard">Dashboard</Link>
+              <button onClick={logout}>Logout</button>
+            </>
+          ) : (
+            <>
+              <Link href="/login">Login</Link>
+              <Link href="/register">Register</Link>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/Protected.tsx
+++ b/frontend/src/components/Protected.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { ReactNode, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function Protected({ children }: { children: ReactNode }) {
+  const { user, check } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    check();
+  }, [check]);
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace('/login');
+    }
+  }, [user, router]);
+
+  if (!user) return null;
+  return <>{children}</>;
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import api from '@/lib/api';
+import { useRouter } from 'next/navigation';
+
+interface AuthState {
+  user: any;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (data: Record<string, any>) => Promise<void>;
+  logout: () => Promise<void>;
+  check: () => Promise<void>;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  user: null,
+  loading: false,
+  async login(email, password) {
+    set({ loading: true });
+    await api.post('/login', { email, password });
+    set({ loading: false });
+  },
+  async register(data) {
+    set({ loading: true });
+    await api.post('/register', data);
+    set({ loading: false });
+  },
+  async logout() {
+    await api.post('/logout');
+    set({ user: null });
+  },
+  async check() {
+    try {
+      const res = await api.get('/me');
+      set({ user: res.data });
+    } catch {
+      set({ user: null });
+    }
+  },
+}));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE,
+  withCredentials: true,
+});
+
+api.interceptors.request.use((config) => {
+  return config;
+});
+
+export default api;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/hooks/*": ["src/hooks/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js frontend in `frontend/`
- integrate Tailwind CSS and base components
- add basic pages for login, register, dashboard, upload and reports
- document frontend usage in README
- ignore frontend build artifacts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888043cec98832e9e7f1505e4af48b7