### PR TITLE
Add eligibility report API route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,7 @@ app.use('/api/users', require('./routes/users'));
 app.use('/api/files', require('./routes/files'));
 app.use('/api/analyze', require('./routes/analyze'));
 app.use('/api/form-fill', require('./routes/formFill'));
+app.use('/api/eligibility-report', require('./routes/eligibility'));
 
 // === Connect to DB and start server ===
 const PORT = process.env.PORT || 5000;

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+
+// GET /api/eligibility-report
+router.get('/', (req, res) => {
+  // For now, just return dummy data
+  res.json({
+    eligible: true,
+    message: 'Eligibility report stub'
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- serve dummy eligibility report data from `/api/eligibility-report`
- register route in Express app

## Testing
- `python -m pytest -q`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aba40b738832ea8224f357a5d74f2