### PR TITLE
Fix auth path and log token

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export const useAuth = create<AuthState>((set) => ({
 
   async login(email, password) {
     set({ loading: true });
-    const res = await api.post('/login', { email, password });
+    const res = await api.post('/auth/login', { email, password });
 
     const token = res.data.token;
     if (typeof window !== 'undefined' && token) {
@@ -29,7 +29,7 @@ export const useAuth = create<AuthState>((set) => ({
 
   async register(data) {
     set({ loading: true });
-    const res = await api.post('/register', data);
+    const res = await api.post('/auth/register', data);
 
     const token = res.data.token;
     if (typeof window !== 'undefined' && token) {
@@ -55,7 +55,7 @@ export const useAuth = create<AuthState>((set) => ({
         return;
       }
 
-      const res = await api.get('/me', {
+      const res = await api.get('/auth/me', {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -86,10 +86,18 @@ router.post('/login', async (req, res) => {
 // @desc    Get current authenticated user
 router.get('/me', auth, async (req, res) => {
   console.log('\uD83D\uDD0D GET /me hit');
-  console.log('Auth Header:', req.headers.authorization);
+  const rawHeader = req.headers.authorization || '';
+  const token = rawHeader.startsWith('Bearer ')
+    ? rawHeader.split(' ')[1]
+    : rawHeader;
+  console.log('Token received (partial):', token ? token.substring(0, 10) + '...' : 'none');
 
   try {
     console.log('Decoded JWT:', req.user);
+    if (!req.user || !req.user.id) {
+      console.warn('req.user missing user id');
+      return res.status(401).json({ message: 'Token is not valid' });
+    }
     const user = await User.findById(req.user.id).select('-password');
     if (!user) {
       return res.status(404).json({ message: 'User not found' });


### PR DESCRIPTION
## Summary
- use `/auth/*` endpoints from the frontend
- improve `/auth/me` logging and validation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897ba11acc832ea55a0e3bbb564f38