### PR TITLE
Refactor microservice pipeline for analyzer and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The document upload flow accepts **PDF**, **JPG/JPEG**, and **PNG** files.
 
 The backend exposes a unified flow that processes grant applications end‑to‑end:
 
-1. **POST `/api/submit-case`** – Frontend sends raw user data and uploaded documents. The server forwards everything to the AI Agent (`AI_AGENT_URL/analyze`) for extraction and normalization.
-2. **AI Agent → Eligibility Engine** – Normalized data is submitted to the Eligibility Engine (`ELIGIBILITY_ENGINE_URL/check`) for rule-based eligibility checks.
-3. **Eligibility → Form Filler** – The results and required form names are passed to the Form Filler (`FORM_FILLER_URL/fill-forms`) which returns filled PDFs ready for signature.
+1. **POST `/api/submit-case`** – Frontend sends raw user data and uploaded documents. The server forwards data to the AI Analyzer (`AI_ANALYZER_URL/analyze`) to extract and normalize fields.
+2. **AI Analyzer → Eligibility Engine** – Normalized data is submitted to the Eligibility Engine (`ELIGIBILITY_ENGINE_URL/check`) for rule-based eligibility checks.
+3. **Eligibility → AI Agent** – Eligibility results and normalized data are passed to the AI Agent (`AI_AGENT_URL/form-fill`) which generates filled PDFs and summaries.
 4. **Digital signature & submission** – Hooks exist after form filling for optional signing and external submission.
 5. **GET `/api/status/:caseId`** – Fetch case status, eligibility results and generated documents for the applicant dashboard.
 
@@ -33,9 +33,9 @@ All service calls exchange JSON payloads, are logged, and bubble up descriptive 
 Environment variables configuring service locations:
 
 ```
-AI_AGENT_URL=http://ai-agent:5001
+AI_ANALYZER_URL=http://ai-analyzer:8000
 ELIGIBILITY_ENGINE_URL=http://eligibility-engine:4001
-FORM_FILLER_URL=http://ai-agent:5001
+AI_AGENT_URL=http://ai-agent:5001
 ```
 
 ### Case Management API
@@ -108,10 +108,10 @@ curl -X POST http://localhost:5001/check -H "Content-Type: application/json" \
     -d '{"notes": "We started around 2021 and are women-led in biotech"}'
 ```
 
-To fill a grant application form, send JSON directly to `/fill-forms`:
+To fill a grant application form, send JSON directly to `/form-fill`:
 
 ```bash
-curl -X POST http://localhost:5001/fill-forms \
+curl -X POST http://localhost:5001/form-fill \
     -H "Content-Type: application/json" \
     -d '{
         "form_name": "sba_microloan_form",
