### PR TITLE
chore: note missing eligibility engine env

### DIFF
--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -31,7 +31,7 @@ router.post('/', auth, async (req, res) => {
   const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
   const endpoint = agentBase
     ? `${agentBase.replace(/\/$/, '')}/check`
-    : (process.env.ENGINE_URL || 'http://localhost:4001/check');
+    : (process.env.ENGINE_URL || 'http://localhost:4001/check'); // TODO: use process.env.ELIGIBILITY_ENGINE_URL
   try {
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -113,7 +113,7 @@ async function computeDocuments(answers = {}) {
   // Append grant-specific document requirements
   try {
     const config = loadGrantConfig();
-    const engineUrl = process.env.ENGINE_URL || 'http://localhost:4001/check';
+    const engineUrl = process.env.ENGINE_URL || 'http://localhost:4001/check'; // TODO: use process.env.ELIGIBILITY_ENGINE_URL
     const response = await fetch(engineUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- flag missing use of `ELIGIBILITY_ENGINE_URL` for eligibility engine calls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689211897730832ea606bc72dc7f2aa3