### PR TITLE
feat(ai-agent): load MongoDB URI from env

### DIFF
--- a/ai-agent/.env.example
+++ b/ai-agent/.env.example
@@ -1,2 +1,3 @@
 # Example env vars for ai-agent
 OPENAI_API_KEY=your_openai_key
+MONGODB_URI=mongodb://localhost:27017

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -11,6 +11,15 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
+Create a `.env` file in this directory and set your MongoDB connection string:
+
+```
+MONGODB_URI=mongodb://localhost:27017
+```
+
+The service uses [python-dotenv](https://github.com/theskumar/python-dotenv) to
+load this file automatically.
+
 ## Endpoints
 
 - `POST /check` – submit user data, notes or an uploaded document. Free-form

--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -4,9 +4,13 @@ from typing import Any
 from pathlib import Path
 import json
 import sys
+from dotenv import load_dotenv
+
+# Resolve project directories and load environment variables
+CURRENT_DIR = Path(__file__).resolve().parent
+load_dotenv(CURRENT_DIR / ".env")
 
 # ensure local imports work regardless of working directory
-CURRENT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(CURRENT_DIR))
 
 # allow importing the eligibility engine

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -3,7 +3,10 @@ from typing import Dict, Any, List
 from pymongo import MongoClient
 import os
 
-client = MongoClient(os.getenv("MONGO_URI", "mongodb://localhost:27017"))
+MONGO_URI = os.getenv("MONGODB_URI")
+if not MONGO_URI:
+    raise ValueError("MONGODB_URI environment variable is not set")
+client = MongoClient(MONGO_URI)
 db = client["ai_agent"]
 collection = db["session_memory"]
 


### PR DESCRIPTION
## Summary
- load ai-agent environment variables from a local .env file
- configure session memory to use `MONGODB_URI`
- document `.env` setup and provide example file

## Testing
- `pip install -r ai-agent/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.95.2)*
- `pytest -q ai-agent/test_agent_check.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68954bc3732c832e91b048353b2dffce