### PR TITLE
Pin Python microservice dependencies and document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains three microservices used to test a grant eligibility wo
 - **eligibility-engine/** – Python rules engine returning missing fields and suggested next steps
 - **ai-agent/** – LLM-ready service with conversational endpoints and smart form filling
 
-All Node.js dependencies are pinned to exact versions, and the server runs on the stable Express 4.18.2 release for consistent builds.
+All Node.js dependencies are pinned to exact versions, and the server runs on the stable Express 4.18.2 release for consistent builds. Python microservice dependencies are likewise pinned in their respective `requirements.txt` files.
 
 The eligibility engine now ships with templates for common programs including a Business Tax Refund Grant, a Veteran Owned Business Grant, the Employee Retention Credit (ERC), a comprehensive Rural Development Grant covering USDA sub-programs, a Green Energy State Incentive aggregating state-level rebates, credits and grants for renewable installations, an Urban Small Business Grants (2025) package spanning nine city programs, and a California Small Business Grant (2025) bundling the Dream Fund, STEP export vouchers, San Francisco Women’s Entrepreneurship Fund, Route 66 Extraordinary Women Micro-Grant, CDFA grants, RUST assistance, CalChamber awards and the LA Region Small Business Relief Fund.
 The Rural Development configuration now includes federal form templates for SF-424, 424A, RD 400-1, RD 400-4 and RD 400-8.
@@ -108,17 +108,25 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    ```
    Environment variables should be placed in a `.env` file. See `.env.example` for required keys.
 
-2. Start the AI agent service
+2. Start the AI analyzer service
+   ```bash
+   cd ai-analyzer
+   pip install -r requirements.txt
+   python -m uvicorn main:app --port 8000
+   ```
+3. Start the AI agent service
    ```bash
    cd ai-agent
+   pip install -r requirements.txt
    python -m uvicorn main:app --port 5001
    ```
-3. Start the eligibility engine
+4. Start the eligibility engine
    ```bash
    cd eligibility-engine
-   python -m uvicorn main:app --port 4001
+   pip install -r requirements.txt
+   python -m uvicorn api:app --port 4001
    ```
-4. (Optional) Run the eligibility engine tests
+5. (Optional) Run the eligibility engine tests
    ```bash
    cd eligibility-engine
    python -m pytest

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -7,6 +7,7 @@ future foundation for chatbot or cockpit style integrations.
 ## Running
 
 ```bash
+pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -1,7 +1,7 @@
-fastapi
-pydantic
-uvicorn
-pytesseract
-pdfplumber
-python-dotenv
-openai
+fastapi==0.95.2
+pydantic==1.10.12
+uvicorn==0.22.0
+pytesseract==0.3.10
+pdfplumber==0.10.2
+python-dotenv==1.0.0
+openai==0.27.8

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -1,4 +1,4 @@
-pytesseract
-pillow
-fastapi
-uvicorn
+pytesseract==0.3.10
+pillow==9.5.0
+fastapi==0.95.2
+uvicorn==0.22.0

--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -18,7 +18,7 @@ This definition aggregates eight statewide initiatives including the California 
 
 ## Running the Engine
 
-Install dependencies (FastAPI is only required for the optional API service):
+Install dependencies (versions are pinned in `requirements.txt`; FastAPI is only required for the optional API service):
 
 ```bash
 pip install -r requirements.txt  # if running outside Codex environment

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn
+fastapi==0.95.2
+uvicorn==0.22.0


### PR DESCRIPTION
## Summary
- pin dependencies for `ai-agent`, `ai-analyzer`, and `eligibility-engine`
- document installing pinned Python deps in service READMEs and root README

## Testing
- `pip install -r ai-agent/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install -r ai-analyzer/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install -r eligibility-engine/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest eligibility-engine`
- `pytest ai-agent/test_agent_check.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68953fe1d7cc832e9d3444f54e0d0c1b