### PR TITLE
Fix eligibility report URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 MONGO_URI=mongodb://localhost:27017/grants
 JWT_SECRET=your_jwt_secret
 ANALYZER_URL=http://localhost:8000/analyze
-AGENT_URL=http://localhost:5001/form-fill
+# Base URL of the AI agent service
+AGENT_URL=http://localhost:5001

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm run dev
 ```
 
 Environment variables should be placed in a `.env.local` file. See `.env.local.example` for the API base URL.
-The backend now respects `AGENT_URL` to enable AI-driven eligibility summaries.
+The backend uses `AGENT_URL` which should point to the root of the AI agent service (e.g. `http://localhost:5001`).
 
 ## Docker Compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - MONGO_URI=mongodb://mongo:27017/grants
       - JWT_SECRET=devsecret
       - ANALYZER_URL=http://ai-analyzer:8000/analyze
-      - AGENT_URL=http://ai-agent:5001/form-fill
+      - AGENT_URL=http://ai-agent:5001
+      - ENGINE_URL=http://eligibility-engine:4001/check
     depends_on:
       - mongo
       - ai-analyzer

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -8,14 +8,22 @@ const { getCase } = require('../utils/caseStore');
 router.post('/', auth, async (req, res) => {
   const c = getCase(req.user.id, false);
   if (!c) return res.status(400).json({ message: 'No active case' });
-  const agentUrl = process.env.AGENT_URL;
-  const endpoint = agentUrl ? `${agentUrl.replace(/\/$/, '')}/check` : (process.env.ENGINE_URL || 'http://localhost:4001/check');
+  const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
+  const endpoint = agentBase
+    ? `${agentBase.replace(/\/$/, '')}/check`
+    : (process.env.ENGINE_URL || 'http://localhost:4001/check');
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(c.answers || {}),
     });
+    if (!response.ok) {
+      const text = await response.text();
+      console.error('Eligibility engine error:', response.status, text);
+      return res.status(502).json({ message: 'Engine unavailable' });
+    }
+
     const data = await response.json();
     c.eligibility = {
       eligible: Array.isArray(data) ? data.some((r) => r.eligible) : false,

--- a/server/routes/formFill.js
+++ b/server/routes/formFill.js
@@ -6,7 +6,8 @@ const router = express.Router();
 // @route   POST /api/form-fill
 // @desc    Forward form fill requests to the AI agent
 router.post('/', auth, async (req, res) => {
-  const agentUrl = process.env.AGENT_URL || 'http://localhost:5001/form-fill';
+  const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
+  const agentUrl = `${agentBase.replace(/\/$/, '')}/form-fill`;
   try {
     const response = await fetch(agentUrl, {
       method: 'POST',

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -5,7 +5,8 @@ const router = express.Router();
 
 // POST /api/forms/auto-fill
 router.post('/auto-fill', auth, async (req, res) => {
-  const agentUrl = process.env.AGENT_URL || 'http://localhost:5001/form-fill';
+  const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
+  const agentUrl = `${agentBase.replace(/\/$/, '')}/form-fill`;
   try {
     const response = await fetch(agentUrl, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- clean up AGENT_URL usage and assume it's the service root
- build form fill and eligibility endpoints from AGENT_URL
- provide better error handling in eligibility route
- document new AGENT_URL usage and Docker Compose settings

## Testing
- `npm test --silent`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688d40221d1c832e8e2d0478d0b39ad5