### PR TITLE
test: scaffold frontend and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: server-coverage
+          path: server/coverage.txt
 
   ai-agent:
     runs-on: ubuntu-latest
@@ -29,7 +33,13 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -r requirements.txt
-      - run: pytest
+      - run: coverage run -m pytest
+      - run: coverage report --fail-under=70
+      - run: coverage xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ai-agent-coverage
+          path: ai-agent/coverage.xml
 
   ai-analyzer:
     runs-on: ubuntu-latest
@@ -42,7 +52,13 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -r requirements.txt
-      - run: pytest
+      - run: coverage run -m pytest
+      - run: coverage report --fail-under=70
+      - run: coverage xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ai-analyzer-coverage
+          path: ai-analyzer/coverage.xml
 
   eligibility-engine:
     runs-on: ubuntu-latest
@@ -55,5 +71,30 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -r requirements.txt
-      - run: pytest
+      - run: coverage run -m pytest
+      - run: coverage report --fail-under=70
+      - run: coverage xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: eligibility-engine-coverage
+          path: eligibility-engine/coverage.xml
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npm run e2e
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ node_modules
 .env
 uploads
 server/uploads
+# Coverage outputs
+coverage/
+**/coverage.txt
+**/coverage/
 # Frontend build outputs
 /frontend/.next
 /frontend/node_modules

--- a/README.md
+++ b/README.md
@@ -198,16 +198,20 @@ The frontend will be available at [http://localhost:3000](http://localhost:3000)
 
 ## Testing
 
-Each microservice includes a small test suite. Run them individually from the repository root:
+Each microservice includes a small test suite with coverage reporting. Run them individually from the repository root:
 
 ```bash
-# Express API
+# Express API (coverage written to server/coverage.txt)
 cd server && npm test
 
-# Python services
-cd ai-agent && pip install -r requirements.txt && pytest
-cd ai-analyzer && pip install -r requirements.txt && pytest
-cd eligibility-engine && pip install -r requirements.txt && pytest
+# Frontend unit tests and E2E (coverage in frontend/coverage)
+cd frontend && npm test
+cd frontend && npm run e2e
+
+# Python services (coverage.xml output)
+cd ai-agent && pip install -r requirements.txt && coverage run -m pytest && coverage report
+cd ai-analyzer && pip install -r requirements.txt && coverage run -m pytest && coverage report
+cd eligibility-engine && pip install -r requirements.txt && coverage run -m pytest && coverage report
 ```
 
 Continuous integration runs these commands on every push and pull request using the workflow in `.github/workflows/ci.yml`.

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.0
 openai==0.27.8
 pymongo==4.6.3
 pytest==8.0.2
+coverage==7.4.0

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -3,3 +3,4 @@ pillow==9.5.0
 fastapi==0.95.2
 uvicorn==0.22.0
 pytest==8.0.2
+coverage==7.4.0

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.95.2
 uvicorn==0.22.0
 pytest==8.0.2
+coverage==7.4.0

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page displays headline', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Grant Application Platform' })).toBeVisible();
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({ dir: './' });
+const customJestConfig = {
+  testEnvironment: 'jest-environment-jsdom',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: { branches: 70, functions: 70, lines: 70, statements: 70 },
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "next": "14.1.0",
@@ -22,6 +24,11 @@
     "typescript": "^5.3.2",
     "@types/react": "^18.2.0",
     "@types/node": "^20.9.0",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0",
+    "@types/jest": "^29.5.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.3",
+    "@playwright/test": "^1.43.0",
+    "jest": "^29.7.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'npm run build && npm run start',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Home from './page';
+
+describe('Home', () => {
+  it('renders headline', () => {
+    render(<Home />);
+    expect(screen.getByText('Grant Application Platform')).toBeInTheDocument();
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node --test"
+    "test": "node --test --experimental-test-coverage > coverage.txt && node scripts/check-coverage.js coverage.txt"
   },
   "dependencies": {
     "bcryptjs": "3.0.2",

--- a/server/scripts/check-coverage.js
+++ b/server/scripts/check-coverage.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const text = fs.readFileSync(process.argv[2], 'utf8');
+const match = text.match(/# all files\s*\|\s*(\d+\.\d+)\s*\|\s*(\d+\.\d+)\s*\|\s*(\d+\.\d+)\s*\|/);
+if (!match) {
+  console.error('Coverage summary not found');
+  process.exit(1);
+}
+const lines = parseFloat(match[1]);
+const branches = parseFloat(match[2]);
+const funcs = parseFloat(match[3]);
+const threshold = 70; // coverage threshold
+if (lines < threshold || branches < threshold || funcs < threshold) {
+  console.error(`Coverage below threshold: lines ${lines}, branches ${branches}, funcs ${funcs}`);
+  process.exit(1);
+}
+console.log(`Coverage check passed: lines ${lines}, branches ${branches}, funcs ${funcs}`);
+


### PR DESCRIPTION
## Summary
- add Jest unit test and Playwright E2E skeleton for frontend
- enforce coverage in Node and Python services and upload reports in CI
- document test and coverage commands in README

## Testing
- `npm test` in server with coverage (passes)
- `coverage run -m pytest` in ai-agent (fails: command not found)
- `npm test` in frontend (fails: jest: not found)
- `npm run e2e` in frontend (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68962f24c2c4832ea2859695586a70f4