### PR TITLE
chore: pin frontend deps and enhance ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: server/package-lock.json
       - run: npm ci
       - run: npm test
       - uses: actions/upload-artifact@v4
@@ -32,7 +34,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ai-agent/requirements.txt
       - run: pip install -r requirements.txt
+      - run: flake8 .
       - run: coverage run -m pytest
       - run: coverage report --fail-under=70
       - run: coverage xml
@@ -51,7 +56,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ai-analyzer/requirements.txt
       - run: pip install -r requirements.txt
+      - run: flake8 .
       - run: coverage run -m pytest
       - run: coverage report --fail-under=70
       - run: coverage xml
@@ -70,7 +78,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: eligibility-engine/requirements.txt
       - run: pip install -r requirements.txt
+      - run: flake8 .
       - run: coverage run -m pytest
       - run: coverage report --fail-under=70
       - run: coverage xml
@@ -89,7 +100,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm run lint
       - run: npm test
       - run: npx playwright install --with-deps
       - run: npm run e2e
@@ -97,4 +111,20 @@ jobs:
         with:
           name: frontend-coverage
           path: frontend/coverage
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - server
+      - ai-agent
+      - ai-analyzer
+      - eligibility-engine
+      - frontend
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: coverage
+      - uses: codecov/codecov-action@v3
+        with:
+          files: coverage/**/*
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ cd ai-analyzer && pip install -r requirements.txt && coverage run -m pytest && c
 cd eligibility-engine && pip install -r requirements.txt && coverage run -m pytest && coverage report
 ```
 
+### Linting and Coverage
+
+Run `npm run lint` in the `frontend` folder and `flake8 .` within each Python service to perform static analysis. Coverage results are written per service (e.g., `server/coverage.txt`, `frontend/coverage`, `ai-agent/coverage.xml`) and the CI workflow aggregates them via Codecov.
+
 Continuous integration runs these commands on every push and pull request using the workflow in `.github/workflows/ci.yml`.
 
 When contributing new features, add tests in the corresponding service and keep test imports local to that service.

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -8,3 +8,4 @@ openai==0.27.8
 pymongo==4.6.3
 pytest==8.0.2
 coverage==7.4.0
+flake8==6.1.0

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -4,3 +4,4 @@ fastapi==0.95.2
 uvicorn==0.22.0
 pytest==8.0.2
 coverage==7.4.0
+flake8==6.1.0

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.95.2
 uvicorn==0.22.0
 pytest==8.0.2
 coverage==7.4.0
+flake8==6.1.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,21 +14,21 @@
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "axios": "^1.6.0",
-    "zustand": "^4.4.0"
+    "axios": "1.6.0",
+    "zustand": "4.4.0"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.24",
-    "autoprefixer": "^10.4.14",
-    "typescript": "^5.3.2",
-    "@types/react": "^18.2.0",
-    "@types/node": "^20.9.0",
-    "eslint": "^8.56.0",
-    "@types/jest": "^29.5.5",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.1.3",
-    "@playwright/test": "^1.43.0",
-    "jest": "^29.7.0"
+    "tailwindcss": "3.4.0",
+    "postcss": "8.4.24",
+    "autoprefixer": "10.4.14",
+    "typescript": "5.3.2",
+    "@types/react": "18.2.0",
+    "@types/node": "20.9.0",
+    "eslint": "8.56.0",
+    "@types/jest": "29.5.5",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.1.3",
+    "@playwright/test": "1.43.0",
+    "jest": "29.7.0"
   }
 }

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Login from './page';
+
+describe('Login page', () => {
+  it('renders login button', () => {
+    render(<Login />);
+    expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -44,11 +44,15 @@ app.use('/api', require('./routes/case'));
 // === Connect to DB and start server ===
 const PORT = process.env.PORT || 5000;
 
-connectDB()
-  .then(() => {
-    app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
-  })
-  .catch((err) => {
-    console.error('❌ Failed to connect to MongoDB:', err.message);
-    process.exit(1); // Exit process if DB fails
-  });
+if (process.env.SKIP_DB !== 'true') {
+  connectDB()
+    .then(() => {
+      app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+    })
+    .catch((err) => {
+      console.error('❌ Failed to connect to MongoDB:', err.message);
+      process.exit(1); // Exit process if DB fails
+    });
+}
+
+module.exports = app;

--- a/server/tests/status.test.js
+++ b/server/tests/status.test.js
@@ -1,0 +1,14 @@
+process.env.SKIP_DB = 'true';
+const test = require('node:test');
+const assert = require('node:assert');
+const app = require('../index');
+
+test('GET /status returns ok', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/status`);
+  const body = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(body.status, 'ok');
+  server.close();
+});


### PR DESCRIPTION
## Summary
- pin frontend dependencies to exact versions
- add flake8 and eslint steps with caching in CI
- add basic route and page tests
- document linting and coverage reporting

## Testing
- `pip install -r requirements.txt` *(failed: Tunnel connection failed: 403 Forbidden)*
- `flake8 .` *(command not found)*
- `coverage run -m pytest` *(command not found)*
- `npm test` *(Coverage below threshold: lines 58.04, branches 94.19, funcs 44.44)*
- `npm run lint` *(failed: next: not found)*
- `npm test` *(failed: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68963b40a3f8832e83083adf2c26e09f