### PR TITLE
Fix dashboard crash when documents absent

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -45,7 +45,9 @@ export default function Dashboard() {
     <Protected><p>Loading...</p></Protected>
   );
 
-  const allUploaded = caseData.documents.every((d: any) => d.uploaded);
+  const allUploaded = Array.isArray(caseData.documents)
+    ? caseData.documents.every((d: any) => d.uploaded)
+    : false;
 
   return (
     <Protected>
@@ -55,19 +57,33 @@ export default function Dashboard() {
 
         <div>
           <h2 className="font-semibold">Required Documents</h2>
-          {caseData.documents.map((doc: any) => (
-            <div key={doc.key} className="my-2 flex items-center space-x-2">
-              <span>{doc.name}</span>
-              {doc.uploaded ? (
-                <span className="text-green-600">✓</span>
-              ) : (
-                <>
-                  <input type="file" onChange={e => setUploads({ ...uploads, [doc.key]: e.target.files?.[0] || null })} />
-                  <button onClick={() => handleUpload(doc.key)} className="px-2 py-1 bg-blue-600 text-white rounded">Upload</button>
-                </>
-              )}
-            </div>
-          ))}
+          {Array.isArray(caseData.documents) ? (
+            caseData.documents.map((doc: any) => (
+              <div key={doc.key} className="my-2 flex items-center space-x-2">
+                <span>{doc.name}</span>
+                {doc.uploaded ? (
+                  <span className="text-green-600">✓</span>
+                ) : (
+                  <>
+                    <input
+                      type="file"
+                      onChange={e =>
+                        setUploads({ ...uploads, [doc.key]: e.target.files?.[0] || null })
+                      }
+                    />
+                    <button
+                      onClick={() => handleUpload(doc.key)}
+                      className="px-2 py-1 bg-blue-600 text-white rounded"
+                    >
+                      Upload
+                    </button>
+                  </>
+                )}
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-gray-600">No document data available.</p>
+          )}
         </div>
 
         {allUploaded && !caseData.eligibility && (

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -5,12 +5,17 @@ console.log('Case route loaded');
 
 const router = express.Router();
 
+const { getCase } = require('../utils/caseStore');
+
 // Simple status endpoint used by the dashboard
 router.get('/status', (req, res) => {
+  // Use a static user id for now since auth is optional in this demo
+  const c = getCase('demo-user');
+
   res.json({
-    status: 'open',
-    docsUploaded: 2,
-    totalDocs: 3
+    status: c.status,
+    documents: c.documents,
+    eligibility: c.eligibility,
   });
 });
 


### PR DESCRIPTION
## Summary
- add array guard in dashboard page
- show fallback message if documents array missing
- ensure `/api/case/status` returns a documents array using the case store

## Testing
- `npm run lint` *(fails: next not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c09fe3e74832eb37ff6ec7ca1236d