### PR TITLE
fix: remove deprecated Pydantic Body embed usage

### DIFF
--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -15,9 +15,9 @@ uvicorn main:app --reload
 - `POST /check` – submit user data, notes or an uploaded document. Free-form
   text is semantically parsed and merged with the eligibility engine. Results
   include `llm_summary`, `clarifying_questions` and richer `reasoning_steps`.
-- `POST /form-fill` – submit `form_name` and `user_payload` as JSON to receive a
-  filled form from `form_templates/`. Conditional and computed fields will be
-  evaluated.
+- `POST /form-fill` – submit `form_name` and `user_payload` as JSON (top-level,
+  no embedded wrapper) to receive a filled form from `form_templates/`.
+  Conditional and computed fields will be evaluated.
 - `POST /chat` – simple conversational endpoint that stores context in
   `session_id` records.
 

--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -111,7 +111,9 @@ async def check(
 @app.post("/form-fill")
 async def form_fill(
     request_model: FormFillRequest = Body(
-        ..., embed=False,
+        ...,
+        # Pydantic v2 removed the ``embed`` parameter so we rely on the default
+        # behavior which expects the JSON fields at the top level.
         example={"form_name": "tech_startup_credit_form", "user_payload": {"zip": "94110"}}
     )
 ):

--- a/ai-agent/test_agent_check.py
+++ b/ai-agent/test_agent_check.py
@@ -158,3 +158,10 @@ def test_form_fill_invalid_payload():
     """Invalid payloads should raise validation errors."""
     with pytest.raises(ValidationError):
         asyncio.run(form_fill({"user_payload": {"foo": "bar"}}))
+
+
+def test_form_fill_rejects_embedded_payload():
+    """Legacy embedded bodies should not be accepted after Pydantic v2 upgrade."""
+    payload = {"request_model": {"form_name": "sba_microloan_form", "user_payload": {}}}
+    with pytest.raises(ValidationError):
+        asyncio.run(form_fill(payload))


### PR DESCRIPTION
## Summary
- drop unsupported `embed` flag from `/form-fill` body
- clarify top-level JSON structure in README
- test rejection of legacy embedded request payload

## Testing
- `pytest -q` *(fails: No module named 'pydantic')*
- `pip install pydantic==2.5.2` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6893c8ee0c64832ea2b73f77880995e2