### PR TITLE
Use safe evaluator for form templates

### DIFF
--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -38,6 +38,15 @@ load this file automatically.
 Add a new JSON file under `form_templates/` using the existing examples as a
 starting point. The `fields` object will be merged with user data.
 
+## Safe Expression Evaluation
+
+Computed, conditional and visibility rules inside form templates are expressed
+using a very small subset of Python. These expressions are evaluated with a
+custom AST-based interpreter that supports arithmetic, boolean logic and
+comparisons while restricting function calls to a tiny whitelist (`int` and
+`float`).  Any invalid or malicious expression is rejected, preventing arbitrary
+code execution and keeping template evaluation safe.
+
 ## Testing Documents
 
 Example documents live under `test_documents/`. They are simple text files used

--- a/ai-agent/test_safe_eval.py
+++ b/ai-agent/test_safe_eval.py
@@ -1,0 +1,32 @@
+import pytest
+
+from form_filler import safe_eval, _fill_template
+
+def test_safe_eval_basic():
+    ctx = {"a": 2, "b": 3, "flag": False}
+    assert safe_eval("a + b * 2", ctx) == 8
+    assert safe_eval("not flag and a < 5", ctx) is True
+
+
+def test_safe_eval_rejects_malicious():
+    with pytest.raises(ValueError):
+        safe_eval("__import__('os').system('ls')", {})
+
+
+def test_computed_field_uses_safe_eval():
+    template = {
+        "fields": {"a": "", "b": "", "sum": ""},
+        "computed_fields": {"sum": "a + b"},
+    }
+    data = {"a": 1, "b": 2}
+    result = _fill_template(template, data)
+    assert result["fields"]["sum"] == 3
+
+
+def test_computed_field_rejects_malicious():
+    template = {
+        "fields": {"bad": {"example": "placeholder"}},
+        "computed_fields": {"bad": "__import__('os').system('ls')"},
+    }
+    result = _fill_template(template, {})
+    assert result["fields"]["bad"] == "placeholder"


### PR DESCRIPTION
## Summary
- add `safe_eval` using Python AST to safely evaluate arithmetic, boolean and comparison expressions
- replace `eval` calls in form filling logic with `safe_eval`
- document the secure expression evaluation mechanism and add unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -r ai-agent/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.95.2)*
- `pytest ai-agent/test_safe_eval.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68960de2c86c832ea1cfc5c4149a4d3a