### PR TITLE
Secure AI Analyzer file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains three microservices used to test a grant eligibility workflow.
 
 - **server/** – Express API for authentication, file uploads and analysis forwarding
-- **ai-analyzer/** – FastAPI service that extracts text using Tesseract OCR and simple NLP with confidence scores
+- **ai-analyzer/** – FastAPI service that extracts text using Tesseract OCR and simple NLP with confidence scores while enforcing API key authentication, a 5MB upload limit and ClamAV virus scanning
 - **eligibility-engine/** – Python rules engine returning missing fields and suggested next steps
 - **ai-agent/** – LLM-ready service with conversational endpoints and smart form filling
 
@@ -25,7 +25,7 @@ project-root/
   frontend/             Next.js application
 ```
 
-The document upload flow accepts **PDF**, **JPG/JPEG**, and **PNG** files.
+The document upload flow accepts **PDF**, **JPG/JPEG**, and **PNG** files up to 5MB each and scans them for viruses before analysis.
 
 ### Veteran Owned Business Grant
 

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -1,0 +1,25 @@
+# AI Analyzer Service
+
+This FastAPI microservice extracts text from uploaded documents using Tesseract OCR
+and parses simple business fields. The `/analyze` endpoint accepts `application/pdf`,
+`image/png` and `image/jpeg` uploads.
+
+## Security
+
+Uploads are protected with several layers of security:
+
+* **API key authentication** – requests must include an `X-API-Key` header that matches
+  the `INTERNAL_API_KEY` environment variable. Unauthorized requests return `401`.
+* **File size limit** – files larger than **5MB** are rejected with a `413` error.
+* **Virus scanning** – uploaded files are scanned with `clamscan`. Infected files
+  result in a `400` response. If the scanner is unavailable the service responds
+  with a `500` error.
+
+## Running tests
+
+Install the dependencies and run the test suite:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -22,6 +22,8 @@ def scan_for_viruses(data: bytes) -> None:
             result = subprocess.run(["clamscan", tmp.name], capture_output=True)
             if result.returncode == 1:
                 raise HTTPException(status_code=400, detail="Virus detected")
+            if result.returncode != 0:
+                raise HTTPException(status_code=500, detail="Virus scan failed")
     except FileNotFoundError:
         raise HTTPException(status_code=500, detail="Virus scanner not available")
 

--- a/ai-analyzer/tests/test_security.py
+++ b/ai-analyzer/tests/test_security.py
@@ -1,0 +1,45 @@
+import os
+from importlib import reload
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+
+def get_client(monkeypatch, scan_behavior=None):
+    os.environ["INTERNAL_API_KEY"] = "test-key"
+    import main as main_module
+    reload(main_module)
+    # Stub out heavy functions
+    monkeypatch.setattr(main_module, "extract_text", lambda data: "")
+    monkeypatch.setattr(main_module, "parse_fields", lambda text: ({}, {}))
+    if scan_behavior is None:
+        monkeypatch.setattr(main_module, "scan_for_viruses", lambda data: None)
+    else:
+        monkeypatch.setattr(main_module, "scan_for_viruses", scan_behavior)
+    return TestClient(main_module.app)
+
+
+def test_analyze_requires_api_key(monkeypatch):
+    client = get_client(monkeypatch)
+    files = {"file": ("doc.pdf", b"data", "application/pdf")}
+    resp = client.post("/analyze", files=files)
+    assert resp.status_code == 401
+    resp = client.post("/analyze", files=files, headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 200
+
+
+def test_file_too_large(monkeypatch):
+    client = get_client(monkeypatch)
+    big = b"0" * (5 * 1024 * 1024 + 1)
+    files = {"file": ("big.pdf", big, "application/pdf")}
+    resp = client.post("/analyze", files=files, headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 413
+
+
+def test_detects_infected_file(monkeypatch):
+    def fake_scan(_):
+        raise HTTPException(status_code=400, detail="Virus detected")
+    client = get_client(monkeypatch, scan_behavior=fake_scan)
+    files = {"file": ("doc.pdf", b"data", "application/pdf")}
+    resp = client.post("/analyze", files=files, headers={"X-API-Key": "test-key"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Virus detected"


### PR DESCRIPTION
## Summary
- enforce API key authentication, file size limit and ClamAV scanning for `/analyze`
- document AI Analyzer security requirements and test instructions
- add tests covering auth, oversize uploads and infected files

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytesseract==0.3.10)*
- `flake8 .` *(fails: command not found: flake8)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68965d688fc8832ea7c644a3e7fd5eb9