### PR TITLE
Normalize dateEstablished field in questionnaire validation

### DIFF
--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -23,11 +23,12 @@ router.post('/case/questionnaire', auth, async (req, res) => {
     const { data, missing, invalid } = normalizeQuestionnaire(req.body);
     if (missing.length || invalid.length) {
       console.log('  ✖ validation failed', { missing, invalid });
-      return res
-        .status(400)
-        .json({ message: 'Invalid questionnaire data', missing, invalid });
+      const message = missing.length
+        ? `Missing required fields: ${missing.join(', ')}`
+        : 'Invalid questionnaire data';
+      return res.status(400).json({ message, missing, invalid });
     }
-    console.log('  ✓ validation passed');
+    console.log('  ✓ validation passed', { normalized: data });
     const c = getCase(req.user.id);
     c.answers = { ...c.answers, ...data };
     c.documents = await computeDocuments(c.answers);
@@ -121,11 +122,12 @@ router.post('/eligibility-report', auth, async (req, res) => {
     const { data, missing, invalid } = normalizeQuestionnaire(req.body);
     if (missing.length || invalid.length) {
       console.log('  ✖ validation failed', { missing, invalid });
-      return res
-        .status(400)
-        .json({ message: 'Invalid eligibility payload', missing, invalid });
+      const message = missing.length
+        ? `Missing required fields: ${missing.join(', ')}`
+        : 'Invalid eligibility payload';
+      return res.status(400).json({ message, missing, invalid });
     }
-    console.log('  ✓ validation passed');
+    console.log('  ✓ validation passed', { normalized: data });
 
     c.answers = { ...c.answers, ...data };
 

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { normalizeQuestionnaire } = require('../utils/validation');
 
-test('normalizeQuestionnaire maps and converts fields', () => {
+test('normalizeQuestionnaire maps dateEstablished to incorporationDate and converts fields', () => {
   const { data, missing } = normalizeQuestionnaire({
     businessType: 'LLC',
     businessName: 'Biz',
@@ -20,7 +20,6 @@ test('normalizeQuestionnaire maps and converts fields', () => {
     ownershipPercent: '50',
     previousGrants: 'yes',
     ein: '12',
-    incorporationDate: '2020-01-01',
     cpaPrepared: 'true',
     minorityOwned: 'false',
     womanOwned: 'true',
@@ -32,6 +31,8 @@ test('normalizeQuestionnaire maps and converts fields', () => {
   assert.strictEqual(data.previousGrants, true);
   assert.strictEqual(data.annualRevenue, 100);
   assert.strictEqual(data.employees, 2);
+  assert.equal(data.incorporationDate, '2020-01-01');
+  assert(!('dateEstablished' in data));
   assert.equal(missing.length, 0);
 });
 
@@ -39,6 +40,7 @@ test('normalizeQuestionnaire reports missing fields', () => {
   const { missing } = normalizeQuestionnaire({});
   assert(missing.includes('businessName'));
   assert(missing.includes('entityType'));
+  assert(missing.includes('incorporationDate'));
 });
 
 test('normalizeQuestionnaire flags invalid numeric fields', () => {
@@ -59,7 +61,27 @@ test('normalizeQuestionnaire flags invalid numeric fields', () => {
     ownershipPercent: '50',
     previousGrants: 'no',
     ein: '12',
-    incorporationDate: '2020-01-01',
   });
   assert(invalid.includes('annualRevenue'));
+});
+
+test('normalizeQuestionnaire requires incorporationDate when dateEstablished missing', () => {
+  const { missing } = normalizeQuestionnaire({
+    businessName: 'Biz',
+    phone: '555',
+    email: 'a@b.com',
+    address: '1 st',
+    city: 'City',
+    state: 'ST',
+    zip: '12345',
+    locationZone: 'urban',
+    entityType: 'LLC',
+    annualRevenue: '100',
+    netProfit: '10',
+    employees: '2',
+    ownershipPercent: '50',
+    previousGrants: 'no',
+    ein: '12',
+  });
+  assert(missing.includes('incorporationDate'));
 });

--- a/server/utils/validation.js
+++ b/server/utils/validation.js
@@ -4,6 +4,11 @@ const booleanFields = ['previousGrants', 'cpaPrepared', 'minorityOwned', 'womanO
 function normalizeQuestionnaire(input = {}) {
   const data = { ...input };
 
+  if (data.dateEstablished && !data.incorporationDate) {
+    data.incorporationDate = data.dateEstablished;
+    delete data.dateEstablished;
+  }
+
   if (data.businessType && !data.entityType) {
     data.entityType = data.businessType;
     delete data.businessType;
@@ -41,7 +46,7 @@ function normalizeQuestionnaire(input = {}) {
     'zip',
     'locationZone',
     'entityType',
-    'dateEstablished',
+    'incorporationDate',
     'annualRevenue',
     'netProfit',
     'employees',
@@ -56,7 +61,6 @@ function normalizeQuestionnaire(input = {}) {
     if (!data.ssn) missing.push('ssn');
   } else {
     if (!data.ein) missing.push('ein');
-    if (!data.incorporationDate) missing.push('incorporationDate');
   }
 
   const invalid = [];
@@ -64,6 +68,7 @@ function normalizeQuestionnaire(input = {}) {
     if (data[f] !== undefined && !Number.isFinite(data[f])) invalid.push(f);
   });
 
+  console.log('normalizeQuestionnaire normalized data', data);
   return { data, missing, invalid };
 }
 


### PR DESCRIPTION
## Summary
- Map `dateEstablished` to `incorporationDate` during questionnaire normalization
- Improve validation error messages and log normalized data
- Add tests for date field mapping and missing field handling

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936b01aedc832eba643b9f5918f46c