### PR TITLE
Enforce MongoDB authentication and TLS across services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Example environment configuration
-MONGO_URI=mongodb://localhost:27017/grants
+MONGO_URI=mongodb://mongo:27017/grants?authSource=admin&tls=true
+MONGO_USER=serverUser
+MONGO_PASS=strongPassword
+MONGO_CA_FILE=/path/to/ca.pem
 JWT_SECRET=your_jwt_secret
 AI_AGENT_URL=http://localhost:5001
 ELIGIBILITY_ENGINE_URL=http://localhost:4001

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All Node.js dependencies are pinned to exact versions, and the server runs on th
 
 ## Persistence
 
-User cases, pipeline state, uploaded file metadata and AI agent conversations are now stored in MongoDB. Sessions are persisted in a TTL-indexed collection and file uploads stream to disk with their paths tracked in the database.
+User cases, pipeline state, uploaded file metadata and AI agent conversations are now stored in MongoDB. Sessions are persisted in a TTL-indexed collection and file uploads stream to disk with their paths tracked in the database. See [`docs/mongo-security.md`](docs/mongo-security.md) for details on authentication, TLS and role setup.
 
 The eligibility engine now ships with templates for common programs including a Business Tax Refund Grant, a Veteran Owned Business Grant, the Employee Retention Credit (ERC), a comprehensive Rural Development Grant covering USDA sub-programs, a Green Energy State Incentive aggregating state-level rebates, credits and grants for renewable installations, an Urban Small Business Grants (2025) package spanning nine city programs, and a California Small Business Grant (2025) bundling the Dream Fund, STEP export vouchers, San Francisco Women’s Entrepreneurship Fund, Route 66 Extraordinary Women Micro-Grant, CDFA grants, RUST assistance, CalChamber awards and the LA Region Small Business Relief Fund.
 The Rural Development configuration now includes federal form templates for SF-424, 424A, RD 400-1, RD 400-4 and RD 400-8.
@@ -127,7 +127,15 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    npm install
    node server/index.js
    ```
-   Create a `.env` file in the repository root (copy from `.env.example`) and set `MONGO_URI` along with other service URLs.
+   Create a `.env` file in the repository root (copy from `.env.example`) and set
+   credentials for a TLS-enabled MongoDB connection along with other service URLs:
+
+   ```
+   MONGO_URI=mongodb://mongo:27017/grants?authSource=admin&tls=true
+   MONGO_USER=serverUser
+   MONGO_PASS=strongPassword
+   MONGO_CA_FILE=/path/to/ca.pem
+   ```
 
 2. Start the AI analyzer service
    ```bash
@@ -141,7 +149,9 @@ All routes are protected and expect a `Bearer` JWT token. Service URLs for the A
    pip install -r requirements.txt
    python -m uvicorn main:app --port 5001
    ```
-   The AI agent requires its own `.env` file (see `ai-agent/.env.example`) with `MONGO_URI` and, optionally, `OPENAI_API_KEY`.
+   The AI agent requires its own `.env` file (see `ai-agent/.env.example`) with
+   authenticated TLS settings for MongoDB (`MONGO_URI`, `MONGO_USER`,
+   `MONGO_PASS`, and `MONGO_CA_FILE`) and, optionally, `OPENAI_API_KEY`.
 4. Start the eligibility engine
    ```bash
    cd eligibility-engine

--- a/SECURITY_REPORT.md
+++ b/SECURITY_REPORT.md
@@ -6,8 +6,9 @@
 - Secured the `/llm-debug/{session_id}` endpoint behind authentication and environment flag.
 - Hardened file uploads in AI Analyzer with size limits (5MB) and ClamAV virus scanning.
 - Enforced authenticated inter-service communication by sending `X-API-Key` headers and defaulting internal URLs to HTTPS.
-- Improved MongoDB security with optional username/password and TLS support.
+- Enforced MongoDB authentication and TLS across services and documented least-privilege roles.
 - Added simple in-memory rate limiting middleware to the Express server.
+ - Added a script to verify MongoDB TLS connectivity (`npm run verify:mongo`).
 
 ## Further Recommendations
 

--- a/ai-agent/.env.example
+++ b/ai-agent/.env.example
@@ -1,2 +1,5 @@
-MONGO_URI=mongodb://localhost:27017
+MONGO_URI=mongodb://mongo:27017/ai_agent?authSource=admin&tls=true
+MONGO_USER=agentUser
+MONGO_PASS=strongPassword
+MONGO_CA_FILE=/path/to/ca.pem
 OPENAI_API_KEY=your_openai_api_key

--- a/ai-agent/README.md
+++ b/ai-agent/README.md
@@ -12,10 +12,14 @@ uvicorn main:app --reload
 ```
 
 Create a `.env` file in this directory (you can copy from `.env.example`) and set
-your MongoDB connection string and optional OpenAI API key:
+credentials for an authenticated, TLS-enabled MongoDB connection along with an
+optional OpenAI API key:
 
 ```
