### PR TITLE
feat: allow optional business details

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The dashboard shows any missing documents so applicants know what is still requi
 
 Answers for all sections are submitted to `POST /api/case/questionnaire`. The payload must contain:
 
-- business information – legal name, contact details, NAICS code, and operating status
+- business information – legal name, contact details, and operating status
 - an array of owners with name, date of birth, address, SSN/ITIN and ownership percentage (must total 100)
 - financial data such as annual revenue, net profit and employee counts
 - grant request details (amount, purpose and any prior assistance)

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -37,8 +37,6 @@ router.post('/questionnaire', auth, async (req, res) => {
     'entityType',
     'ein',
     'dateEstablished',
-    'businessDescription',
-    'naicsCode',
   ];
 
   const missing = required.filter((f) => !answers[f]);


### PR DESCRIPTION
## Summary
- drop businessDescription and naicsCode from mandatory questionnaire fields
- clarify in docs that NAICS code is not required

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68921ab2bd98832ea75af0448a1b6990