### PR TITLE
feat: allow empty questionnaire submissions

### DIFF
--- a/frontend/src/app/dashboard/documents/page.tsx
+++ b/frontend/src/app/dashboard/documents/page.tsx
@@ -60,7 +60,6 @@ export default function Documents() {
 
   const docs = Array.isArray(caseData.documents) ? caseData.documents : [];
   const uploadedCount = docs.filter((d: any) => d.uploaded).length;
-  const allUploaded = docs.length > 0 && uploadedCount === docs.length;
 
   const goBack = () => {
     if (typeof window !== 'undefined') {
@@ -77,21 +76,10 @@ export default function Documents() {
     }
     try {
       await api.post('/eligibility-report');
-      const status = await api.get('/case/status');
-      setCaseData(status.data);
-      const docs = Array.isArray(status.data.documents) ? status.data.documents : [];
-      const missing = docs.filter((d: any) => !d.uploaded).length;
-      if (missing > 0) {
-        alert('Additional documents are required.');
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('caseStage', 'documents');
-        }
-      } else {
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('caseStage', 'results');
-        }
-        router.push('/dashboard');
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('caseStage', 'results');
       }
+      router.push('/dashboard');
     } catch (err: any) {
       alert(err?.response?.data?.message || 'Submission failed');
       if (typeof window !== 'undefined') {
@@ -206,21 +194,19 @@ export default function Documents() {
         <div className="h-2 bg-gray-200 rounded">
           <div
             className="h-full bg-green-500 rounded"
-            style={{ width: `${(uploadedCount / docs.length) * 100}%` }}
+            style={{ width: `${docs.length ? (uploadedCount / docs.length) * 100 : 0}%` }}
           />
         </div>
         <div className="flex justify-between pt-4">
           <button onClick={goBack} className="px-4 py-2 border rounded">
             Back
           </button>
-          {allUploaded && (
-            <button
-              onClick={submitAnalysis}
-              className="px-4 py-2 bg-purple-600 text-white rounded ml-auto"
-            >
-              {loading ? 'Submitting...' : 'Submit for Analysis'}
-            </button>
-          )}
+          <button
+            onClick={submitAnalysis}
+            className="px-4 py-2 bg-purple-600 text-white rounded ml-auto"
+          >
+            {loading ? 'Submitting...' : 'Submit for Analysis'}
+          </button>
         </div>
       </div>
     </Protected>

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -56,8 +56,6 @@ export default function Questionnaire() {
     hasInsurance: false,
   });
 
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
   useEffect(() => {
     const load = async () => {
       try {
@@ -73,35 +71,8 @@ export default function Questionnaire() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const validate = () => {
-    const newErrors: Record<string, string> = {};
-    const stepRequirements: Record<number, string[]> = {
-      0: ['businessName', 'phone', 'email', 'address', 'city', 'state', 'zip', 'locationZone'],
-      1: ['businessType', 'dateEstablished'],
-      2: ['annualRevenue', 'netProfit', 'employees', 'ownershipPercent', 'previousGrants'],
-      3: [],
-    };
-    const required = stepRequirements[step] || [];
-    if (step === 1) {
-      if (answers.businessType === 'Corporation' || answers.businessType === 'LLC') {
-        required.push('incorporationDate', 'ein');
-      } else if (answers.businessType === 'Sole') {
-        required.push('ssn');
-      } else {
-        required.push('ein');
-      }
-    }
-    required.forEach((field) => {
-      if (!answers[field as keyof typeof answers]) {
-        newErrors[field] = 'Required';
-      }
-    });
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
   const next = () => {
-    if (validate()) setStep((s) => Math.min(s + 1, 3));
+    setStep((s) => Math.min(s + 1, 3));
   };
   const prev = () => setStep((s) => Math.max(s - 1, 0));
 
@@ -118,7 +89,6 @@ export default function Questionnaire() {
   };
 
   const finish = async () => {
-    if (!validate()) return;
     localStorage.setItem('questionnaire', JSON.stringify(answers));
     try {
       await api.post('/case/questionnaire', answers);
@@ -143,65 +113,51 @@ export default function Questionnaire() {
             <FormInput
               label="Business Name"
               value={answers.businessName}
-              error={errors.businessName}
               onChange={(e) => {
                 setAnswers({ ...answers, businessName: e.target.value });
-                if (errors.businessName) setErrors({ ...errors, businessName: '' });
               }}
             />
             <FormInput
               label="Business Phone"
               value={answers.phone}
-              error={errors.phone}
               onChange={(e) => {
                 setAnswers({ ...answers, phone: e.target.value });
-                if (errors.phone) setErrors({ ...errors, phone: '' });
               }}
             />
             <FormInput
               label="Business Email"
               type="email"
               value={answers.email}
-              error={errors.email}
               onChange={(e) => {
                 setAnswers({ ...answers, email: e.target.value });
-                if (errors.email) setErrors({ ...errors, email: '' });
               }}
             />
             <FormInput
               label="Address"
               value={answers.address}
-              error={errors.address}
               onChange={(e) => {
                 setAnswers({ ...answers, address: e.target.value });
-                if (errors.address) setErrors({ ...errors, address: '' });
               }}
             />
             <FormInput
               label="City"
               value={answers.city}
-              error={errors.city}
               onChange={(e) => {
                 setAnswers({ ...answers, city: e.target.value });
-                if (errors.city) setErrors({ ...errors, city: '' });
               }}
             />
             <FormInput
               label="State"
               value={answers.state}
-              error={errors.state}
               onChange={(e) => {
                 setAnswers({ ...answers, state: e.target.value });
-                if (errors.state) setErrors({ ...errors, state: '' });
               }}
             />
             <FormInput
               label="Zip Code"
               value={answers.zip}
-              error={errors.zip}
               onChange={(e) => {
                 setAnswers({ ...answers, zip: e.target.value });
-                if (errors.zip) setErrors({ ...errors, zip: '' });
               }}
             />
             <label className="block mb-2 font-medium">Location Zone</label>
@@ -210,7 +166,6 @@ export default function Questionnaire() {
               value={answers.locationZone}
               onChange={(e) => {
                 setAnswers({ ...answers, locationZone: e.target.value });
-                if (errors.locationZone) setErrors({ ...errors, locationZone: '' });
               }}
             >
               <option value="">Select</option>
@@ -218,9 +173,6 @@ export default function Questionnaire() {
               <option value="rural">Rural</option>
               <option value="hubzone">HUBZone</option>
             </select>
-            {errors.locationZone && (
-              <p className="text-red-600 text-sm mb-2">{errors.locationZone}</p>
-            )}
           </>
         )}
         {step === 1 && (
@@ -231,7 +183,6 @@ export default function Questionnaire() {
               value={answers.businessType}
               onChange={(e) => {
                 setAnswers({ ...answers, businessType: e.target.value });
-                if (errors.businessType) setErrors({ ...errors, businessType: '' });
               }}
             >
               <option value="">Select</option>
@@ -240,19 +191,13 @@ export default function Questionnaire() {
               <option value="LLC">LLC</option>
               <option value="Corporation">Corporation</option>
             </select>
-            {errors.businessType && (
-              <p className="text-red-600 text-sm mb-2">{errors.businessType}</p>
-            )}
               {(answers.businessType === 'Corporation' || answers.businessType === 'LLC') && (
                 <FormInput
                   label="Incorporation Date"
                   type="date"
                   value={answers.incorporationDate}
-                  error={errors.incorporationDate}
                   onChange={(e) => {
                     setAnswers({ ...answers, incorporationDate: e.target.value });
-                    if (errors.incorporationDate)
-                      setErrors({ ...errors, incorporationDate: '' });
                   }}
                 />
               )}
@@ -260,31 +205,24 @@ export default function Questionnaire() {
                 label="Date Established"
                 type="date"
                 value={answers.dateEstablished}
-                error={errors.dateEstablished}
                 onChange={(e) => {
                   setAnswers({ ...answers, dateEstablished: e.target.value });
-                  if (errors.dateEstablished)
-                    setErrors({ ...errors, dateEstablished: '' });
                 }}
               />
               {answers.businessType === 'Sole' ? (
                 <FormInput
                   label="Owner SSN"
                   value={answers.ssn}
-                  error={errors.ssn}
                   onChange={(e) => {
                     setAnswers({ ...answers, ssn: e.target.value });
-                    if (errors.ssn) setErrors({ ...errors, ssn: '' });
                   }}
                 />
               ) : (
                 <FormInput
                   label="Business EIN"
                   value={answers.ein}
-                  error={errors.ein}
                   onChange={(e) => {
                     setAnswers({ ...answers, ein: e.target.value });
-                    if (errors.ein) setErrors({ ...errors, ein: '' });
                   }}
                 />
               )}
@@ -296,42 +234,32 @@ export default function Questionnaire() {
               label="Annual Revenue"
               type="number"
               value={answers.annualRevenue}
-              error={errors.annualRevenue}
               onChange={(e) => {
                 setAnswers({ ...answers, annualRevenue: e.target.value });
-                if (errors.annualRevenue)
-                  setErrors({ ...errors, annualRevenue: '' });
               }}
             />
             <FormInput
               label="Net Profit"
               type="number"
               value={answers.netProfit}
-              error={errors.netProfit}
               onChange={(e) => {
                 setAnswers({ ...answers, netProfit: e.target.value });
-                if (errors.netProfit) setErrors({ ...errors, netProfit: '' });
               }}
             />
             <FormInput
               label="Number of Employees"
               type="number"
               value={answers.employees}
-              error={errors.employees}
               onChange={(e) => {
                 setAnswers({ ...answers, employees: e.target.value });
-                if (errors.employees) setErrors({ ...errors, employees: '' });
               }}
             />
             <FormInput
               label="Ownership Percentage"
               type="number"
               value={answers.ownershipPercent}
-              error={errors.ownershipPercent}
               onChange={(e) => {
                 setAnswers({ ...answers, ownershipPercent: e.target.value });
-                if (errors.ownershipPercent)
-                  setErrors({ ...errors, ownershipPercent: '' });
               }}
             />
             <label className="block mb-2 font-medium">Previous Grants</label>
@@ -340,17 +268,12 @@ export default function Questionnaire() {
               value={answers.previousGrants}
               onChange={(e) => {
                 setAnswers({ ...answers, previousGrants: e.target.value });
-                if (errors.previousGrants)
-                  setErrors({ ...errors, previousGrants: '' });
               }}
             >
               <option value="">Select</option>
               <option value="yes">Yes</option>
               <option value="no">No</option>
             </select>
-            {errors.previousGrants && (
-              <p className="text-red-600 text-sm mb-2">{errors.previousGrants}</p>
-            )}
           </>
         )}
         {step === 3 && (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -26,7 +26,6 @@ export default function Login() {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          required
           hint="We'll send updates to this address"
         />
         <FormInput
@@ -34,7 +33,6 @@ export default function Login() {
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          required
           tooltip="Minimum 8 characters"
         />
         <button

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -26,7 +26,6 @@ export default function Register() {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          required
           hint="We'll send a confirmation link"
         />
         <FormInput
@@ -34,7 +33,6 @@ export default function Register() {
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          required
           tooltip="Minimum 8 characters"
         />
         <button

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -9,25 +9,6 @@ router.post('/', auth, async (req, res) => {
   const c = getCase(req.user.id, false);
   if (!c) return res.status(400).json({ message: 'No active case' });
   const answers = c.answers || {};
-  const required = ['businessName','phone','email','address','city','state','zip','locationZone','businessType','dateEstablished','annualRevenue','netProfit','employees','ownershipPercent','previousGrants'];
-  if (answers.businessType === 'Corporation' || answers.businessType === 'LLC') {
-    required.push('incorporationDate','ein');
-  } else if (answers.businessType === 'Sole') {
-    required.push('ssn');
-  } else {
-    required.push('ein');
-  }
-  const missingAnswers = required.filter((f) => !answers[f]);
-  const missingDocs = Array.isArray(c.documents)
-    ? c.documents.filter((d) => !d.uploaded).map((d) => d.name)
-    : [];
-  if (missingAnswers.length || missingDocs.length) {
-    return res.status(400).json({
-      message: 'Case incomplete',
-      missingAnswers,
-      missingDocs,
-    });
-  }
   const agentBase = process.env.AGENT_URL || 'http://localhost:5001';
   const endpoint = agentBase
     ? `${agentBase.replace(/\/$/, '')}/check`


### PR DESCRIPTION
## Summary
- remove all field validations from questionnaire workflow and related forms
- allow document step to submit even without uploads
- relax eligibility report endpoint to accept empty payloads

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*


------
https://chatgpt.com/codex/tasks/task_e_68922e102eec832ea42cacff619ceb62