### PR TITLE
Add health endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,15 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
+// === Root & Health Routes ===
+app.get('/', (req, res) => {
+  res.send('🚀 Grant Platform API is running!');
+});
+
+app.get('/status', (req, res) => {
+  res.json({ status: 'ok', env: process.env.NODE_ENV || 'development' });
+});
+
 // === API Routes ===
 app.use('/api/auth', require('./routes/auth'));
 console.log('✅ Auth routes registered');


### PR DESCRIPTION
## Summary
- add root route with greeting message
- add `/status` route showing environment

## Testing
- `node server/index.js` *(with DB exit prevention for testing)*
- `curl http://localhost:5000/`
- `curl http://localhost:5000/status`

------
https://chatgpt.com/codex/tasks/task_e_688814fdb1f0832eb43da0923875768d