### PR TITLE
Add multi-step customer grant flow

### DIFF
--- a/frontend/src/app/dashboard/documents/page.tsx
+++ b/frontend/src/app/dashboard/documents/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+/**
+ * Document upload step for grant application.
+ * Allows users to upload required files and trigger analysis.
+ */
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Protected from '@/components/Protected';
+import api from '@/lib/api';
+
+export default function Documents() {
+  const router = useRouter();
+  const [caseData, setCaseData] = useState<any>(null);
+  const [uploads, setUploads] = useState<Record<string, File | null>>({});
+  const [loading, setLoading] = useState(false);
+
+  const fetchStatus = async () => {
+    const res = await api.get('/case/status');
+    setCaseData(res.data);
+  };
+
+  useEffect(() => {
+    fetchStatus();
+  }, []);
+
+  const handleUpload = async (key: string) => {
+    const file = uploads[key];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('key', key);
+    await api.post('/files/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    fetchStatus();
+  };
+
+  if (!caseData) return (
+    <Protected><p>Loading...</p></Protected>
+  );
+
+  const docs = Array.isArray(caseData.documents) ? caseData.documents : [];
+  const uploadedCount = docs.filter((d: any) => d.uploaded).length;
+  const allUploaded = docs.length > 0 && uploadedCount === docs.length;
+
+  const submitAnalysis = async () => {
+    setLoading(true);
+    await api.post('/eligibility-report');
+    await fetchStatus();
+    localStorage.setItem('caseStage', 'results');
+    setLoading(false);
+    router.push('/dashboard');
+  };
+
+  return (
+    <Protected>
+      <div className="py-6 max-w-xl mx-auto space-y-4">
+        <h1 className="text-2xl font-bold">Upload Documents</h1>
+        {docs.map((doc: any) => (
+          <div key={doc.key} className="flex items-center space-x-3">
+            <span className="w-48">{doc.name}</span>
+            {doc.uploaded ? (
+              <span className="text-green-600">✓ Uploaded</span>
+            ) : (
+              <>
+                <input
+                  type="file"
+                  onChange={(e) =>
+                    setUploads({ ...uploads, [doc.key]: e.target.files?.[0] || null })
+                  }
+                />
+                <button
+                  onClick={() => handleUpload(doc.key)}
+                  className="px-2 py-1 bg-blue-600 text-white rounded"
+                >
+                  Upload
+                </button>
+              </>
+            )}
+          </div>
+        ))}
+        <div className="h-2 bg-gray-200 rounded">
+          <div
+            className="h-full bg-green-500 rounded"
+            style={{ width: `${(uploadedCount / docs.length) * 100}%` }}
+          />
+        </div>
+        {allUploaded && (
+          <button
+            onClick={submitAnalysis}
+            className="px-4 py-2 bg-purple-600 text-white rounded"
+          >
+            {loading ? 'Submitting...' : 'Submit for Analysis'}
+          </button>
+        )}
+      </div>
+    </Protected>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,116 +1,90 @@
 'use client';
+/**
+ * Main dashboard showing case progress and results.
+ * Redirects to steps based on localStorage state.
+ */
 import Protected from '@/components/Protected';
 import { useAuth } from '@/hooks/useAuth';
 import { useEffect, useState } from 'react';
 import api from '@/lib/api';
+import { useRouter } from 'next/navigation';
 
 export default function Dashboard() {
   const { user } = useAuth();
+  const router = useRouter();
   const [caseData, setCaseData] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
-  const [uploads, setUploads] = useState<Record<string, File | null>>({});
+
+  const fetchStatus = async () => {
+    const res = await api.get('/case/status');
+    setCaseData(res.data);
+  };
 
   useEffect(() => {
-    api.get('/case/status').then(res => setCaseData(res.data));
+    fetchStatus();
   }, []);
-
-  const handleUpload = async (key: string) => {
-    const file = uploads[key];
-    if (!file) return;
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('key', key);
-    await api.post('/files/upload', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    });
-    const updated = await api.get('/case/status');
-    setCaseData(updated.data);
-  };
-
-  const startAnalysis = async () => {
-    setLoading(true);
-    await api.post('/eligibility-report');
-    const updated = await api.get('/case/status');
-    setCaseData(updated.data);
-    setLoading(false);
-  };
-
-  const submitCase = async () => {
-    await api.post('/case/submit');
-    const updated = await api.get('/case/status');
-    setCaseData(updated.data);
-  };
 
   if (!caseData) return (
     <Protected><p>Loading...</p></Protected>
   );
 
-  const allUploaded = Array.isArray(caseData.documents)
-    ? caseData.documents.every((d: any) => d.uploaded)
-    : false;
+  const stage = typeof window !== 'undefined' ? localStorage.getItem('caseStage') : null;
+
+  if (!stage || stage === 'open') {
+    return (
+      <Protected>
+        <div className="text-center py-10 space-y-4">
+          <h1 className="text-2xl font-bold">Welcome, {user?.email}</h1>
+          <button
+            onClick={() => {
+              localStorage.setItem('caseStage', 'questionnaire');
+              router.push('/dashboard/questionnaire');
+            }}
+            className="px-6 py-3 bg-blue-700 text-white rounded text-lg"
+          >
+            OPEN CASE
+          </button>
+        </div>
+      </Protected>
+    );
+  }
+
+  if (caseData.eligibility) {
+    return (
+      <Protected>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold">Eligibility Results</h1>
+          <p>Eligible: {caseData.eligibility.eligible ? 'Yes' : 'No'}</p>
+          <p>{caseData.eligibility.summary}</p>
+          <h3 className="font-semibold">Forms</h3>
+          <ul className="list-disc ml-6">
+            {caseData.eligibility.forms.map((f: string) => (
+              <li key={f}>{f}</li>
+            ))}
+          </ul>
+        </div>
+      </Protected>
+    );
+  }
 
   return (
     <Protected>
-      <div className="space-y-4">
-        <h1 className="text-2xl font-bold">Welcome, {user?.email}</h1>
-        <p>Status: {caseData.status}</p>
-
-        <div>
-          <h2 className="font-semibold">Required Documents</h2>
-          {Array.isArray(caseData.documents) ? (
-            caseData.documents.map((doc: any) => (
-              <div key={doc.key} className="my-2 flex items-center space-x-2">
-                <span>{doc.name}</span>
-                {doc.uploaded ? (
-                  <span className="text-green-600">✓</span>
-                ) : (
-                  <>
-                    <input
-                      type="file"
-                      onChange={e =>
-                        setUploads({ ...uploads, [doc.key]: e.target.files?.[0] || null })
-                      }
-                    />
-                    <button
-                      onClick={() => handleUpload(doc.key)}
-                      className="px-2 py-1 bg-blue-600 text-white rounded"
-                    >
-                      Upload
-                    </button>
-                  </>
-                )}
-              </div>
-            ))
-          ) : (
-            <p className="text-sm text-gray-600">No document data available.</p>
-          )}
-        </div>
-
-        {allUploaded && !caseData.eligibility && (
-          <button onClick={startAnalysis} className="px-4 py-2 bg-purple-600 text-white rounded">
-            {loading ? 'Analyzing...' : 'Start Analysis'}
+      <div className="py-10 space-y-4 text-center">
+        <p>Case in progress. Please complete remaining steps.</p>
+        {stage === 'questionnaire' && (
+          <button
+            onClick={() => router.push('/dashboard/questionnaire')}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Continue Questionnaire
           </button>
         )}
-
-        {caseData.eligibility && (
-          <div className="border p-4 rounded">
-            <p>Eligible: {caseData.eligibility.eligible ? 'Yes' : 'No'}</p>
-            <p>{caseData.eligibility.summary}</p>
-            <h3 className="font-semibold mt-2">Forms</h3>
-            <ul className="list-disc ml-6">
-              {caseData.eligibility.forms.map((f: string) => (
-                <li key={f}>{f}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {caseData.status !== 'Submitted' && caseData.eligibility && (
-          <button onClick={submitCase} className="px-4 py-2 bg-green-600 text-white rounded">Submit Case</button>
-        )}
-
-        {caseData.status === 'Submitted' && (
-          <p className="text-green-700 font-bold">Your case is submitted!</p>
+        {stage === 'documents' && (
+          <button
+            onClick={() => router.push('/dashboard/documents')}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Go to Documents
+          </button>
         )}
       </div>
     </Protected>

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+/**
+ * Questionnaire wizard for collecting grant information.
+ * Saves answers to localStorage and moves user to the upload step.
+ */
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Protected from '@/components/Protected';
+import FormInput from '@/components/FormInput';
+
+export default function Questionnaire() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState({
+    businessName: '',
+    industry: '',
+    revenue: '',
+    employees: '',
+    minorityOwned: false,
+  });
+
+  useEffect(() => {
+    const saved = localStorage.getItem('questionnaire');
+    if (saved) {
+      setAnswers(JSON.parse(saved));
+    }
+  }, []);
+
+  const next = () => setStep((s) => Math.min(s + 1, 2));
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
+
+  const finish = () => {
+    localStorage.setItem('questionnaire', JSON.stringify(answers));
+    localStorage.setItem('caseStage', 'documents');
+    router.push('/dashboard/documents');
+  };
+
+  return (
+    <Protected>
+      <div className="max-w-xl mx-auto py-6 space-y-4">
+        <h1 className="text-2xl font-bold">Grant Questionnaire</h1>
+        {step === 0 && (
+          <>
+            <FormInput
+              label="Business Name"
+              value={answers.businessName}
+              onChange={(e) =>
+                setAnswers({ ...answers, businessName: e.target.value })
+              }
+            />
+            <FormInput
+              label="Industry"
+              value={answers.industry}
+              onChange={(e) =>
+                setAnswers({ ...answers, industry: e.target.value })
+              }
+            />
+          </>
+        )}
+        {step === 1 && (
+          <>
+            <FormInput
+              label="Annual Revenue"
+              type="number"
+              value={answers.revenue}
+              onChange={(e) =>
+                setAnswers({ ...answers, revenue: e.target.value })
+              }
+            />
+            <FormInput
+              label="Employees"
+              type="number"
+              value={answers.employees}
+              onChange={(e) =>
+                setAnswers({ ...answers, employees: e.target.value })
+              }
+            />
+          </>
+        )}
+        {step === 2 && (
+          <div className="mb-4">
+            <label className="inline-flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={answers.minorityOwned}
+                onChange={(e) =>
+                  setAnswers({ ...answers, minorityOwned: e.target.checked })
+                }
+              />
+              <span>Minority Owned</span>
+            </label>
+          </div>
+        )}
+        <div className="flex justify-between pt-4">
+          {step > 0 && (
+            <button
+              onClick={prev}
+              className="px-4 py-2 border rounded"
+            >
+              Back
+            </button>
+          )}
+          {step < 2 && (
+            <button
+              onClick={next}
+              className="px-4 py-2 bg-blue-600 text-white rounded ml-auto"
+            >
+              Next
+            </button>
+          )}
+          {step === 2 && (
+            <button
+              onClick={finish}
+              className="px-4 py-2 bg-green-600 text-white rounded ml-auto"
+            >
+              Continue
+            </button>
+          )}
+        </div>
+      </div>
+    </Protected>
+  );
+}


### PR DESCRIPTION
## Summary
- overhaul dashboard to use step-by-step flow and initial **OPEN CASE** button
- add questionnaire wizard for grant details
- add document upload page with progress bar and Submit for Analysis button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cdb318270832ea15b74c40c9b7129