### PR TITLE
Align backend questionnaire with frontend fields

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -51,17 +51,15 @@ Content-Type: application/json
   "address": "1 Main St",
   "city": "Metropolis",
   "state": "NY",
-  "zip": "10001",
+  "zipCode": "10001",
   "locationZone": "urban",
-  "entityType": "LLC",
-  "ein": "12-3456789",
-  "incorporationDate": "2020-01-01",
-  "dateEstablished": "2019-06-01",
+  "businessType": "LLC",
+  "dateEstablished": "01/06/2019",
+  "businessEIN": "12-3456789",
   "annualRevenue": 500000,
   "netProfit": 80000,
-  "employees": 5,
-  "ownershipPercent": 100,
-  "previousGrants": false,
-  "cpaPrepared": true
+  "numberOfEmployees": 5,
+  "ownershipPercentage": 100,
+  "previousGrants": false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -53,20 +53,26 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
 
 ### Questionnaire Payload
 
-`POST /api/case/questionnaire` accepts JSON with the following fields. All numeric values must be numbers and boolean flags must be true/false.
+`POST /api/case/questionnaire` accepts JSON with the following fields. Numeric strings will be converted to numbers, boolean-like strings are parsed, and dates must be in `dd/MM/YYYY` format.
 
-| Field | Type | Notes |
-| --- | --- | --- |
-| businessName, phone, email, address, city, state, zip | string | required |
-| locationZone | string | required (`urban`, `rural`, `hubzone`) |
-| entityType | string | required (`Sole`, `Partnership`, `LLC`, `Corporation`) |
-| ein | string | required for `LLC`/`Corporation`/`Partnership` |
-| ssn | string | required for `Sole` |
-| incorporationDate | string (date) | required for `LLC`/`Corporation` |
-| dateEstablished | string (date) | required |
-| annualRevenue, netProfit, employees, ownershipPercent | number | required |
-| previousGrants | boolean | required |
-| cpaPrepared, minorityOwned, womanOwned, veteranOwned, hasPayroll, hasInsurance | boolean | optional |
+| Field | Type | Required? | Notes |
+| --- | --- | --- | --- |
+| businessName | string | yes | |
+| phone | string | yes | |
+| email | string (email) | yes | valid email format |
+| address | string | no | |
+| city | string | no | |
+| state | string | no | |
+| zipCode | string | no | |
+| locationZone | string | no | e.g. `urban` |
+| businessType | string | yes | allowed: `Sole`, `Partnership`, `LLC`, `Corporation` |
+| dateEstablished | string (date) | yes | format `dd/MM/YYYY` |
+| businessEIN | string | no | |
+| annualRevenue | number | no | |
+| netProfit | number | no | |
+| numberOfEmployees | number | no | |
+| ownershipPercentage | number (0-100) | no | |
+| previousGrants | boolean | no | |
 
 ## Running locally
 
