### PR TITLE
refactor: use MONGO_URI env var across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    pip install -r requirements.txt
    python -m uvicorn main:app --port 5001
    ```
-   The AI agent requires its own `.env` file (see `ai-agent/.env.example`) with `MONGODB_URI` and, optionally, `OPENAI_API_KEY`.
+   The AI agent requires its own `.env` file (see `ai-agent/.env.example`) with `MONGO_URI` and, optionally, `OPENAI_API_KEY`.
 4. Start the eligibility engine
    ```bash
    cd eligibility-engine

--- a/ai-agent/.env.example
+++ b/ai-agent/.env.example
@@ -1,2 +1,2 @@
-MONGODB_URI=mongodb://localhost:27017
+MONGO_URI=mongodb://localhost:27017
 OPENAI_API_KEY=your_openai_api_key

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -15,7 +15,7 @@ Create a `.env` file in this directory (you can copy from `.env.example`) and se
 your MongoDB connection string and optional OpenAI API key:
 
 ```
-MONGODB_URI=mongodb://localhost:27017
+MONGO_URI=mongodb://localhost:27017
 OPENAI_API_KEY=your_api_key_here
 ```
 

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -3,9 +3,11 @@ from typing import Dict, Any, List
 from pymongo import MongoClient
 import os
 
-MONGO_URI = os.getenv("MONGODB_URI")
+MONGO_URI = os.getenv("MONGO_URI")
+if not MONGO_URI and os.getenv("NODE_ENV") == "development":
+    MONGO_URI = "mongodb://localhost:27017"
 if not MONGO_URI:
-    raise ValueError("MONGODB_URI environment variable is not set")
+    raise ValueError("MONGO_URI environment variable is not set")
 client = MongoClient(MONGO_URI)
 db = client["ai_agent"]
 collection = db["session_memory"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - '5001:5001'
     depends_on:
       - eligibility-engine
+    environment:
+      - MONGO_URI=mongodb://mongo:27017/grants
 
   ai-analyzer:
     build: ./ai-analyzer

--- a/server/config/connectDB.js
+++ b/server/config/connectDB.js
@@ -3,7 +3,15 @@ require('dotenv').config(); // טען את קובץ ה־.env (אם זה לא נ�
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGO_URI);
+    const mongoURI =
+      process.env.MONGO_URI ||
+      (process.env.NODE_ENV === 'development' ? 'mongodb://localhost:27017/grants' : '');
+
+    if (!mongoURI) {
+      throw new Error('MONGO_URI environment variable is not set');
+    }
+
+    const conn = await mongoose.connect(mongoURI);
     console.log(`✅ MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {
     console.error(`❌ MongoDB Connection Error: ${error.message}`);


### PR DESCRIPTION
## Summary
- use `MONGO_URI` consistently for MongoDB connections in the ai-agent service
- document the `MONGO_URI` variable across repo and docker compose
- add env-based connection handling in server's config

## Testing
- `npm test` in `server`
- `pip install -r ai-agent/requirements.txt` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689609cac668832e92a0f229049a92ec