-MONGO_URI=mongodb://localhost:27017
+MONGO_URI=mongodb://mongo:27017/ai_agent?authSource=admin&tls=true
+MONGO_USER=agentUser
+MONGO_PASS=strongPassword
+MONGO_CA_FILE=/path/to/ca.pem
 OPENAI_API_KEY=your_api_key_here
 ```
 

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -3,12 +3,24 @@ from typing import Dict, Any, List
 from pymongo import MongoClient
 import os
 
+# Require explicit credentials and TLS for all connections
 MONGO_URI = os.getenv("MONGO_URI")
-if not MONGO_URI and os.getenv("NODE_ENV") == "development":
-    MONGO_URI = "mongodb://localhost:27017"
-if not MONGO_URI:
-    raise ValueError("MONGO_URI environment variable is not set")
-client = MongoClient(MONGO_URI)
+MONGO_USER = os.getenv("MONGO_USER")
+MONGO_PASS = os.getenv("MONGO_PASS")
+MONGO_CA_FILE = os.getenv("MONGO_CA_FILE")
+
+if not all([MONGO_URI, MONGO_USER, MONGO_PASS]):
+    raise ValueError("MONGO_URI, MONGO_USER, and MONGO_PASS must be set")
+
+client = MongoClient(
+    MONGO_URI,
+    username=MONGO_USER,
+    password=MONGO_PASS,
+    tls=True,
+    tlsCAFile=MONGO_CA_FILE,
+    authSource=os.getenv("MONGO_AUTH_DB", "admin"),
+    tlsAllowInvalidCertificates=False,
+)
 db = client["ai_agent"]
 collection = db["session_memory"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,22 @@ services:
     restart: always
     ports:
       - '27017:27017'
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=mongoAdmin
+      - MONGO_INITDB_ROOT_PASSWORD=changeMe
+    command: ["mongod", "--auth", "--tlsMode", "requireTLS", "--tlsCertificateKeyFile", "/etc/mongo/certs/mongo.pem", "--tlsCAFile", "/etc/mongo/certs/ca.pem"]
+    volumes:
+      - ./mongo-certs:/etc/mongo/certs:ro
 
   server:
     build: ./server
     ports:
       - '5000:5000'
     environment:
-      - MONGO_URI=mongodb://mongo:27017/grants
+      - MONGO_URI=mongodb://mongo:27017/grants?authSource=admin&tls=true
+      - MONGO_USER=serverUser
+      - MONGO_PASS=serverPass
+      - MONGO_CA_FILE=/etc/mongo/ca.pem
       - JWT_SECRET=devsecret
       - AI_ANALYZER_URL=https://ai-analyzer:8000
       - ELIGIBILITY_ENGINE_URL=https://eligibility-engine:4001
@@ -20,6 +29,8 @@ services:
       - mongo
       - ai-agent
       - ai-analyzer
+    volumes:
+      - ./mongo-certs/ca.pem:/etc/mongo/ca.pem:ro
 
   eligibility-engine:
     build: ./eligibility-engine
@@ -35,7 +46,12 @@ services:
     depends_on:
       - eligibility-engine
     environment:
-      - MONGO_URI=mongodb://mongo:27017/grants
+      - MONGO_URI=mongodb://mongo:27017/ai_agent?authSource=admin&tls=true
+      - MONGO_USER=agentUser
+      - MONGO_PASS=agentPass
+      - MONGO_CA_FILE=/etc/mongo/ca.pem
+    volumes:
+      - ./mongo-certs/ca.pem:/etc/mongo/ca.pem:ro
 
   ai-analyzer:
     build: ./ai-analyzer

--- a/docs/mongo-security.md
+++ b/docs/mongo-security.md
@@ -1,0 +1,47 @@
+# MongoDB Security Configuration
+
+This project requires MongoDB authentication and TLS for all services.
+
+## Server configuration
+
+1. Generate a certificate authority and server certificate (see `mongo-certs/README.md`).
+2. Start MongoDB with authentication and TLS. The provided `docker-compose.yml`
+   uses `mongod --auth --tlsMode requireTLS` and mounts the certificate files.
+3. Create dedicated users for each service with the least privileges needed. For
+   example:
+   ```js
+   use grants;
+   db.createUser({
+     user: "serverUser",
+     pwd:  "strongPassword",
+     roles: [{ role: "readWrite", db: "grants" }]
+   });
+   use ai_agent;
+   db.createUser({
+     user: "agentUser",
+     pwd:  "strongPassword",
+     roles: [{ role: "readWrite", db: "ai_agent" }]
+   });
+   ```
+
+## Application configuration
+
+Each service expects the following environment variables:
+
+```bash
+MONGO_URI=mongodb://mongo:27017/<db>?authSource=admin&tls=true
+MONGO_USER=<serviceUser>
+MONGO_PASS=<servicePassword>
+MONGO_CA_FILE=/path/to/ca.pem
+```
+
+The CA file is used to verify the TLS certificate presented by MongoDB. `MONGO_URI`
+should include `tls=true` to enforce encrypted connections.
+
+## Validation
+
+Run `npm run verify:mongo` from the `server` directory to confirm that the
+application can connect using TLS. The script will fail if authentication or
+encryption is misconfigured. Additionally, try connecting without a password or
+with `tls=false` and confirm that the connection is rejected. Users created for
+one service should not be able to access databases belonging to another.

--- a/mongo-certs/README.md
+++ b/mongo-certs/README.md
@@ -1,0 +1,3 @@
+Place `mongo.pem` (server certificate and key) and `ca.pem` (certificate authority)
+files in this directory before starting the stack. These files are mounted into
+the MongoDB container and used to enforce TLS.

--- a/server/config/connectDB.js
+++ b/server/config/connectDB.js
@@ -3,15 +3,25 @@ require('dotenv').config(); // טען את קובץ ה־.env (אם זה לא נ�
 
 const connectDB = async () => {
   try {
-    const mongoURI =
-      process.env.MONGO_URI ||
-      (process.env.NODE_ENV === 'development' ? 'mongodb://localhost:27017/grants' : '');
+    const mongoURI = process.env.MONGO_URI;
 
     if (!mongoURI) {
       throw new Error('MONGO_URI environment variable is not set');
     }
+    if (!process.env.MONGO_USER || !process.env.MONGO_PASS) {
+      throw new Error('MONGO_USER and MONGO_PASS must be set');
+    }
+    if (!process.env.MONGO_CA_FILE) {
+      throw new Error('MONGO_CA_FILE must be set for TLS');
+    }
 
-    const conn = await mongoose.connect(mongoURI);
+    const conn = await mongoose.connect(mongoURI, {
+      user: process.env.MONGO_USER,
+      pass: process.env.MONGO_PASS,
+      authSource: process.env.MONGO_AUTH_DB || 'admin',
+      tls: true,
+      tlsCAFile: process.env.MONGO_CA_FILE,
+    });
     console.log(`✅ MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {
     console.error(`❌ MongoDB Connection Error: ${error.message}`);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "test": "node --test --experimental-test-coverage > coverage.txt && node scripts/check-coverage.js coverage.txt"
+    "test": "node --test --experimental-test-coverage > coverage.txt && node scripts/check-coverage.js coverage.txt",
+    "verify:mongo": "node scripts/verify-mongo-tls.js"
   },
   "dependencies": {
     "bcryptjs": "3.0.2",

--- a/server/scripts/verify-mongo-tls.js
+++ b/server/scripts/verify-mongo-tls.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+(async () => {
+  try {
+    const conn = await mongoose.connect(process.env.MONGO_URI, {
+      user: process.env.MONGO_USER,
+      pass: process.env.MONGO_PASS,
+      authSource: process.env.MONGO_AUTH_DB || 'admin',
+      tls: true,
+      tlsCAFile: process.env.MONGO_CA_FILE,
+    });
+    const tlsEnabled = conn.connection.client.s.options.tls === true;
+    if (!tlsEnabled) {
+      throw new Error('TLS not enabled');
+    }
+    console.log('✅ MongoDB connection verified with TLS');
+    await conn.disconnect();
+  } catch (err) {
+    console.error('❌ MongoDB verification failed:', err.message);
+    process.exit(1);
+  }
+})();

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -2,30 +2,28 @@ const mongoose = require('mongoose');
 
 const connectDB = async () => {
   try {
-    const mongoURI =
-      process.env.MONGO_URI ||
-      (process.env.NODE_ENV === 'development'
-        ? 'mongodb://localhost:27017/grants'
-        : '');
+    const mongoURI = process.env.MONGO_URI;
     mongoose.set('strictQuery', false);
 
     if (!mongoURI) {
       throw new Error('MONGO_URI environment variable is not set');
     }
+    if (!process.env.MONGO_USER || !process.env.MONGO_PASS) {
+      throw new Error('MONGO_USER and MONGO_PASS must be set');
+    }
+    if (!process.env.MONGO_CA_FILE) {
+      throw new Error('MONGO_CA_FILE must be set for TLS');
+    }
 
     const options = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
+      user: process.env.MONGO_USER,
+      pass: process.env.MONGO_PASS,
+      authSource: process.env.MONGO_AUTH_DB || 'admin',
+      tls: true,
+      tlsCAFile: process.env.MONGO_CA_FILE,
     };
-    if (process.env.MONGO_USER && process.env.MONGO_PASS) {
-      options.auth = {
-        username: process.env.MONGO_USER,
-        password: process.env.MONGO_PASS,
-      };
-    }
-    if (process.env.MONGO_TLS === 'true') {
-      options.tls = true;
-    }
     const conn = await mongoose.connect(mongoURI, options);
 
     console.log(`✅ MongoDB Connected: ${conn.connection.host}`);


### PR DESCRIPTION
## Summary
- require username/password and CA file for MongoDB in server and ai-agent connections
- provision MongoDB with auth & TLS via docker-compose and pass least-privilege credentials to services
- document secure MongoDB setup and add script to verify TLS connectivity

## Testing
- `python -m py_compile ai-agent/session_memory.py`
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965fa95e74832e97f8aa7390016d38