### PR TITLE
Fix auth flow and add /me endpoint

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import api from '@/lib/api';
-import { useRouter } from 'next/navigation';
 
 interface AuthState {
   user: any;
@@ -16,16 +15,26 @@ export const useAuth = create<AuthState>((set) => ({
   loading: false,
   async login(email, password) {
     set({ loading: true });
-    await api.post('/login', { email, password });
+    const res = await api.post('/login', { email, password });
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('token', res.data.token);
+    }
+    await useAuth.getState().check();
     set({ loading: false });
   },
   async register(data) {
     set({ loading: true });
-    await api.post('/register', data);
+    const res = await api.post('/register', data);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('token', res.data.token);
+    }
+    await useAuth.getState().check();
     set({ loading: false });
   },
   async logout() {
-    await api.post('/logout');
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+    }
     set({ user: null });
   },
   async check() {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,13 @@ const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
   return config;
 });
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const auth = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
@@ -75,6 +76,21 @@ router.post('/login', async (req, res) => {
     const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, { expiresIn: '1h' });
 
     res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// @route   GET /api/auth/me
+// @desc    Get current authenticated user
+router.get('/me', auth, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select('-password');
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json(user);
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Server error' });


### PR DESCRIPTION
## Summary
- expose `/api/auth/me` to fetch current user
- attach JWT token to axios requests on the frontend
- persist login token and load user details with `check()`
- clean up logout logic

## Testing
- `python -m pytest -q`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688810709240832e92682bfab126bf45