### PR TITLE
Use ELIGIBILITY_ENGINE_URL for eligibility engine requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - JWT_SECRET=devsecret
       - ANALYZER_URL=http://ai-analyzer:8000/analyze
       - AGENT_URL=http://ai-agent:5001
-      - ENGINE_URL=http://eligibility-engine:4001/check
+      - ELIGIBILITY_ENGINE_URL=http://eligibility-engine:4001
     depends_on:
       - mongo
       - ai-analyzer

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -31,7 +31,7 @@ router.post('/', auth, async (req, res) => {
   const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
   const endpoint = agentBase
     ? `${agentBase.replace(/\/$/, '')}/check`
-    : (process.env.ENGINE_URL || 'http://localhost:4001/check'); // TODO: use process.env.ELIGIBILITY_ENGINE_URL
+    : `${(process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001').replace(/\/$/, '')}/check`;
   try {
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -113,8 +113,8 @@ async function computeDocuments(answers = {}) {
   // Append grant-specific document requirements
   try {
     const config = loadGrantConfig();
-    const engineUrl = process.env.ENGINE_URL || 'http://localhost:4001/check'; // TODO: use process.env.ELIGIBILITY_ENGINE_URL
-    const response = await fetch(engineUrl, {
+    const baseUrl = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
+    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/check`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(answers),


### PR DESCRIPTION
## Summary
- route and utilities now read `process.env.ELIGIBILITY_ENGINE_URL` with local fallback when contacting the eligibility engine
- docker-compose updated to pass `ELIGIBILITY_ENGINE_URL` to the server

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689212c80dc4832e870ed35d65fa5c59