### PR TITLE
feat: improve onboarding and support UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The backend uses `AGENT_URL` which should point to the root of the AI agent serv
 4. When all documents are uploaded, click **Submit for Analysis** to see eligibility results.
 
 ![Dashboard Flow](frontend/public/dashboard-placeholder.svg)
+![Login Screen](frontend/public/login-placeholder.svg)
+![Document Upload](frontend/public/upload-placeholder.svg)
 
 ## Docker Compose
 

--- a/frontend/public/login-placeholder.svg
+++ b/frontend/public/login-placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#f3f4f6" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#374151">
+    Login Screen Placeholder
+  </text>
+</svg>

--- a/frontend/public/upload-placeholder.svg
+++ b/frontend/public/upload-placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#f3f4f6" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#374151">
+    Document Upload Placeholder
+  </text>
+</svg>

--- a/frontend/src/app/dashboard/documents/page.tsx
+++ b/frontend/src/app/dashboard/documents/page.tsx
@@ -15,6 +15,7 @@ export default function Documents() {
   const [uploads, setUploads] = useState<Record<string, File | null>>({});
   const [loading, setLoading] = useState(false);
   const [replaceKey, setReplaceKey] = useState<string | null>(null);
+  const [savedMessage, setSavedMessage] = useState('');
 
   const fetchStatus = async () => {
     const res = await api.get('/case/status');
@@ -45,6 +46,8 @@ export default function Documents() {
       });
       setUploads((u) => ({ ...u, [key]: null }));
       setReplaceKey(null);
+      setSavedMessage('Saved!');
+      setTimeout(() => setSavedMessage(''), 2000);
       fetchStatus();
     } catch (err: any) {
       alert(err?.response?.data?.message || 'Upload failed');
@@ -60,6 +63,7 @@ export default function Documents() {
   const allUploaded = docs.length > 0 && uploadedCount === docs.length;
 
   const submitAnalysis = async () => {
+    if (!confirm('Are you sure you want to submit?')) return;
     setLoading(true);
     if (typeof window !== 'undefined') {
       localStorage.setItem('caseStage', 'analysis');
@@ -98,6 +102,9 @@ export default function Documents() {
           steps={["Questionnaire", "Documents", "Analysis", "Results"]}
           current={loading ? 2 : 1}
         />
+        {savedMessage && (
+          <div className="text-green-600 text-sm">{savedMessage}</div>
+        )}
         <h1 className="text-2xl font-bold">Upload Documents</h1>
         <p className="text-sm text-gray-600">Accepted formats: PDF, JPG, JPEG, PNG.</p>
         {docs.map((doc: any) => (

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import SupportButton from '@/components/SupportButton';
 
 export const metadata: Metadata = {
   title: 'Grant Platform',
@@ -18,6 +19,7 @@ export default function RootLayout({
         <Header />
         <main className="min-h-screen container mx-auto p-4">{children}</main>
         <Footer />
+        <SupportButton />
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -17,11 +17,33 @@ export default function Login() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="max-w-md mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-6">Login</h1>
-      <FormInput label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-      <FormInput label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Login</button>
-    </form>
+    <div className="max-w-md mx-auto py-10 space-y-6">
+      <h1 className="text-3xl font-bold text-center">Apply for Business Grants</h1>
+      <p className="text-center text-gray-600">Sign in to continue your application and track progress.</p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormInput
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          hint="We'll send updates to this address"
+        />
+        <FormInput
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          tooltip="Minimum 8 characters"
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          Login
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -17,11 +17,33 @@ export default function Register() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="max-w-md mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-6">Register</h1>
-      <FormInput label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
-      <FormInput label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
-      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Register</button>
-    </form>
+    <div className="max-w-md mx-auto py-10 space-y-6">
+      <h1 className="text-3xl font-bold text-center">Create Your Account</h1>
+      <p className="text-center text-gray-600">Start your grant application in minutes.</p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormInput
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          hint="We'll send a confirmation link"
+        />
+        <FormInput
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          tooltip="Minimum 8 characters"
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          Register
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/components/FormInput.tsx
+++ b/frontend/src/components/FormInput.tsx
@@ -4,17 +4,27 @@ import { InputHTMLAttributes } from 'react';
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   error?: string;
+  hint?: string;
+  tooltip?: string;
 }
 
-export default function FormInput({ label, error, ...props }: Props) {
+export default function FormInput({ label, error, hint, tooltip, ...props }: Props) {
   return (
     <div className="mb-4">
-      <label className="block mb-1 font-medium">{label}</label>
+      <label className="block mb-1 font-medium">
+        {label}
+        {tooltip && (
+          <span className="ml-1 text-gray-400 cursor-pointer" title={tooltip}>
+            ?
+          </span>
+        )}
+      </label>
       <input
         {...props}
         className={`w-full rounded border px-3 py-2 ${error ? 'border-red-500' : ''}`}
       />
       {error && <p className="text-red-600 text-sm mt-1">{error}</p>}
+      {!error && hint && <p className="text-gray-500 text-sm mt-1">{hint}</p>}
     </div>
   );
 }

--- a/frontend/src/components/SupportButton.tsx
+++ b/frontend/src/components/SupportButton.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+export default function SupportButton() {
+  const openSupport = () => {
+    if (typeof window !== 'undefined') {
+      window.open('mailto:support@example.com');
+    }
+  };
+
+  return (
+    <button
+      onClick={openSupport}
+      aria-label="Support"
+      className="fixed bottom-4 right-4 w-10 h-10 rounded-full bg-blue-600 text-white shadow-lg flex items-center justify-center"
+    >
+      ?
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- refine login and registration pages with guidance text and tooltips
- add floating support button across the app
- show inline feedback and confirmation on document uploads

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890cff8c970832e8678e49311e0de87