### PR TITLE
feat: expand california small business grant programs

### DIFF
--- a/POSTMAN_EXAMPLES.md
+++ b/POSTMAN_EXAMPLES.md
@@ -210,6 +210,48 @@ Sample response:
 }
 ```
 
+## California Small Business Grant (2025) Example
+```http
+POST http://localhost:4001/check
+Content-Type: application/json
+
+{
+  "business_location_state": "CA",
+  "number_of_employees": 4,
+  "annual_revenue": 500000,
+  "registration_year": 2021,
+  "owner_state": "CA",
+  "sbtaep_training_complete": true,
+  "certified_center_approval": true,
+  "net_income": 100000,
+  "business_age_years": 2,
+  "us_content_percent": 0,
+  "sba_standard_compliant": false,
+  "city": "Los Angeles",
+  "women_owned": false,
+  "technical_assistance_complete": false,
+  "route_66_location": false,
+  "industry": "technology",
+  "project_type": "other",
+  "ust_owner_operator": false,
+  "annual_fuel_sales_gallons": 0,
+  "health_safety_compliant": false,
+  "chamber_nomination": false,
+  "county": "Other",
+  "low_income_community": false,
+  "disaster_affected": false
+}
+```
+
+Sample response:
+```json
+{
+  "name": "California Small Business Grant (2025)",
+  "eligible": true,
+  "estimated_amount": 10000
+}
+```
+
 ## Employee Retention Credit Example
 ```http
 POST http://localhost:4001/check

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains three microservices used to test a grant eligibility wo
 - **eligibility-engine/** – Python rules engine returning missing fields and suggested next steps
 - **ai-agent/** – LLM-ready service with conversational endpoints and smart form filling
 
-The eligibility engine now ships with templates for common programs including a Business Tax Refund Grant, a Veteran Owned Business Grant, the Employee Retention Credit (ERC), a comprehensive Rural Development Grant covering USDA sub-programs, a Green Energy State Incentive aggregating state-level rebates, credits and grants for renewable installations, and an Urban Small Business Grants (2025) package spanning nine city programs.
+The eligibility engine now ships with templates for common programs including a Business Tax Refund Grant, a Veteran Owned Business Grant, the Employee Retention Credit (ERC), a comprehensive Rural Development Grant covering USDA sub-programs, a Green Energy State Incentive aggregating state-level rebates, credits and grants for renewable installations, an Urban Small Business Grants (2025) package spanning nine city programs, and a California Small Business Grant (2025) bundling the Dream Fund, STEP export vouchers, San Francisco Women’s Entrepreneurship Fund, Route 66 Extraordinary Women Micro-Grant, CDFA grants, RUST assistance, CalChamber awards and the LA Region Small Business Relief Fund.
 
 ```
 project-root/

--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -2,7 +2,7 @@
 
 This package contains a lightweight rules engine used to determine business eligibility for a variety of grant and credit programs. Grants are defined as JSON files under `grants/` so new programs can be added without touching the code.
 
-Included templates now cover federal and local programs like the **Business Tax Refund Grant**, the **Women-Owned Tech Grant**, the **Minority Female Founder Grant**, the **Employee Retention Credit (ERC)**, the **Rural Development Grant** with multiple USDA sub-programs, the **Green Energy State Incentive** spanning state-level rebates, tax credits, and direct grants for renewable projects, and the **Urban Small Business Grants (2025)** combining nine city recovery programs.
+Included templates now cover federal and local programs like the **Business Tax Refund Grant**, the **Women-Owned Tech Grant**, the **Minority Female Founder Grant**, the **Employee Retention Credit (ERC)**, the **Rural Development Grant** with multiple USDA sub-programs, the **Green Energy State Incentive** spanning state-level rebates, tax credits, and direct grants for renewable projects, the **Urban Small Business Grants (2025)** combining nine city recovery programs, and the **California Small Business Grant (2025)** bundling statewide initiatives such as the Dream Fund and STEP vouchers.
 
 ## Tech Startup Payroll Credit
 
@@ -11,6 +11,10 @@ The Tech Startup Payroll Credit allows qualified small businesses to apply a por
 ## Urban Small Business Grants (2025)
 
 This composite configuration bundles nine city programs such as the Chicago Microbusiness Recovery Grant and Rockford RE-GROW Grant. Businesses must operate within city limits, show COVID‑19 or structural damage impacts, meet local employee and revenue caps, and provide tax returns, W‑9s, business licenses, bank statements and recovery plans. Estimated awards range from $5k to $25k depending on the city program.
+
+## California Small Business Grant (2025)
+
+This definition aggregates eight statewide initiatives including the California Dream Fund, STEP export vouchers, San Francisco Women’s Entrepreneurship Fund, Route 66 Extraordinary Women Micro‑Grant, California Department of Food and Agriculture grants, RUST underground storage tank assistance, CalChamber Small Business Awards and the LA Region Small Business Relief Fund. Programs target California businesses meeting specific size, revenue, location and training criteria with awards from $2k microgrants up to $100k for agricultural projects.
 
 ## Running the Engine
 

--- a/eligibility-engine/grants/california_smallbiz.json
+++ b/eligibility-engine/grants/california_smallbiz.json
@@ -1,31 +1,141 @@
 {
-  "name": "California Small Business Grant",
+  "name": "California Small Business Grant (2025)",
   "year": 2025,
-  "description": "State grant for California-based small businesses",
+  "description": "Collection of California state and regional programs supporting small businesses.",
+  "general_eligibility": "Applicants must be California-based small businesses meeting program-specific size, revenue and training requirements and submit W-9, business license, proof of income and an action plan where applicable.",
   "required_fields": [
-    "state",
-    "employees"
+    "business_location_state",
+    "number_of_employees",
+    "annual_revenue",
+    "registration_year",
+    "owner_state",
+    "sbtaep_training_complete",
+    "certified_center_approval",
+    "net_income",
+    "business_age_years",
+    "us_content_percent",
+    "sba_standard_compliant",
+    "city",
+    "women_owned",
+    "technical_assistance_complete",
+    "route_66_location",
+    "industry",
+    "project_type",
+    "ust_owner_operator",
+    "annual_fuel_sales_gallons",
+    "health_safety_compliant",
+    "chamber_nomination",
+    "county",
+    "low_income_community",
+    "disaster_affected"
   ],
-  "eligibility_rules": {
-    "state": [
-      "CA"
-    ],
-    "employees_min": 1,
-    "employees_max": 100
+  "eligibility_categories": {
+    "__mode__": "any",
+    "california_dream_fund": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "number_of_employees_max": 5,
+        "annual_revenue_max": 1000000,
+        "registration_year_min": 2019,
+        "owner_state": ["CA"],
+        "sbtaep_training_complete": true,
+        "certified_center_approval": true
+      },
+      "estimated_award": {"type": "base", "base": 10000},
+      "required_forms": ["W-9", "business_license", "proof_of_income", "action_plan"]
+    },
+    "california_step": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "net_income_min": 1,
+        "business_age_years_min": 1,
+        "us_content_percent_min": 51,
+        "sba_standard_compliant": true
+      },
+      "estimated_award": {"type": "base", "base": 10000},
+      "required_forms": ["W-9", "business_license", "proof_of_income", "action_plan"]
+    },
+    "san_francisco_womens_entrepreneurship_fund": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "city": ["San Francisco"],
+        "women_owned": true,
+        "annual_revenue_max": 500000,
+        "net_income_max": 27500,
+        "technical_assistance_complete": true
+      },
+      "estimated_award": {"type": "base", "base": 5000},
+      "required_forms": ["W-9", "business_license", "proof_of_income", "action_plan"]
+    },
+    "route_66_extraordinary_women": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "route_66_location": true,
+        "women_owned": true,
+        "number_of_employees_max": 19
+      },
+      "estimated_award": {"type": "base", "base": 2000},
+      "required_forms": ["W-9", "business_license", "proof_of_income"]
+    },
+    "cdfa_grants": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "industry": ["agriculture", "farm"],
+        "project_type": ["healthy_soils", "infrastructure"]
+      },
+      "estimated_award": {"type": "base", "base": 100000},
+      "required_forms": ["W-9", "business_license", "action_plan"]
+    },
+    "rust_grants": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "ust_owner_operator": true,
+        "number_of_employees_max": 20,
+        "annual_fuel_sales_gallons_max": 1500000,
+        "health_safety_compliant": true
+      },
+      "estimated_award": {"type": "base", "base": 70000},
+      "required_forms": ["W-9", "business_license", "proof_of_income"]
+    },
+    "calchamber_small_business_awards": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "chamber_nomination": true
+      },
+      "estimated_award": {"type": "base", "base": 5000},
+      "required_forms": ["W-9", "business_license"]
+    },
+    "la_region_small_business_relief": {
+      "rules": {
+        "business_location_state": ["CA"],
+        "county": ["Los Angeles"],
+        "annual_revenue_max": 6000000,
+        "number_of_employees_max": 99,
+        "low_income_community": true,
+        "disaster_affected": true
+      },
+      "estimated_award": {"type": "base", "base": 25000},
+      "required_forms": ["W-9", "business_license", "proof_of_income", "action_plan"]
+    }
   },
-  "estimated_award": {
-    "type": "base",
-    "base": 10000
-  },
-  "tags": [
-    "state",
-    "california"
-  ],
+  "tags": ["state", "california", "small_business"],
   "ui_questions": [
-    "Which state is your business located in?",
-    "How many employees do you have?"
+    "In which state is your business located?",
+    "How many employees does your business have?",
+    "What is your annual revenue?",
+    "What year was your business registered?",
+    "Are the owners California residents?",
+    "Have you completed SB TAEP training and received approval from a certified center?",
+    "Is your business profitable and at least one year old?",
+    "What percentage of your product content is from the United States?",
+    "Is your business women-owned?",
+    "Where in California is your business located (city, county, Route 66)?",
+    "Does your project involve agriculture or infrastructure improvements?",
+    "Do you own or operate underground storage tanks and meet health and safety standards?",
+    "Have you been nominated by a Chamber of Commerce?",
+    "Is your business in Los Angeles County and affected by disasters or located in a low-income community?"
   ],
-  "complexity_level": "medium",
-  "human_summary": "State grant for California-based small businesses",
+  "complexity_level": "high",
+  "human_summary": "2025 California programs including Dream Fund, STEP, SF Women's Fund, Route 66 Micro-Grant, CDFA grants, RUST, CalChamber awards and LA Region relief.",
   "risk_notes": ""
 }

--- a/eligibility-engine/test_california_small_business_grant.py
+++ b/eligibility-engine/test_california_small_business_grant.py
@@ -1,0 +1,86 @@
+from engine import analyze_eligibility
+
+
+def get_grant(results):
+    return next(r for r in results if r["name"] == "California Small Business Grant (2025)")
+
+
+def base_payload():
+    return {
+        "business_location_state": "CA",
+        "number_of_employees": 50,
+        "annual_revenue": 2000000,
+        "registration_year": 2010,
+        "owner_state": "NV",
+        "sbtaep_training_complete": False,
+        "certified_center_approval": False,
+        "net_income": 0,
+        "business_age_years": 0,
+        "us_content_percent": 0,
+        "sba_standard_compliant": False,
+        "city": "Los Angeles",
+        "women_owned": False,
+        "technical_assistance_complete": False,
+        "route_66_location": False,
+        "industry": "retail",
+        "project_type": "other",
+        "ust_owner_operator": False,
+        "annual_fuel_sales_gallons": 0,
+        "health_safety_compliant": False,
+        "chamber_nomination": False,
+        "county": "Other",
+        "low_income_community": False,
+        "disaster_affected": False,
+    }
+
+
+def test_dream_fund_eligible():
+    payload = base_payload()
+    payload.update(
+        {
+            "number_of_employees": 4,
+            "annual_revenue": 500000,
+            "registration_year": 2021,
+            "owner_state": "CA",
+            "sbtaep_training_complete": True,
+            "certified_center_approval": True,
+        }
+    )
+    results = analyze_eligibility(payload, explain=True)
+    grant = get_grant(results)
+    assert grant["eligible"] is True
+    assert grant["estimated_amount"] == 10000
+    assert grant["debug"].get("selected_group") == "california_dream_fund"
+
+
+def test_step_eligible():
+    payload = base_payload()
+    payload.update(
+        {
+            "net_income": 25000,
+            "business_age_years": 2,
+            "us_content_percent": 80,
+            "sba_standard_compliant": True,
+        }
+    )
+    results = analyze_eligibility(payload, explain=True)
+    grant = get_grant(results)
+    assert grant["eligible"] is True
+    assert grant["debug"].get("selected_group") == "california_step"
+
+
+def test_dream_fund_ineligible_employee_count():
+    payload = base_payload()
+    payload.update(
+        {
+            "number_of_employees": 10,
+            "annual_revenue": 500000,
+            "registration_year": 2021,
+            "owner_state": "CA",
+            "sbtaep_training_complete": True,
+            "certified_center_approval": True,
+        }
+    )
+    results = analyze_eligibility(payload, explain=True)
+    grant = get_grant(results)
+    assert grant["eligible"] is False

--- a/eligibility-engine/test_payload_partial.json
+++ b/eligibility-engine/test_payload_partial.json
@@ -14,5 +14,11 @@
   "city": "Boston",
   "owner_minority": true,
   "rural_area": true,
-  "tags": ["technology"]
+  "tags": ["technology"],
+  "business_income": 15000,
+  "business_expenses": 12000,
+  "tax_paid": 500,
+  "business_type": "LLC",
+  "tax_year": 2023,
+  "previous_refunds_claimed": false
 }

--- a/eligibility-engine/test_sample.py
+++ b/eligibility-engine/test_sample.py
@@ -19,6 +19,12 @@ def test_engine():
         "owner_minority": True,
         "rural_area": False,
         "tags": ["technology", "startup"],
+        "business_income": 150000,
+        "business_expenses": 100000,
+        "tax_paid": 20000,
+        "business_type": "LLC",
+        "tax_year": 2024,
+        "previous_refunds_claimed": False,
     }
     results = analyze_eligibility(user, explain=True)
     # at least one grant should be fully eligible


### PR DESCRIPTION
## Summary
- replace California Small Business Grant with 2025 programs including Dream Fund, STEP, SF Women's Fund, Route 66 micro-grant, CDFA, RUST, CalChamber awards and LA Region relief
- document new state grant and provide Postman example
- add tests for Dream Fund and STEP eligibility scenarios

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bad063c8832e9da7e7eb4bbb4df6