### PR TITLE
Dynamic doc requirements from grant engine

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "express": "^5.1.0",
     "form-data": "^4.0.4",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -25,10 +25,10 @@ router.get('/status', auth, (req, res) => {
 });
 
 // Save questionnaire answers
-router.post('/questionnaire', auth, (req, res) => {
+router.post('/questionnaire', auth, async (req, res) => {
   const c = createCase(req.user.id);
   c.answers = req.body || {};
-  c.documents = computeDocuments(c.answers);
+  c.documents = await computeDocuments(c.answers);
   res.json({ status: 'saved' });
 });
 

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -1,6 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
+
 const cases = {};
 
-function computeDocuments(answers = {}) {
+function loadGrantConfig() {
+  const configPath = path.join(__dirname, '../../eligibility-engine/grants_config.json');
+  const raw = fs.readFileSync(configPath, 'utf8');
+  // remove leading comment line if present
+  const clean = raw.startsWith('//') ? raw.split('\n').slice(1).join('\n') : raw;
+  return JSON.parse(clean);
+}
+
+async function computeDocuments(answers = {}) {
   const docs = [
     { key: 'id_document', name: 'ID Document', uploaded: false, url: '' },
     { key: 'tax_returns', name: 'Business Tax Returns', uploaded: false, url: '' },
@@ -23,6 +35,35 @@ function computeDocuments(answers = {}) {
 
   if (answers.cpaPrepared) {
     docs.push({ key: 'cpa_letter', name: 'CPA Letter', uploaded: false, url: '' });
+  }
+
+  // Append grant-specific document requirements
+  try {
+    const config = loadGrantConfig();
+    const engineUrl = process.env.ENGINE_URL || 'http://localhost:4001/check';
+    const response = await fetch(engineUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(answers),
+    });
+    const results = await response.json();
+    if (Array.isArray(results)) {
+      results
+        .filter((r) => r.eligible || r.score > 0)
+        .forEach((r) => {
+          const grant = Object.values(config).find((g) => g.name === r.name);
+          if (grant && grant.required_documents) {
+            Object.values(grant.required_documents).flat().forEach((name) => {
+              const key = name.toLowerCase().replace(/\s+/g, '_');
+              if (!docs.some((d) => d.key === key)) {
+                docs.push({ key, name, uploaded: false, url: '' });
+              }
+            });
+          }
+        });
+    }
+  } catch (err) {
+    console.error('computeDocuments failed:', err.message);
   }
 
   return docs;


### PR DESCRIPTION
## Summary
- compute required documents using eligibility engine results
- support async call in questionnaire endpoint
- require `node-fetch` for server fetch calls

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d36d47b28832e9a8d2f5d2c107779