### PR TITLE
feat: add back navigation to questionnaire

### DIFF
--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -88,6 +88,18 @@ export default function Questionnaire() {
   };
   const prev = () => setStep((s) => Math.max(s - 1, 0));
 
+  const goBack = () => {
+    if (step === 0) {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('questionnaire', JSON.stringify(answers));
+        localStorage.removeItem('caseStage');
+      }
+      router.push('/dashboard');
+    } else {
+      prev();
+    }
+  };
+
   const finish = async () => {
     if (!validate()) return;
     localStorage.setItem('questionnaire', JSON.stringify(answers));
@@ -388,14 +400,9 @@ export default function Questionnaire() {
             </div>
           )}
         <div className="flex justify-between pt-4">
-          {step > 0 && (
-            <button
-              onClick={prev}
-              className="px-4 py-2 border rounded"
-            >
-              Back
-            </button>
-          )}
+          <button onClick={goBack} className="px-4 py-2 border rounded">
+            Back
+          </button>
           {step < 3 && (
             <button
               onClick={next}


### PR DESCRIPTION
## Summary
- always display Back button in questionnaire wizard
- navigate to dashboard when backing out of first step while preserving answers

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68914a08be3c832ebde4649abc213e88