### PR TITLE
Add RD 400-1 form and update Rural Development Grant

### DIFF
--- a/ai-agent/form_templates/form_RD_400_1.json
+++ b/ai-agent/form_templates/form_RD_400_1.json
@@ -1,0 +1,40 @@
+{
+  "form": "Form RD 400-1",
+  "fields": {
+    "form_number": "RD 400-1",
+    "form_version": "Rev. 8-22",
+    "agency": "United States Department of Agriculture",
+    "OMB_number": "0575-0201",
+    "expiration_date": "3/31/2026",
+    "title": "EQUAL OPPORTUNITY AGREEMENT",
+    "parties_involved": {
+      "recipient": "Recipient",
+      "usda": "United States Department of Agriculture (USDA)"
+    },
+    "agreement_details": {
+      "financial_assistance": "loan, grant, loan guaranty, or other form of financial assistance",
+      "threshold_amount": "$10,000",
+      "requirements": [
+        "Incorporate Equal Opportunity Clause into construction contracts",
+        "Non-discrimination obligations towards employees and applicants",
+        "Notification requirements to labor unions or workers' representatives",
+        "Compliance with Executive Order 11246 and related regulations",
+        "Submission of information and reports as required",
+        "Consequences of noncompliance"
+      ]
+    },
+    "paperwork_reduction_act": {
+      "OMB_control_numbers": [
+        "0575-0201",
+        "0575-0189"
+      ],
+      "expiration_date": "3/31/2026",
+      "burden_estimation": "10 minutes per response",
+      "voluntary_responses": true,
+      "contact_email": "ICRMTRequests@usda.gov"
+    },
+    "position": "6",
+    "form_version_position": "Rev. 5-00"
+  },
+  "text": "Form RD 400-1 establishes an Equal Opportunity Agreement between the USDA and the recipient. The recipient agrees to include nondiscrimination clauses in contracts and comply with Executive Order 11246."
+}

--- a/ai-agent/test_agent_check.py
+++ b/ai-agent/test_agent_check.py
@@ -127,3 +127,9 @@ def test_form_424A_template_loads():
     """Ensure the Form 424A template is accessible and structured."""
     form = direct_fill_form("form_424A", {})
     assert form["fields"]["Budget Information"]["OMB Number"] == "4040-0006"
+
+
+def test_form_RD_400_1_template_loads():
+    """Ensure the Form RD 400-1 template can be loaded."""
+    form = direct_fill_form("form_RD_400_1", {})
+    assert form["fields"]["form_number"] == "RD 400-1"

--- a/eligibility-engine/grants/rural_development_grant.json
+++ b/eligibility-engine/grants/rural_development_grant.json
@@ -51,7 +51,8 @@
   "tags": ["federal", "rural"],
   "requiredForms": [
     "form_sf424",
-    "form_424A"
+    "form_424A",
+    "form_RD_400_1"
   ],
   "ui_questions": [
     "What type of organization are you?",

--- a/eligibility-engine/test_rural_development_grant.py
+++ b/eligibility-engine/test_rural_development_grant.py
@@ -19,6 +19,7 @@ def test_community_facilities_award():
     assert grant["estimated_amount"] == 75000
     assert "form_sf424" in grant.get("requiredForms", [])
     assert "form_424A" in grant.get("requiredForms", [])
+    assert "form_RD_400_1" in grant.get("requiredForms", [])
 
 
 def test_rcdg_cap():


### PR DESCRIPTION
## Summary
- add JSON template for Form RD 400-1
- require RD 400-1 form in Rural Development Grant configuration
- test loading the RD 400-1 template and grant requirements

## Testing
- `pytest eligibility-engine/test_rural_development_grant.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -r ai-agent/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68950c414950832e95f445b5868b8d18