### PR TITLE
Finalize MongoDB environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    npm install
    node server/index.js
    ```
-   Environment variables should be placed in a `.env` file. See `.env.example` for required keys.
+   Create a `.env` file in the repository root (copy from `.env.example`) and set `MONGO_URI` along with other service URLs.
 
 2. Start the AI analyzer service
    ```bash
@@ -124,6 +124,7 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    pip install -r requirements.txt
    python -m uvicorn main:app --port 5001
    ```
+   The AI agent requires its own `.env` file (see `ai-agent/.env.example`) with `MONGODB_URI` and, optionally, `OPENAI_API_KEY`.
 4. Start the eligibility engine
    ```bash
    cd eligibility-engine

--- a/ai-agent/.env.example
+++ b/ai-agent/.env.example
@@ -1,3 +1,2 @@
-# Example env vars for ai-agent
-OPENAI_API_KEY=your_openai_key
 MONGODB_URI=mongodb://localhost:27017
+OPENAI_API_KEY=your_openai_api_key

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -11,10 +11,12 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
-Create a `.env` file in this directory and set your MongoDB connection string:
+Create a `.env` file in this directory (you can copy from `.env.example`) and set
+your MongoDB connection string and optional OpenAI API key:
 
 ```
 MONGODB_URI=mongodb://localhost:27017
+OPENAI_API_KEY=your_api_key_here
 ```
 
 The service uses [python-dotenv](https://github.com/theskumar/python-dotenv) to

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -2,8 +2,16 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    const mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/grants';
+    const mongoURI =
+      process.env.MONGO_URI ||
+      (process.env.NODE_ENV === 'development'
+        ? 'mongodb://localhost:27017/grants'
+        : '');
     mongoose.set('strictQuery', false);
+
+    if (!mongoURI) {
+      throw new Error('MONGO_URI environment variable is not set');
+    }
 
     const conn = await mongoose.connect(mongoURI, {
       useNewUrlParser: true,


### PR DESCRIPTION
## Summary
- Restrict server's fallback MongoDB URI to development and require MONGO_URI otherwise
- Document ai-agent environment variables and add `.env.example`
- Clarify setup steps for configuring `.env` files in README

## Testing
- `cd server && npm test`
- `cd ai-agent && pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.95.2)*
- `MONGODB_URI='mongodb://localhost:27017/?serverSelectionTimeoutMS=1000' OPENAI_API_KEY='dummy' pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68960366d5ec832eb4ed64dedff0e2d5