### PR TITLE
Normalize questionnaire fields and date formats

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -53,13 +53,17 @@ Content-Type: application/json
   "state": "NY",
   "zipCode": "10001",
   "locationZone": "urban",
-  "businessType": "LLC",
-  "dateEstablished": "01/06/2019",
+  "entityType": "LLC",
+  "dateEstablished": "2019-06-01",
   "businessEIN": "12-3456789",
   "annualRevenue": 500000,
   "netProfit": 80000,
-  "numberOfEmployees": 5,
-  "ownershipPercentage": 100,
+  "employees": 5,
+  "ownershipPercent": 100,
   "previousGrants": false
 }
 ```
+
+*The API also accepts legacy fields `businessType`, `numberOfEmployees` and
+`ownershipPercentage`. Dates may be sent in `YYYY-MM-DD` (preferred) or
+`MM/DD/YYYY` formats.*

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -61,12 +61,19 @@ export default function Questionnaire() {
       try {
         const res = await api.get('/case/questionnaire');
         const data = res.data || {};
+        const mapped = {
+          ...data,
+          entityType: data.entityType || data.businessType || '',
+          employees: data.employees || data.numberOfEmployees || '',
+          ownershipPercent:
+            data.ownershipPercent || data.ownershipPercentage || '',
+        };
         setAnswers((prev) => ({
           ...prev,
-          ...data,
+          ...mapped,
           previousGrants:
-            typeof data.previousGrants === 'boolean'
-              ? data.previousGrants
+            typeof mapped.previousGrants === 'boolean'
+              ? mapped.previousGrants
                 ? 'yes'
                 : 'no'
               : prev.previousGrants,

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
 const auth = require('../middleware/authMiddleware');
 const { getCase, computeDocuments } = require('../utils/caseStore');
-const { normalizeQuestionnaire } = require('../utils/validation');
+const { normalizeQuestionnaire, denormalizeQuestionnaire } = require('../utils/validation');
 
 const router = express.Router();
 
@@ -14,7 +14,8 @@ const router = express.Router();
 router.get('/case/questionnaire', auth, (req, res) => {
   console.log('➡️  GET /case/questionnaire', { user: req.user.id });
   const c = getCase(req.user.id, false);
-  res.json(c?.answers || {});
+  const data = c?.answers ? denormalizeQuestionnaire(c.answers) : {};
+  res.json(data);
 });
 
 router.post('/case/questionnaire', auth, async (req, res) => {

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -2,25 +2,36 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { normalizeQuestionnaire } = require('../utils/validation');
 
-test('normalizeQuestionnaire converts types and normalizes date', () => {
+test('normalizeQuestionnaire handles frontend field names and ISO dates', () => {
   const { data, missing, invalid } = normalizeQuestionnaire({
+    businessName: 'Biz',
+    phone: '555',
+    email: 'a@b.com',
+    entityType: 'LLC',
+    dateEstablished: '2020-02-01',
+    annualRevenue: '100',
+    netProfit: '10',
+    employees: '2',
+    ownershipPercent: '50',
+    previousGrants: 'yes',
+  });
+  assert.equal(data.businessType, 'LLC');
+  assert.strictEqual(data.numberOfEmployees, 2);
+  assert.strictEqual(data.ownershipPercentage, 50);
+  assert.strictEqual(data.previousGrants, true);
+  assert.equal(missing.length, 0);
+  assert.equal(invalid.length, 0);
+});
+
+test('normalizeQuestionnaire converts MM/DD/YYYY dates to ISO', () => {
+  const { data } = normalizeQuestionnaire({
     businessName: 'Biz',
     phone: '555',
     email: 'a@b.com',
     businessType: 'LLC',
     dateEstablished: '01/02/2020',
-    annualRevenue: '100',
-    netProfit: '10',
-    numberOfEmployees: '2',
-    ownershipPercentage: '50',
-    previousGrants: 'yes',
   });
-  assert.equal(data.dateEstablished, '2020-02-01');
-  assert.strictEqual(data.annualRevenue, 100);
-  assert.strictEqual(data.numberOfEmployees, 2);
-  assert.strictEqual(data.previousGrants, true);
-  assert.equal(missing.length, 0);
-  assert.equal(invalid.length, 0);
+  assert.equal(data.dateEstablished, '2020-01-02');
 });
 
 test('normalizeQuestionnaire reports missing required fields', () => {
@@ -38,7 +49,7 @@ test('normalizeQuestionnaire flags invalid fields', () => {
     phone: '555',
     email: 'not-an-email',
     businessType: 'Unknown',
-    dateEstablished: '2020-01-01',
+    dateEstablished: '2020-13-01',
     annualRevenue: 'oops',
     ownershipPercentage: '150',
   });


### PR DESCRIPTION
## Summary
- support frontend field aliases and ISO/MM-DD-YYYY date formats in questionnaire normalization
- expose denormalized questionnaire data to frontend and sync field names
- update docs, tests and frontend loader for new aliases and date handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68938f9c7a58832eb8653d5fad238173