### PR TITLE
Align questionnaire field names with backend

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -53,17 +53,15 @@ Content-Type: application/json
   "state": "NY",
   "zipCode": "10001",
   "locationZone": "urban",
-  "entityType": "LLC",
-  "dateEstablished": "2019-06-01",
+  "businessType": "LLC",
+  "incorporationDate": "2019-06-01",
   "businessEIN": "12-3456789",
   "annualRevenue": 500000,
   "netProfit": 80000,
-  "employees": 5,
-  "ownershipPercent": 100,
+  "numberOfEmployees": 5,
+  "ownershipPercentage": 100,
   "previousGrants": false
 }
 ```
 
-*The API also accepts legacy fields `businessType`, `numberOfEmployees` and
-`ownershipPercentage`. Dates may be sent in `YYYY-MM-DD` (preferred) or
-`MM/DD/YYYY` formats.*
+*The API also accepts legacy fields `entityType`, `employees`, `ownershipPercent` and `dateEstablished`. Dates may be sent in `YYYY-MM-DD` (preferred) or `MM/DD/YYYY` formats.*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
 | zipCode | string | no | |
 | locationZone | string | no | e.g. `urban` |
 | businessType | string | yes | allowed: `Sole`, `Partnership`, `LLC`, `Corporation` |
-| dateEstablished | string (date) | yes | format `dd/MM/YYYY` |
+| incorporationDate | string (date) | yes | format `dd/MM/YYYY` |
 | businessEIN | string | no | |
 | annualRevenue | number | no | |
 | netProfit | number | no | |

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -38,15 +38,14 @@ export default function Questionnaire() {
     state: '',
     zip: '',
     locationZone: '',
-    entityType: '',
+    businessType: '',
     ein: '',
     ssn: '',
     incorporationDate: '',
-    dateEstablished: '',
     annualRevenue: '',
     netProfit: '',
-    employees: '',
-    ownershipPercent: '',
+    numberOfEmployees: '',
+    ownershipPercentage: '',
     previousGrants: '',
     cpaPrepared: false,
     minorityOwned: false,
@@ -63,10 +62,11 @@ export default function Questionnaire() {
         const data = res.data || {};
         const mapped = {
           ...data,
-          entityType: data.entityType || data.businessType || '',
-          employees: data.employees || data.numberOfEmployees || '',
-          ownershipPercent:
-            data.ownershipPercent || data.ownershipPercentage || '',
+          businessType: data.businessType || data.entityType || '',
+          numberOfEmployees: data.numberOfEmployees || data.employees || '',
+          ownershipPercentage:
+            data.ownershipPercentage || data.ownershipPercent || '',
+          incorporationDate: data.incorporationDate || data.dateEstablished || '',
         };
         setAnswers((prev) => ({
           ...prev,
@@ -112,11 +112,12 @@ export default function Questionnaire() {
         ...answers,
         annualRevenue: Number(answers.annualRevenue),
         netProfit: Number(answers.netProfit),
-        employees: Number(answers.employees),
-        ownershipPercent: Number(answers.ownershipPercent),
+        numberOfEmployees: Number(answers.numberOfEmployees),
+        ownershipPercentage: Number(answers.ownershipPercentage),
         previousGrants: answers.previousGrants === 'yes',
       };
       await api.post('/case/questionnaire', payload);
+      console.log('Questionnaire submitted successfully', payload);
       localStorage.setItem('caseStage', 'documents');
       router.push('/dashboard/documents');
     } catch (err: any) {
@@ -208,9 +209,9 @@ export default function Questionnaire() {
             <label className="block mb-2 font-medium">Business Type</label>
             <select
               className="w-full border rounded p-2 mb-1"
-              value={answers.entityType}
+              value={answers.businessType}
               onChange={(e) => {
-                setAnswers({ ...answers, entityType: e.target.value });
+                setAnswers({ ...answers, businessType: e.target.value });
               }}
             >
               <option value="">Select</option>
@@ -219,25 +220,15 @@ export default function Questionnaire() {
               <option value="LLC">LLC</option>
               <option value="Corporation">Corporation</option>
             </select>
-              {(answers.entityType === 'Corporation' || answers.entityType === 'LLC') && (
-                <FormInput
-                  label="Incorporation Date"
-                  type="date"
-                  value={answers.incorporationDate}
-                  onChange={(e) => {
-                    setAnswers({ ...answers, incorporationDate: e.target.value });
-                  }}
-                />
-              )}
-              <FormInput
-                label="Date Established"
-                type="date"
-                value={answers.dateEstablished}
-                onChange={(e) => {
-                  setAnswers({ ...answers, dateEstablished: e.target.value });
-                }}
-              />
-              {answers.entityType === 'Sole' ? (
+            <FormInput
+              label="Incorporation Date"
+              type="date"
+              value={answers.incorporationDate}
+              onChange={(e) => {
+                setAnswers({ ...answers, incorporationDate: e.target.value });
+              }}
+            />
+            {answers.businessType === 'Sole' ? (
                 <FormInput
                   label="Owner SSN"
                   value={answers.ssn}
@@ -277,17 +268,17 @@ export default function Questionnaire() {
             <FormInput
               label="Number of Employees"
               type="number"
-              value={answers.employees}
+              value={answers.numberOfEmployees}
               onChange={(e) => {
-                setAnswers({ ...answers, employees: e.target.value });
+                setAnswers({ ...answers, numberOfEmployees: e.target.value });
               }}
             />
             <FormInput
               label="Ownership Percentage"
               type="number"
-              value={answers.ownershipPercent}
+              value={answers.ownershipPercentage}
               onChange={(e) => {
-                setAnswers({ ...answers, ownershipPercent: e.target.value });
+                setAnswers({ ...answers, ownershipPercentage: e.target.value });
               }}
             />
             <label className="block mb-2 font-medium">Previous Grants</label>

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,12 +1,24 @@
-export const numericFields = ['annualRevenue', 'netProfit', 'employees', 'ownershipPercent'];
+export const numericFields = ['annualRevenue', 'netProfit', 'numberOfEmployees', 'ownershipPercentage'];
 export const booleanFields = ['previousGrants', 'cpaPrepared', 'minorityOwned', 'womanOwned', 'veteranOwned', 'hasPayroll', 'hasInsurance'];
 
 export function normalizeQuestionnaire(input: any = {}) {
   const data: any = { ...input };
 
-  if (data.businessType && !data.entityType) {
-    data.entityType = data.businessType;
-    delete data.businessType;
+  if (data.entityType && !data.businessType) {
+    data.businessType = data.entityType;
+    delete data.entityType;
+  }
+  if (data.employees && !data.numberOfEmployees) {
+    data.numberOfEmployees = data.employees;
+    delete data.employees;
+  }
+  if (data.ownershipPercent && !data.ownershipPercentage) {
+    data.ownershipPercentage = data.ownershipPercent;
+    delete data.ownershipPercent;
+  }
+  if (data.dateEstablished && !data.incorporationDate) {
+    data.incorporationDate = data.dateEstablished;
+    delete data.dateEstablished;
   }
 
   numericFields.forEach((f) => {
@@ -38,22 +50,21 @@ export function normalizeQuestionnaire(input: any = {}) {
     'state',
     'zip',
     'locationZone',
-    'entityType',
-    'dateEstablished',
+    'businessType',
+    'incorporationDate',
     'annualRevenue',
     'netProfit',
-    'employees',
-    'ownershipPercent',
+    'numberOfEmployees',
+    'ownershipPercentage',
     'previousGrants',
   ];
 
   const missing = required.filter((f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f]));
 
-  if (data.entityType === 'Sole') {
+  if (data.businessType === 'Sole') {
     if (!data.ssn) missing.push('ssn');
   } else {
     if (!data.ein) missing.push('ein');
-    if (!data.incorporationDate) missing.push('incorporationDate');
   }
 
   const invalid: string[] = [];

--- a/server/tests/validation.test.js
+++ b/server/tests/validation.test.js
@@ -16,6 +16,7 @@ test('normalizeQuestionnaire handles frontend field names and ISO dates', () => 
     previousGrants: 'yes',
   });
   assert.equal(data.businessType, 'LLC');
+  assert.equal(data.incorporationDate, '2020-02-01');
   assert.strictEqual(data.numberOfEmployees, 2);
   assert.strictEqual(data.ownershipPercentage, 50);
   assert.strictEqual(data.previousGrants, true);
@@ -29,9 +30,9 @@ test('normalizeQuestionnaire converts MM/DD/YYYY dates to ISO', () => {
     phone: '555',
     email: 'a@b.com',
     businessType: 'LLC',
-    dateEstablished: '01/02/2020',
+    incorporationDate: '01/02/2020',
   });
-  assert.equal(data.dateEstablished, '2020-01-02');
+  assert.equal(data.incorporationDate, '2020-01-02');
 });
 
 test('normalizeQuestionnaire reports missing required fields', () => {
@@ -40,7 +41,7 @@ test('normalizeQuestionnaire reports missing required fields', () => {
   assert(missing.includes('phone'));
   assert(missing.includes('email'));
   assert(missing.includes('businessType'));
-  assert(missing.includes('dateEstablished'));
+  assert(missing.includes('incorporationDate'));
 });
 
 test('normalizeQuestionnaire flags invalid fields', () => {
@@ -49,13 +50,13 @@ test('normalizeQuestionnaire flags invalid fields', () => {
     phone: '555',
     email: 'not-an-email',
     businessType: 'Unknown',
-    dateEstablished: '2020-13-01',
+    incorporationDate: '2020-13-01',
     annualRevenue: 'oops',
     ownershipPercentage: '150',
   });
   assert(invalid.includes('email'));
   assert(invalid.includes('businessType'));
-  assert(invalid.includes('dateEstablished'));
+  assert(invalid.includes('incorporationDate'));
   assert(invalid.includes('annualRevenue'));
   assert(invalid.includes('ownershipPercentage'));
 });

--- a/server/utils/validation.js
+++ b/server/utils/validation.js
@@ -7,13 +7,14 @@ const fieldMap = {
   entityType: 'businessType',
   employees: 'numberOfEmployees',
   ownershipPercent: 'ownershipPercentage',
+  dateEstablished: 'incorporationDate',
 };
 
 const reverseFieldMap = Object.fromEntries(
   Object.entries(fieldMap).map(([k, v]) => [v, k]),
 );
 
-const dateFields = ['dateEstablished', 'incorporationDate'];
+const dateFields = ['incorporationDate'];
 
 function normalizeQuestionnaire(input = {}) {
   const data = { ...input };
@@ -66,7 +67,7 @@ function normalizeQuestionnaire(input = {}) {
     }
   });
 
-  const required = ['businessName', 'phone', 'email', 'businessType', 'dateEstablished'];
+  const required = ['businessName', 'phone', 'email', 'businessType', 'incorporationDate'];
   const missing = required.filter(
     (f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f])
   );


### PR DESCRIPTION
## Summary
- Update questionnaire state and form to use backend field names (businessType, incorporationDate, numberOfEmployees, ownershipPercentage)
- Normalize and validate using new names while mapping legacy fields
- Refresh backend validation/tests and docs for updated field names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test server/tests/validation.test.js`
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893940d5310832eadb303198b41b861