### PR TITLE
Add Form 424A template and require for Rural Development Grant

### DIFF
--- a/ai-agent/form_templates/form_424A.json
+++ b/ai-agent/form_templates/form_424A.json
@@ -1,0 +1,132 @@
+{
+  "form": "Standard Form 424A",
+  "fields": {
+    "Budget Information": {
+      "OMB Number": "4040-0006",
+      "Expiration Date": "06/30/2028",
+      "Section": "A",
+      "Grant Program": {
+        "Assistance Listing": "Estimated Unobligated Funds",
+        "New or Revised Budget": {
+          "Function or Activity Number": {
+            "Federal": {
+              "Non-Federal": {
+                "Total": {
+                  "a": "$",
+                  "b": "$",
+                  "c": "$",
+                  "d": "$",
+                  "e": "$",
+                  "f": "$",
+                  "g": "$"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Standard Form": "424A (Rev. 7-97)",
+      "Prescribed by": "OMB (Circular A-102)",
+      "Page": "1"
+    }
+  },
+  "sections": [
+    {
+      "section": "Section B - Budget Categories",
+      "fields": [
+        {
+          "label": "6. Object Class Categories",
+          "items": [
+            {"code": "a", "name": "Personnel", "amount": null},
+            {"code": "b", "name": "Fringe Benefits", "amount": null},
+            {"code": "c", "name": "Travel", "amount": null},
+            {"code": "d", "name": "Equipment", "amount": null},
+            {"code": "e", "name": "Supplies", "amount": null},
+            {"code": "f", "name": "Contractual", "amount": null},
+            {"code": "g", "name": "Construction", "amount": null},
+            {"code": "h", "name": "Other", "amount": null},
+            {"code": "i", "name": "Total Direct Charges (sum of 6a-6h)", "amount": null},
+            {"code": "j", "name": "Indirect Charges", "amount": null},
+            {"code": "k", "name": "TOTALS (sum of 6i and 6j)", "amount": null}
+          ]
+        },
+        {
+          "label": "7. Program Income",
+          "amount": null
+        }
+      ],
+      "metadata": {
+        "form": "Standard Form 424A",
+        "revision_date": "7-97",
+        "prescribed_by": "OMB Circular A-102",
+        "page": "1A",
+        "note": "Authorized for Local Reproduction"
+      }
+    },
+    {
+      "section": "Section C - Non-Federal Resources",
+      "fields": [
+        {"label": "Grant Program (a)", "amount": null},
+        {"label": "Applicant (b)", "amount": null},
+        {"label": "State (c)", "amount": null},
+        {"label": "Other Sources (d)", "amount": null},
+        {"label": "TOTALS (e)", "amount": null}
+      ],
+      "totals": [
+        {"label": "8", "amount": null},
+        {"label": "9", "amount": null},
+        {"label": "10", "amount": null},
+        {"label": "11", "amount": null},
+        {"label": "12 TOTAL (sum of lines 8-11)", "amount": null}
+      ]
+    },
+    {
+      "section": "Section D - Forecasted Cash Needs",
+      "fields": [
+        {"label": "13 Federal", "amount": null},
+        {"label": "14 Non-Federal", "amount": null},
+        {"label": "15 TOTAL (sum of lines 13 and 14)", "amount": null}
+      ],
+      "time_periods": {
+        "Total for 1st Year": null,
+        "1st Quarter": null,
+        "2nd Quarter": null,
+        "3rd Quarter": null,
+        "4th Quarter": null,
+        "Future Funding Periods (Years)": null
+      }
+    },
+    {
+      "section": "Section E - Budget Estimates of Federal Funds Needed for Balance of the Project",
+      "fields": [
+        {"label": "16", "amount": null},
+        {"label": "17", "amount": null},
+        {"label": "18", "amount": null},
+        {"label": "19", "amount": null},
+        {"label": "20 TOTAL (sum of lines 16-19)", "amount": null}
+      ]
+    },
+    {
+      "section": "Section F - Other Budget Information",
+      "fields": [
+        {"label": "21 Direct Charges (a) Grant Program", "amount": null},
+        {"label": "22 Indirect Charges", "amount": null},
+        {"label": "23 Remarks", "text": ""}
+      ],
+      "quarterly_breakdown": {
+        "First": null,
+        "Second": null,
+        "Third": null,
+        "Fourth": null
+      }
+    }
+  ],
+  "metadata": {
+    "form": "Standard Form 424A",
+    "revision_date": "7-97",
+    "prescribed_by": "OMB Circular A-102",
+    "page": "2",
+    "note": "Authorized for Local Reproduction"
+  },
+  "text": "BUDGET INFORMATION - Non - Construction Programs OMB Number : 4040-0006\nExpiration Date : 06/30/2028\nSECTION A BUDGET SUMMARY\nGrant Program\nAssistance Listing Estimated Unobligated Funds New or Revised Budget\nFunction or\nActivity Number\nFederal Non - Federal Federal Non - Federal Total\n( a ) ( b ) ( c ) ( d ) ( e ) ( f ) ( g )\n1 . $ $ $ $ $\n2 .\n3 .\n4 .\n5 . Totals $ $ $ $ $\nStandard Form 424A ( Rev. 7-97 )\nPrescribed by OMB ( Circular A -102 ) Page 1 ."
+}

--- a/ai-agent/test_agent_check.py
+++ b/ai-agent/test_agent_check.py
@@ -121,3 +121,9 @@ def test_form_6765_template_loads():
     """Ensure the new Form 6765 template is accessible."""
     form = direct_fill_form("form_6765", {})
     assert "Form" in form["fields"]
+
+
+def test_form_424A_template_loads():
+    """Ensure the Form 424A template is accessible and structured."""
+    form = direct_fill_form("form_424A", {})
+    assert form["fields"]["Budget Information"]["OMB Number"] == "4040-0006"

--- a/eligibility-engine/grants/rural_development_grant.json
+++ b/eligibility-engine/grants/rural_development_grant.json
@@ -50,7 +50,8 @@
   },
   "tags": ["federal", "rural"],
   "requiredForms": [
-    "form_sf424"
+    "form_sf424",
+    "form_424A"
   ],
   "ui_questions": [
     "What type of organization are you?",

--- a/eligibility-engine/test_rural_development_grant.py
+++ b/eligibility-engine/test_rural_development_grant.py
@@ -18,6 +18,7 @@ def test_community_facilities_award():
     assert grant["eligible"] is True
     assert grant["estimated_amount"] == 75000
     assert "form_sf424" in grant.get("requiredForms", [])
+    assert "form_424A" in grant.get("requiredForms", [])
 
 
 def test_rcdg_cap():


### PR DESCRIPTION
## Summary
- add Standard Form 424A template to form catalog
- require Form 424A alongside SF-424 for Rural Development Grant
- test coverage for new form template and grant configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6895089b41b0832eb2b484b67d7dbbd4