### PR TITLE
Align questionnaire data handling

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -37,3 +37,31 @@ Content-Type: multipart/form-data
 file: <path to your file.png>
 key: id_document
 ```
+
+## Save Questionnaire
+```http
+POST http://localhost:5000/api/case/questionnaire
+Authorization: Bearer <JWT_TOKEN>
+Content-Type: application/json
+
+{
+  "businessName": "Tech Co",
+  "phone": "555-1234",
+  "email": "owner@example.com",
+  "address": "1 Main St",
+  "city": "Metropolis",
+  "state": "NY",
+  "zip": "10001",
+  "locationZone": "urban",
+  "entityType": "LLC",
+  "ein": "12-3456789",
+  "incorporationDate": "2020-01-01",
+  "dateEstablished": "2019-06-01",
+  "annualRevenue": 500000,
+  "netProfit": 80000,
+  "employees": 5,
+  "ownershipPercent": 100,
+  "previousGrants": false,
+  "cpaPrepared": true
+}
+```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ The frontend interacts with a simpler set of endpoints that manage a user's inâ€
 
 All routes are protected and expect a `Bearer` JWT token. Service URLs for the AI Agent, Eligibility Engine and Form Filler are configured with the environment variables shown above.
 
+### Questionnaire Payload
+
+`POST /api/case/questionnaire` accepts JSON with the following fields. All numeric values must be numbers and boolean flags must be true/false.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| businessName, phone, email, address, city, state, zip | string | required |
+| locationZone | string | required (`urban`, `rural`, `hubzone`) |
+| entityType | string | required (`Sole`, `Partnership`, `LLC`, `Corporation`) |
+| ein | string | required for `LLC`/`Corporation`/`Partnership` |
+| ssn | string | required for `Sole` |
+| incorporationDate | string (date) | required for `LLC`/`Corporation` |
+| dateEstablished | string (date) | required |
+| annualRevenue, netProfit, employees, ownershipPercent | number | required |
+| previousGrants | boolean | required |
+| cpaPrepared, minorityOwned, womanOwned, veteranOwned, hasPayroll, hasInsurance | boolean | optional |
+
 ## Running locally
 
 1. Install Node dependencies and start the API server

--- a/server/tests/caseStore.test.js
+++ b/server/tests/caseStore.test.js
@@ -24,3 +24,9 @@ test('employees trigger payroll records', async () => {
   const keys = docs.map(d => d.key);
   assert(keys.includes('payroll_records'));
 });
+
+test('previous grants require documentation', async () => {
+  const docs = await computeDocuments({ previousGrants: true });
+  const keys = docs.map(d => d.key);
+  assert(keys.includes('previous_grant_docs'));
+});

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { normalizeQuestionnaire } = require('../utils/validation');
+
+test('normalizeQuestionnaire maps and converts fields', () => {
+  const { data, missing } = normalizeQuestionnaire({
+    businessType: 'LLC',
+    businessName: 'Biz',
+    phone: '555',
+    email: 'a@b.com',
+    address: '1 st',
+    city: 'City',
+    state: 'ST',
+    zip: '12345',
+    locationZone: 'urban',
+    dateEstablished: '2020-01-01',
+    annualRevenue: '100',
+    netProfit: '10',
+    employees: '2',
+    ownershipPercent: '50',
+    previousGrants: 'yes',
+    ein: '12',
+    incorporationDate: '2020-01-01',
+    cpaPrepared: 'true',
+    minorityOwned: 'false',
+    womanOwned: 'true',
+    veteranOwned: 'false',
+    hasPayroll: 'true',
+    hasInsurance: 'false',
+  });
+  assert.equal(data.entityType, 'LLC');
+  assert.strictEqual(data.previousGrants, true);
+  assert.strictEqual(data.annualRevenue, 100);
+  assert.strictEqual(data.employees, 2);
+  assert.equal(missing.length, 0);
+});
+
+test('normalizeQuestionnaire reports missing fields', () => {
+  const { missing } = normalizeQuestionnaire({});
+  assert(missing.includes('businessName'));
+  assert(missing.includes('entityType'));
+});

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -100,7 +100,7 @@ async function computeDocuments(answers = {}) {
     });
   }
 
-  if (answers.previousGrants === 'yes') {
+  if (answers.previousGrants) {
     docs.push({
       key: 'previous_grant_docs',
       name: 'Previous Grant Documents',

--- a/server/utils/validation.js
+++ b/server/utils/validation.js
@@ -1,0 +1,70 @@
+const numericFields = ['annualRevenue', 'netProfit', 'employees', 'ownershipPercent'];
+const booleanFields = ['previousGrants', 'cpaPrepared', 'minorityOwned', 'womanOwned', 'veteranOwned', 'hasPayroll', 'hasInsurance'];
+
+function normalizeQuestionnaire(input = {}) {
+  const data = { ...input };
+
+  if (data.businessType && !data.entityType) {
+    data.entityType = data.businessType;
+    delete data.businessType;
+  }
+
+  // convert numeric fields
+  numericFields.forEach((f) => {
+    if (data[f] !== undefined && data[f] !== '') {
+      const n = Number(data[f]);
+      data[f] = Number.isFinite(n) ? n : NaN;
+    }
+  });
+
+  // convert booleans
+  booleanFields.forEach((f) => {
+    if (data[f] !== undefined && data[f] !== '') {
+      const v = data[f];
+      if (typeof v === 'boolean') {
+        data[f] = v;
+      } else if (typeof v === 'string') {
+        data[f] = ['true', 'yes', '1', 'on'].includes(v.toLowerCase());
+      } else {
+        data[f] = Boolean(v);
+      }
+    }
+  });
+
+  const required = [
+    'businessName',
+    'phone',
+    'email',
+    'address',
+    'city',
+    'state',
+    'zip',
+    'locationZone',
+    'entityType',
+    'dateEstablished',
+    'annualRevenue',
+    'netProfit',
+    'employees',
+    'ownershipPercent',
+    'previousGrants',
+  ];
+
+  const missing = required.filter((f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f]));
+
+  // conditional requirements
+  if (data.entityType === 'Sole') {
+    if (!data.ssn) missing.push('ssn');
+  } else {
+    if (!data.ein) missing.push('ein');
+    if (!data.incorporationDate) missing.push('incorporationDate');
+  }
+
+  const invalid = [];
+  numericFields.forEach((f) => {
+    if (data[f] !== undefined && !Number.isFinite(data[f])) invalid.push(f);
+  });
+
+  return { data, missing, invalid };
+}
+
+module.exports = { normalizeQuestionnaire };


### PR DESCRIPTION
## Summary
- normalize and validate questionnaire fields, mapping `businessType` to `entityType`
- enforce validation in `/api/case/questionnaire` and log eligibility submissions
- update frontend questionnaire to send typed values and display validation errors
- document questionnaire payload and add tests for data normalization and previous grants

## Testing
- `npm test --prefix server`
- `npm run lint --prefix frontend` *(fails: next not found; dependency install blocked by 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689363e8dab8832eb10dbf191e58835c