### PR TITLE
Add auth tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ ELIGIBILITY_ENGINE_URL=http://eligibility-engine:4001
 AI_AGENT_URL=http://ai-agent:5001
 ```
 
+## Authentication
+
+Internal Python services (AI Agent, AI Analyzer, Eligibility Engine) require an `X-API-Key` header that matches `INTERNAL_API_KEY`. Example:
+
+```bash
+curl -H "X-API-Key: your_key" http://localhost:5001/status
+```
+
+Requests without a key return **401 Unauthorized**. The Express server protects routes under `/api` using JWT bearer tokens:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:5000/api/users
+```
+
+A missing or invalid token results in **401 Unauthorized**.
+
+
 ### Case Management API
 
 The frontend interacts with a simpler set of endpoints that manage a user's in‑progress case:

--- a/ai-agent/test_auth.py
+++ b/ai-agent/test_auth.py
@@ -1,0 +1,19 @@
+import os
+from importlib import reload
+
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    os.environ["INTERNAL_API_KEY"] = "test-key"
+    import main as main_module
+    reload(main_module)
+    return TestClient(main_module.app)
+
+
+def test_requires_api_key():
+    client = get_client()
+    resp = client.get("/status")
+    assert resp.status_code == 401
+    resp = client.get("/status", headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 200

--- a/ai-analyzer/tests/test_auth.py
+++ b/ai-analyzer/tests/test_auth.py
@@ -1,0 +1,18 @@
+import os
+from importlib import reload
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    os.environ["INTERNAL_API_KEY"] = "test-key"
+    import main as main_module
+    reload(main_module)
+    return TestClient(main_module.app)
+
+
+def test_requires_api_key():
+    client = get_client()
+    resp = client.get("/status")
+    assert resp.status_code == 401
+    resp = client.get("/status", headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 200

--- a/eligibility-engine/test_auth.py
+++ b/eligibility-engine/test_auth.py
@@ -1,0 +1,18 @@
+import os
+from importlib import reload
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    os.environ["INTERNAL_API_KEY"] = "test-key"
+    import api as api_module
+    reload(api_module)
+    return TestClient(api_module.app)
+
+
+def test_requires_api_key():
+    client = get_client()
+    resp = client.get("/status")
+    assert resp.status_code == 401
+    resp = client.get("/status", headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 200

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+process.env.SKIP_DB = 'true';
+
+const app = require('../index');
+
+// accessing protected route without token should be rejected
+
+test('GET /api/users requires auth', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/api/users`);
+  assert.strictEqual(res.status, 401);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- document API key and JWT usage across services
- add auth enforcement tests for ai-agent, ai-analyzer, eligibility engine, and server

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test --prefix server` *(fails: Coverage below threshold: lines 58.85, branches 90.43, funcs 47.69)*

------
https://chatgpt.com/codex/tasks/task_e_689657dc8e34832eb355259332599a07