@@ -112,7 +118,7 @@ curl -X POST http://localhost:5001/fill-forms \
         "user_payload": {
             "business_name": "Tech Boosters",
             "annual_revenue": 250000,
-            "zipcode": "10001",
+            "zipCode": "10001",
             "minority_owned": true
         }
     }'

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -23,9 +23,12 @@ router.post('/case/questionnaire', auth, async (req, res) => {
     const { data, missing, invalid } = normalizeQuestionnaire(req.body);
     if (missing.length || invalid.length) {
       console.log('  ✖ validation failed', { missing, invalid });
-      const message = missing.length
-        ? `Missing required fields: ${missing.join(', ')}`
-        : 'Invalid questionnaire data';
+      let message = '';
+      if (missing.length) message += `Missing required fields: ${missing.join(', ')}`;
+      if (invalid.length) {
+        if (message) message += '; ';
+        message += `Invalid fields: ${invalid.join(', ')}`;
+      }
       return res.status(400).json({ message, missing, invalid });
     }
     console.log('  ✓ validation passed', { normalized: data });
@@ -122,9 +125,12 @@ router.post('/eligibility-report', auth, async (req, res) => {
     const { data, missing, invalid } = normalizeQuestionnaire(req.body);
     if (missing.length || invalid.length) {
       console.log('  ✖ validation failed', { missing, invalid });
-      const message = missing.length
-        ? `Missing required fields: ${missing.join(', ')}`
-        : 'Invalid eligibility payload';
+      let message = '';
+      if (missing.length) message += `Missing required fields: ${missing.join(', ')}`;
+      if (invalid.length) {
+        if (message) message += '; ';
+        message += `Invalid fields: ${invalid.join(', ')}`;
+      }
       return res.status(400).json({ message, missing, invalid });
     }
     console.log('  ✓ validation passed', { normalized: data });

--- a/server/tests/caseStore.test.js
+++ b/server/tests/caseStore.test.js
@@ -13,14 +13,14 @@ test('base document requirements', async () => {
 });
 
 test('corporation requires incorporation docs', async () => {
-  const docs = await computeDocuments({ entityType: 'Corporation' });
+  const docs = await computeDocuments({ businessType: 'Corporation' });
   const keys = docs.map(d => d.key);
   assert(keys.includes('articles_incorporation'));
   assert(keys.includes('ein_document'));
 });
 
 test('employees trigger payroll records', async () => {
-  const docs = await computeDocuments({ employees: 5 });
+  const docs = await computeDocuments({ numberOfEmployees: 5 });
   const keys = docs.map(d => d.key);
   assert(keys.includes('payroll_records'));
 });

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -2,86 +2,49 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { normalizeQuestionnaire } = require('../utils/validation');
 
-test('normalizeQuestionnaire maps dateEstablished to incorporationDate and converts fields', () => {
-  const { data, missing } = normalizeQuestionnaire({
-    businessType: 'LLC',
+test('normalizeQuestionnaire converts types and normalizes date', () => {
+  const { data, missing, invalid } = normalizeQuestionnaire({
     businessName: 'Biz',
     phone: '555',
     email: 'a@b.com',
-    address: '1 st',
-    city: 'City',
-    state: 'ST',
-    zip: '12345',
-    locationZone: 'urban',
-    dateEstablished: '2020-01-01',
+    businessType: 'LLC',
+    dateEstablished: '01/02/2020',
     annualRevenue: '100',
     netProfit: '10',
-    employees: '2',
-    ownershipPercent: '50',
+    numberOfEmployees: '2',
+    ownershipPercentage: '50',
     previousGrants: 'yes',
-    ein: '12',
-    cpaPrepared: 'true',
-    minorityOwned: 'false',
-    womanOwned: 'true',
-    veteranOwned: 'false',
-    hasPayroll: 'true',
-    hasInsurance: 'false',
   });
-  assert.equal(data.entityType, 'LLC');
-  assert.strictEqual(data.previousGrants, true);
+  assert.equal(data.dateEstablished, '2020-02-01');
   assert.strictEqual(data.annualRevenue, 100);
-  assert.strictEqual(data.employees, 2);
-  assert.equal(data.incorporationDate, '2020-01-01');
-  assert(!('dateEstablished' in data));
+  assert.strictEqual(data.numberOfEmployees, 2);
+  assert.strictEqual(data.previousGrants, true);
   assert.equal(missing.length, 0);
+  assert.equal(invalid.length, 0);
 });
 
-test('normalizeQuestionnaire reports missing fields', () => {
+test('normalizeQuestionnaire reports missing required fields', () => {
   const { missing } = normalizeQuestionnaire({});
   assert(missing.includes('businessName'));
-  assert(missing.includes('entityType'));
-  assert(missing.includes('incorporationDate'));
+  assert(missing.includes('phone'));
+  assert(missing.includes('email'));
+  assert(missing.includes('businessType'));
+  assert(missing.includes('dateEstablished'));
 });
 
-test('normalizeQuestionnaire flags invalid numeric fields', () => {
+test('normalizeQuestionnaire flags invalid fields', () => {
   const { invalid } = normalizeQuestionnaire({
     businessName: 'Biz',
     phone: '555',
-    email: 'a@b.com',
-    address: '1 st',
-    city: 'City',
-    state: 'ST',
-    zip: '12345',
-    locationZone: 'urban',
-    entityType: 'LLC',
+    email: 'not-an-email',
+    businessType: 'Unknown',
     dateEstablished: '2020-01-01',
     annualRevenue: 'oops',
-    netProfit: '10',
-    employees: '2',
-    ownershipPercent: '50',
-    previousGrants: 'no',
-    ein: '12',
+    ownershipPercentage: '150',
   });
+  assert(invalid.includes('email'));
+  assert(invalid.includes('businessType'));
+  assert(invalid.includes('dateEstablished'));
   assert(invalid.includes('annualRevenue'));
-});
-
-test('normalizeQuestionnaire requires incorporationDate when dateEstablished missing', () => {
-  const { missing } = normalizeQuestionnaire({
-    businessName: 'Biz',
-    phone: '555',
-    email: 'a@b.com',
-    address: '1 st',
-    city: 'City',
-    state: 'ST',
-    zip: '12345',
-    locationZone: 'urban',
-    entityType: 'LLC',
-    annualRevenue: '100',
-    netProfit: '10',
-    employees: '2',
-    ownershipPercent: '50',
-    previousGrants: 'no',
-    ein: '12',
-  });
-  assert(missing.includes('incorporationDate'));
+  assert(invalid.includes('ownershipPercentage'));
 });

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -73,7 +73,7 @@ async function computeDocuments(answers = {}) {
   ];
 
   // Dynamic requirements based on answers
-  if (answers.entityType === 'Corporation' || answers.entityType === 'LLC') {
+  if (answers.businessType === 'Corporation' || answers.businessType === 'LLC') {
     docs.push({
       key: 'articles_incorporation',
       name: 'Articles of Incorporation',
@@ -90,7 +90,7 @@ async function computeDocuments(answers = {}) {
     });
   }
 
-  if (answers.employees && Number(answers.employees) > 0) {
+  if (answers.numberOfEmployees && Number(answers.numberOfEmployees) > 0) {
     docs.push({
       key: 'payroll_records',
       name: 'Payroll Records',

--- a/server/utils/validation.js
+++ b/server/utils/validation.js
@@ -1,18 +1,9 @@
-const numericFields = ['annualRevenue', 'netProfit', 'employees', 'ownershipPercent'];
-const booleanFields = ['previousGrants', 'cpaPrepared', 'minorityOwned', 'womanOwned', 'veteranOwned', 'hasPayroll', 'hasInsurance'];
+const numericFields = ['annualRevenue', 'netProfit', 'numberOfEmployees', 'ownershipPercentage'];
+const booleanFields = ['previousGrants'];
+const allowedBusinessTypes = ['Sole', 'Partnership', 'LLC', 'Corporation'];
 
 function normalizeQuestionnaire(input = {}) {
   const data = { ...input };
-
-  if (data.dateEstablished && !data.incorporationDate) {
-    data.incorporationDate = data.dateEstablished;
-    delete data.dateEstablished;
-  }
-
-  if (data.businessType && !data.entityType) {
-    data.entityType = data.businessType;
-    delete data.businessType;
-  }
 
   // convert numeric fields
   numericFields.forEach((f) => {
@@ -22,7 +13,7 @@ function normalizeQuestionnaire(input = {}) {
     }
   });
 
-  // convert booleans
+  // convert boolean-like values
   booleanFields.forEach((f) => {
     if (data[f] !== undefined && data[f] !== '') {
       const v = data[f];
@@ -36,37 +27,55 @@ function normalizeQuestionnaire(input = {}) {
     }
   });
 
-  const required = [
-    'businessName',
-    'phone',
-    'email',
-    'address',
-    'city',
-    'state',
-    'zip',
-    'locationZone',
-    'entityType',
-    'incorporationDate',
-    'annualRevenue',
-    'netProfit',
-    'employees',
-    'ownershipPercent',
-    'previousGrants',
-  ];
-
-  const missing = required.filter((f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f]));
-
-  // conditional requirements
-  if (data.entityType === 'Sole') {
-    if (!data.ssn) missing.push('ssn');
-  } else {
-    if (!data.ein) missing.push('ein');
+  // normalize dateEstablished to ISO 8601
+  let dateConverted = false;
+  if (data.dateEstablished) {
+    const m = /^([0-9]{2})\/([0-9]{2})\/([0-9]{4})$/.exec(data.dateEstablished);
+    if (m) {
+      const iso = `${m[3]}-${m[2]}-${m[1]}`;
+      const d = new Date(iso);
+      if (!isNaN(d.getTime())) {
+        data.dateEstablished = iso;
+        dateConverted = true;
+      }
+    }
   }
 
+  const required = ['businessName', 'phone', 'email', 'businessType', 'dateEstablished'];
+  const missing = required.filter(
+    (f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f])
+  );
+
   const invalid = [];
+
+  // email format
+  if (data.email && !/^\S+@\S+\.\S+$/.test(data.email)) invalid.push('email');
+
+  // dateEstablished validation
+  if (data.dateEstablished) {
+    const d = new Date(data.dateEstablished);
+    const isoRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (!dateConverted || isNaN(d.getTime()) || !isoRegex.test(data.dateEstablished)) {
+      invalid.push('dateEstablished');
+    }
+  }
+
+  // numeric validation and ranges
   numericFields.forEach((f) => {
-    if (data[f] !== undefined && !Number.isFinite(data[f])) invalid.push(f);
+    if (data[f] !== undefined) {
+      if (!Number.isFinite(data[f])) {
+        invalid.push(f);
+      } else {
+        if (f === 'ownershipPercentage' && (data[f] < 0 || data[f] > 100)) invalid.push(f);
+        if (f !== 'ownershipPercentage' && data[f] < 0) invalid.push(f);
+      }
+    }
   });
+
+  // businessType allowed values
+  if (data.businessType && !allowedBusinessTypes.includes(data.businessType)) {
+    invalid.push('businessType');
+  }
 
   console.log('normalizeQuestionnaire normalized data', data);
   return { data, missing, invalid };


### PR DESCRIPTION
## Summary
- normalize questionnaire payload using frontend field names with type conversion and format checks
- clarify error messages listing missing and invalid fields
- document and test new validation rules

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689370543aec832e9ac82985546cd31c