@@ -137,7 +137,7 @@ npm run dev
 ```
 
 Environment variables should be placed in a `.env.local` file. See `.env.local.example` for the API base URL.
-The backend uses `AI_AGENT_URL`, `ELIGIBILITY_ENGINE_URL` and `FORM_FILLER_URL` to locate the downstream services.
+The backend uses `AI_ANALYZER_URL`, `ELIGIBILITY_ENGINE_URL` and `AI_AGENT_URL` to locate the downstream services.
 
 ### Testing file uploads
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,13 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/grants
       - JWT_SECRET=devsecret
-      - AI_AGENT_URL=http://ai-agent:5001
+      - AI_ANALYZER_URL=http://ai-analyzer:8000
       - ELIGIBILITY_ENGINE_URL=http://eligibility-engine:4001
-      - FORM_FILLER_URL=http://ai-agent:5001
-      depends_on:
-        - mongo
-        - ai-agent
+      - AI_AGENT_URL=http://ai-agent:5001
+    depends_on:
+      - mongo
+      - ai-agent
+      - ai-analyzer
 
   eligibility-engine:
     build: ./eligibility-engine
@@ -33,6 +34,11 @@ services:
       - '5001:5001'
     depends_on:
       - eligibility-engine
+
+  ai-analyzer:
+    build: ./ai-analyzer
+    ports:
+      - '8000:8000'
 
   frontend:
     build: ./frontend

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -40,22 +40,33 @@ router.post('/submit-case', auth, upload.any(), async (req, res) => {
 
   const caseId = createCase(req.user.id);
   try {
-    // ---- AI Agent step ----
-    const form = new FormData();
-    form.append('payload', JSON.stringify(req.body));
-    req.files.forEach((file) => form.append('files', file.buffer, file.originalname));
-    const aiBase = process.env.AI_AGENT_URL || 'http://localhost:5001';
-    const aiUrl = `${aiBase.replace(/\/$/, '')}/analyze`;
-    console.log(`→ POST ${aiUrl}`);
-    const aiResp = await fetch(aiUrl, { method: 'POST', body: form, headers: form.getHeaders() });
-    if (!aiResp.ok) {
-      const text = await aiResp.text();
-      console.error('AI agent error', aiResp.status, text);
-      updateCase(caseId, { status: 'error', error: text });
-      return res.status(502).json({ message: `AI agent error ${aiResp.status}`, details: text });
+    // ---- AI Analyzer step ----
+    const analyzerBase = process.env.AI_ANALYZER_URL || 'http://localhost:8000';
+    const analyzerUrl = `${analyzerBase.replace(/\/$/, '')}/analyze`;
+    let extracted = {};
+    for (const file of req.files) {
+      const form = new FormData();
+      form.append('file', file.buffer, file.originalname);
+      console.log(`→ POST ${analyzerUrl}`, { file: file.originalname });
+      const resp = await fetch(analyzerUrl, {
+        method: 'POST',
+        body: form,
+        headers: form.getHeaders(),
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        console.error('AI analyzer error', resp.status, text);
+        updateCase(caseId, { status: 'error', error: text });
+        return res
+          .status(502)
+          .json({ message: `AI analyzer error ${resp.status}`, details: text });
+      }
+      const fields = await resp.json();
+      console.log('← AI analyzer response', fields);
+      extracted = { ...extracted, ...fields };
     }
-    const normalized = await aiResp.json();
-    console.log('← AI agent response', normalized);
+    const normalized = { ...req.body, ...extracted };
+    console.log('Normalized data', normalized);
     updateCase(caseId, { status: 'analyzed', normalized });
 
     // ---- Eligibility Engine ----
@@ -77,23 +88,29 @@ router.post('/submit-case', auth, upload.any(), async (req, res) => {
     console.log('← Eligibility engine response', eligibility);
     updateCase(caseId, { status: 'checked', eligibility });
 
-    // ---- Form Filler ----
-    const fillerBase = process.env.FORM_FILLER_URL || 'http://localhost:5002';
-    const fillerUrl = `${fillerBase.replace(/\/$/, '')}/fill-forms`;
-    console.log(`→ POST ${fillerUrl}`);
-    const fillerResp = await fetch(fillerUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data: normalized, forms: eligibility.requiredForms || [] }),
-    });
-    if (!fillerResp.ok) {
-      const text = await fillerResp.text();
-      console.error('Form filler error', fillerResp.status, text);
-      updateCase(caseId, { status: 'error', error: text });
-      return res.status(502).json({ message: `Form filler error ${fillerResp.status}`, details: text });
+    // ---- AI Agent form filling ----
+    const agentBase = process.env.AI_AGENT_URL || 'http://localhost:5001';
+    const agentUrl = `${agentBase.replace(/\/$/, '')}/form-fill`;
+    const filled = {};
+    for (const formName of eligibility.requiredForms || []) {
+      console.log(`→ POST ${agentUrl}`, { form: formName });
+      const agentResp = await fetch(agentUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ form_name: formName, user_payload: normalized }),
+      });
+      if (!agentResp.ok) {
+        const text = await agentResp.text();
+        console.error('AI agent form-fill error', agentResp.status, text);
+        updateCase(caseId, { status: 'error', error: text });
+        return res
+          .status(502)
+          .json({ message: `AI agent form-fill error ${agentResp.status}`, details: text });
+      }
+      const agentData = await agentResp.json();
+      console.log('← AI agent response', agentData);
+      filled[formName] = agentData.filled_form || agentData;
     }
-    const filled = await fillerResp.json();
-    console.log('← Form filler response', filled);
     updateCase(caseId, { status: 'forms_filled', documents: filled });
 
     // ---- Placeholder: digital signature & submission hooks ----


### PR DESCRIPTION
## Summary
- call new AI Analyzer service before eligibility checks
- send eligibility results to AI Agent for form filling
- document updated service flow and environment variables

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939f09fd84832eb4e4e5577f40f61f