### PR TITLE
feat: enforce exact origin in CSRF middleware

### DIFF
--- a/server/middleware/csrf.js
+++ b/server/middleware/csrf.js
@@ -1,7 +1,19 @@
 const crypto = require('crypto');
 const parseCookies = require('../utils/cookies');
 
+// Parse the configured frontend URL once and compare using URL.origin to avoid
+// subdomain spoofing or partial matches.
 const allowedOrigin = process.env.FRONTEND_URL || 'https://localhost:3000';
+const allowedUrl = new URL(allowedOrigin);
+
+function isValidOrigin(value) {
+  try {
+    const url = new URL(value);
+    return url.origin === allowedUrl.origin;
+  } catch (e) {
+    return false;
+  }
+}
 
 function generateCsrfToken() {
   return crypto.randomBytes(24).toString('hex');
@@ -15,12 +27,11 @@ function csrfProtection(req, res, next) {
   const cookies = parseCookies(req.headers.cookie || '');
   const csrfCookie = cookies['csrfToken'];
   const csrfHeader = req.headers['x-csrf-token'];
-  const origin = req.headers.origin || '';
-  const referer = req.headers.referer || '';
-  if (
-    (origin && !origin.startsWith(allowedOrigin)) &&
-    (referer && !referer.startsWith(allowedOrigin))
-  ) {
+  const origin = req.headers.origin;
+  const referer = req.headers.referer;
+  const originValid = origin ? isValidOrigin(origin) : false;
+  const refererValid = referer ? isValidOrigin(referer) : false;
+  if (!originValid && !refererValid) {
     return res.status(403).json({ message: 'Invalid origin' });
   }
   if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {

--- a/server/tests/csrf-origin.test.js
+++ b/server/tests/csrf-origin.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+require('./testEnvSetup');
+const app = require('../index');
+
+async function getCsrf(port) {
+  const res = await fetch(`http://localhost:${port}/api/auth/csrf-token`, {
+    headers: { Origin: 'https://localhost:3000' },
+  });
+  const cookie = res.headers.get('set-cookie') || '';
+  const token = cookie.split(';')[0].split('=')[1];
+  return { token, cookie: cookie.split(',')[0] };
+}
+
+test('rejects requests from subdomain origin', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const csrf = await getCsrf(port);
+  const res = await fetch(`http://localhost:${port}/echo`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': csrf.token,
+      Cookie: csrf.cookie,
+      Origin: 'https://evil.localhost:3000'
+    },
+    body: JSON.stringify({ test: 1 })
+  });
+  assert.strictEqual(res.status, 403);
+  server.close();
+});
+
+test('accepts request from exact allowed origin', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const csrf = await getCsrf(port);
+  const res = await fetch(`http://localhost:${port}/echo`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': csrf.token,
+      Cookie: csrf.cookie,
+      Origin: 'https://localhost:3000'
+    },
+    body: JSON.stringify({ ok: 1 })
+  });
+  assert.strictEqual(res.status, 200);
+  server.close();
+});
+
+test('rejects when origin and referer missing', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const csrf = await getCsrf(port);
+  const res = await fetch(`http://localhost:${port}/echo`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': csrf.token,
+      Cookie: csrf.cookie
+    },
+    body: JSON.stringify({ test: 1 })
+  });
+  assert.strictEqual(res.status, 403);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- validate request origin/referrer using exact URL match to prevent subdomain spoofing
- require origin or referer headers to be present and match allowed frontend origin
- add unit tests covering valid origins, subdomain rejection, and missing origin/referer

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`
- `grep -n "subdomain origin" coverage.txt`
- `grep -n "exact allowed origin" coverage.txt`
- `grep -n "origin and referer missing" coverage.txt`


------
https://chatgpt.com/codex/tasks/task_b_689a675a7644832786567a5c24d431b5