### PR TITLE
Fix eligibility report payload validation

### DIFF
--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,0 +1,65 @@
+export const numericFields = ['annualRevenue', 'netProfit', 'employees', 'ownershipPercent'];
+export const booleanFields = ['previousGrants', 'cpaPrepared', 'minorityOwned', 'womanOwned', 'veteranOwned', 'hasPayroll', 'hasInsurance'];
+
+export function normalizeQuestionnaire(input: any = {}) {
+  const data: any = { ...input };
+
+  if (data.businessType && !data.entityType) {
+    data.entityType = data.businessType;
+    delete data.businessType;
+  }
+
+  numericFields.forEach((f) => {
+    if (data[f] !== undefined && data[f] !== '') {
+      const n = Number(data[f]);
+      data[f] = Number.isFinite(n) ? n : NaN;
+    }
+  });
+
+  booleanFields.forEach((f) => {
+    if (data[f] !== undefined && data[f] !== '') {
+      const v = data[f];
+      if (typeof v === 'boolean') {
+        data[f] = v;
+      } else if (typeof v === 'string') {
+        data[f] = ['true', 'yes', '1', 'on'].includes(v.toLowerCase());
+      } else {
+        data[f] = Boolean(v);
+      }
+    }
+  });
+
+  const required = [
+    'businessName',
+    'phone',
+    'email',
+    'address',
+    'city',
+    'state',
+    'zip',
+    'locationZone',
+    'entityType',
+    'dateEstablished',
+    'annualRevenue',
+    'netProfit',
+    'employees',
+    'ownershipPercent',
+    'previousGrants',
+  ];
+
+  const missing = required.filter((f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f]));
+
+  if (data.entityType === 'Sole') {
+    if (!data.ssn) missing.push('ssn');
+  } else {
+    if (!data.ein) missing.push('ein');
+    if (!data.incorporationDate) missing.push('incorporationDate');
+  }
+
+  const invalid: string[] = [];
+  numericFields.forEach((f) => {
+    if (data[f] !== undefined && !Number.isFinite(data[f])) invalid.push(f);
+  });
+
+  return { data, missing, invalid };
+}

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -40,3 +40,26 @@ test('normalizeQuestionnaire reports missing fields', () => {
   assert(missing.includes('businessName'));
   assert(missing.includes('entityType'));
 });
+
+test('normalizeQuestionnaire flags invalid numeric fields', () => {
+  const { invalid } = normalizeQuestionnaire({
+    businessName: 'Biz',
+    phone: '555',
+    email: 'a@b.com',
+    address: '1 st',
+    city: 'City',
+    state: 'ST',
+    zip: '12345',
+    locationZone: 'urban',
+    entityType: 'LLC',
+    dateEstablished: '2020-01-01',
+    annualRevenue: 'oops',
+    netProfit: '10',
+    employees: '2',
+    ownershipPercent: '50',
+    previousGrants: 'no',
+    ein: '12',
+    incorporationDate: '2020-01-01',
+  });
+  assert(invalid.includes('annualRevenue'));
+});


### PR DESCRIPTION
## Summary
- validate and normalize request body for `POST /api/eligibility-report`
- add client-side normalization & validation before submitting analysis
- cover invalid numeric fields in questionnaire validation tests

## Testing
- `cd server && npm test`
- `cd frontend && npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden for next)*

------
https://chatgpt.com/codex/tasks/task_e_689367edd44c832e8ed367a8d5d9f845