### PR TITLE
Add CI workflow and analyzer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  ai-agent:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ai-agent
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  ai-analyzer:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ai-analyzer
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  eligibility-engine:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: eligibility-engine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt
+      - run: pytest
+

--- a/README.md
+++ b/README.md
@@ -195,3 +195,21 @@ docker-compose up --build
 ```
 
 The frontend will be available at [http://localhost:3000](http://localhost:3000) and the API at [http://localhost:5000/api](http://localhost:5000/api).
+
+## Testing
+
+Each microservice includes a small test suite. Run them individually from the repository root:
+
+```bash
+# Express API
+cd server && npm test
+
+# Python services
+cd ai-agent && pip install -r requirements.txt && pytest
+cd ai-analyzer && pip install -r requirements.txt && pytest
+cd eligibility-engine && pip install -r requirements.txt && pytest
+```
+
+Continuous integration runs these commands on every push and pull request using the workflow in `.github/workflows/ci.yml`.
+
+When contributing new features, add tests in the corresponding service and keep test imports local to that service.

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -6,3 +6,4 @@ pdfplumber==0.10.2
 python-dotenv==1.0.0
 openai==0.27.8
 pymongo==4.6.3
+pytest==8.0.2

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -2,3 +2,4 @@ pytesseract==0.3.10
 pillow==9.5.0
 fastapi==0.95.2
 uvicorn==0.22.0
+pytest==8.0.2

--- a/ai-analyzer/tests/test_nlp_parser.py
+++ b/ai-analyzer/tests/test_nlp_parser.py
@@ -1,0 +1,23 @@
+"""Tests for the lightweight NLP parser."""
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from nlp_parser import parse_fields
+
+
+def test_parse_fields_extracts_known_values():
+    text = (
+        "Revenue: 123,456 with 10 employees "
+        "and founded in 2019."
+    )
+    fields, confidence = parse_fields(text)
+
+    assert fields["revenue"] == 123456
+    assert fields["employees"] == 10
+    assert fields["year_founded"] == "2019"
+    # confidence should include keys for extracted fields
+    assert set(confidence) == set(fields)
+

--- a/ai-analyzer/tests/test_ocr_utils.py
+++ b/ai-analyzer/tests/test_ocr_utils.py
@@ -1,0 +1,20 @@
+"""Tests for OCR helper functions."""
+
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ocr_utils import extract_text
+
+
+def test_extract_text_falls_back_to_utf8_decode():
+    data = b"hello world"
+    assert extract_text(data) == "hello world"
+
+
+def test_extract_text_handles_binary_data():
+    # Non-decodable bytes should return placeholder text
+    data = bytes([0, 255, 0, 255])
+    assert extract_text(data)
+

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.95.2
 uvicorn==0.22.0
+pytest==8.0.2


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow running tests for server and Python services
- add pytest to Python service requirements
- add initial unit tests for ai-analyzer
- document test commands in README

## Testing
- `npm test` (server)
- `pytest` (ai-analyzer)
- `pytest` (eligibility-engine)
- `python -m pip install -r requirements.txt` *(ai-agent: missing dependency fastapi)*


------
https://chatgpt.com/codex/tasks/task_e_68962ce197b0832e96caeb8d9901e581