### PR TITLE
Fix dashboard case logic

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 /**
  * Main dashboard showing case progress and results.
- * Redirects to steps based on localStorage state.
+ * Determines the current step from API status.
  */
 import Protected from '@/components/Protected';
 import { useAuth } from '@/hooks/useAuth';
@@ -27,9 +27,22 @@ export default function Dashboard() {
     <Protected><p>Loading...</p></Protected>
   );
 
-  const stage = typeof window !== 'undefined' ? localStorage.getItem('caseStage') : null;
+  const computeStage = () => {
+    if (caseData.status === 'not_started') return 'open';
+    if (caseData.eligibility) return 'results';
+    if (Array.isArray(caseData.documents) && caseData.documents.length > 0) {
+      return 'documents';
+    }
+    return 'questionnaire';
+  };
 
-  if (!stage || stage === 'open') {
+  const stage = computeStage();
+
+  if (stage === 'open' && typeof window !== 'undefined') {
+    localStorage.removeItem('caseStage');
+  }
+
+  if (stage === 'open') {
     return (
       <Protected>
         <div className="text-center py-10 space-y-4">

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -6,11 +6,15 @@ console.log('Case route loaded');
 const router = express.Router();
 
 const auth = require('../middleware/authMiddleware');
-const { getCase, computeDocuments } = require('../utils/caseStore');
+const { getCase, createCase, computeDocuments } = require('../utils/caseStore');
 
 // Status endpoint used by the dashboard
 router.get('/status', auth, (req, res) => {
-  const c = getCase(req.user.id);
+  const c = getCase(req.user.id, false);
+
+  if (!c) {
+    return res.json({ status: 'not_started' });
+  }
 
   res.json({
     status: c.status,
@@ -22,7 +26,7 @@ router.get('/status', auth, (req, res) => {
 
 // Save questionnaire answers
 router.post('/questionnaire', auth, (req, res) => {
-  const c = getCase(req.user.id);
+  const c = createCase(req.user.id);
   c.answers = req.body || {};
   c.documents = computeDocuments(c.answers);
   res.json({ status: 'saved' });
@@ -30,7 +34,7 @@ router.post('/questionnaire', auth, (req, res) => {
 
 // Fetch questionnaire answers
 router.get('/questionnaire', auth, (req, res) => {
-  const c = getCase(req.user.id);
+  const c = createCase(req.user.id);
   res.json(c.answers || {});
 });
 

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -6,7 +6,8 @@ const { getCase } = require('../utils/caseStore');
 
 // GET /api/eligibility-report
 router.post('/', auth, async (req, res) => {
-  const c = getCase(req.user.id);
+  const c = getCase(req.user.id, false);
+  if (!c) return res.status(400).json({ message: 'No active case' });
   const engineUrl = process.env.ENGINE_URL || 'http://localhost:4001/check';
   try {
     const response = await fetch(engineUrl, {
@@ -30,7 +31,8 @@ router.post('/', auth, async (req, res) => {
 });
 
 router.get('/', auth, (req, res) => {
-  const c = getCase(req.user.id);
+  const c = getCase(req.user.id, false);
+  if (!c) return res.status(400).json({ message: 'No active case' });
   res.json(c.eligibility || { eligible: false });
 });
 

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -16,7 +16,8 @@ router.post('/upload', auth, upload.single('file'), (req, res) => {
 
   const docKey = req.body.key;
   if (docKey) {
-    const c = getCase(req.user.id);
+    const c = getCase(req.user.id, false);
+    if (!c) return res.status(400).json({ message: 'No active case' });
     const doc = c.documents.find((d) => d.key === docKey);
     if (doc) {
       doc.uploaded = true;
@@ -36,7 +37,8 @@ router.post('/', auth, upload.single('file'), (req, res) => {
   req.body.key = req.body.key || '';
   const docKey = req.body.key;
   if (req.file && docKey) {
-    const c = getCase(req.user.id);
+    const c = getCase(req.user.id, false);
+    if (!c) return res.status(400).json({ message: 'No active case' });
     const doc = c.documents.find((d) => d.key === docKey);
     if (doc) {
       doc.uploaded = true;

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -17,8 +17,9 @@ function computeDocuments(answers = {}) {
   return docs;
 }
 
-function getCase(userId) {
+function getCase(userId, createIfMissing = true) {
   if (!cases[userId]) {
+    if (!createIfMissing) return null;
     cases[userId] = {
       status: 'Open',
       answers: {},
@@ -29,4 +30,8 @@ function getCase(userId) {
   return cases[userId];
 }
 
-module.exports = { cases, getCase, computeDocuments };
+function createCase(userId) {
+  return getCase(userId, true);
+}
+
+module.exports = { cases, getCase, createCase, computeDocuments };


### PR DESCRIPTION
## Summary
- prevent auto-case creation for new users
- improve case status endpoints and file uploads
- adjust dashboard flow to read status from API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688ce9ce48ac832ebc8d8dcabd312f72