### PR TITLE
Implement API key auth and security hardening

### DIFF
--- a/SECURITY_REPORT.md
+++ b/SECURITY_REPORT.md
@@ -1,0 +1,18 @@
+# Security Report
+
+## Implemented Changes
+
+- Added API key authentication to AI Agent, AI Analyzer, and Eligibility Engine services.
+- Secured the `/llm-debug/{session_id}` endpoint behind authentication and environment flag.
+- Hardened file uploads in AI Analyzer with size limits (5MB) and ClamAV virus scanning.
+- Enforced authenticated inter-service communication by sending `X-API-Key` headers and defaulting internal URLs to HTTPS.
+- Improved MongoDB security with optional username/password and TLS support.
+- Added simple in-memory rate limiting middleware to the Express server.
+
+## Further Recommendations
+
+- Deploy a real virus scanning service (e.g., ClamAV daemon) and integrate with the analyzer.
+- Replace in-memory rate limiting with a distributed solution like Redis for multi-instance deployments.
+- Enable full HTTPS or mTLS across all services with proper certificates.
+- Centralize logging and implement audit trails for authentication and data access.
+- Conduct penetration testing to validate the security posture.

--- a/eligibility-engine/api.py
+++ b/eligibility-engine/api.py
@@ -1,8 +1,17 @@
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request, HTTPException, Depends, Header
 from engine import analyze_eligibility
 from grants_loader import load_grants
+import os
 
-app = FastAPI(title="Grant Eligibility Engine")
+API_KEY = os.getenv("INTERNAL_API_KEY")
+
+
+async def verify_api_key(x_api_key: str = Header(None)):
+    if not API_KEY or x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+app = FastAPI(title="Grant Eligibility Engine", dependencies=[Depends(verify_api_key)])
 
 
 @app.get("/")

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -13,10 +13,20 @@ const connectDB = async () => {
       throw new Error('MONGO_URI environment variable is not set');
     }
 
-    const conn = await mongoose.connect(mongoURI, {
+    const options = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-    });
+    };
+    if (process.env.MONGO_USER && process.env.MONGO_PASS) {
+      options.auth = {
+        username: process.env.MONGO_USER,
+        password: process.env.MONGO_PASS,
+      };
+    }
+    if (process.env.MONGO_TLS === 'true') {
+      options.tls = true;
+    }
+    const conn = await mongoose.connect(mongoURI, options);
 
     console.log(`✅ MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {


### PR DESCRIPTION
## Summary
- add API key authentication to AI Agent, AI Analyzer, and Eligibility Engine endpoints
- secure llm-debug endpoint and tighten file upload checks with size limits and virus scanning
- send API keys between services, default internal URLs to HTTPS, enable MongoDB auth/TLS and basic rate limiting

## Testing
- `pytest ai-agent` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest ai-analyzer`
- `pytest eligibility-engine`
- `cd server && npm test` *(fails: Coverage below threshold: lines 57.92, branches 92.13, funcs 45.31)*

------
https://chatgpt.com/codex/tasks/task_e_689651d71d04832e9c7e145775b0ea87