### PR TITLE
Harden safe_eval against malicious context and heavy expressions

### DIFF
--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -45,7 +45,13 @@ using a very small subset of Python. These expressions are evaluated with a
 custom AST-based interpreter that supports arithmetic, boolean logic and
 comparisons while restricting function calls to a tiny whitelist (`int` and
 `float`).  Any invalid or malicious expression is rejected, preventing arbitrary
-code execution and keeping template evaluation safe.
+code execution and keeping template evaluation safe. The evaluator now also
+sanitizes the context, rejecting variable names containing double underscores or
+values that are callable to block access to dangerous objects. In addition,
+limits on expression complexity (maximum AST nodes) and constant size (maximum
+string length and numeric magnitude) prevent resource exhaustion attacks. These
+limits can be tuned via optional arguments to ``safe_eval`` if stricter or more
+lenient behavior is desired.
 
 ## Testing Documents
 

--- a/ai-agent/test_safe_eval.py
+++ b/ai-agent/test_safe_eval.py
@@ -13,6 +13,30 @@ def test_safe_eval_rejects_malicious():
         safe_eval("__import__('os').system('ls')", {})
 
 
+def test_safe_eval_rejects_bad_names():
+    with pytest.raises(ValueError):
+        safe_eval("x", {"bad__name": 1})
+
+
+def test_safe_eval_rejects_callables_in_context():
+    with pytest.raises(ValueError):
+        safe_eval("x", {"f": lambda: 1})
+
+
+def test_safe_eval_rejects_too_complex():
+    expr = " + ".join(["1"] * 60)
+    with pytest.raises(ValueError):
+        safe_eval(expr, {})
+
+
+def test_safe_eval_rejects_large_literals():
+    long_str = "a" * 1001
+    with pytest.raises(ValueError):
+        safe_eval(f"'{long_str}'", {})
+    with pytest.raises(ValueError):
+        safe_eval(str(10**10), {})
+
+
 def test_computed_field_uses_safe_eval():
     template = {
         "fields": {"a": "", "b": "", "sum": ""},


### PR DESCRIPTION
## Summary
- sanitize evaluation context to reject double-underscore names and callables
- enforce limits on AST nodes and literal size to avoid DoS
- document new protections and add extensive tests

## Testing
- `pytest ai-agent/test_safe_eval.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689611453a64832ea79432b8adb43211