### PR TITLE
Secure /metrics and /echo endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ curl -k -H "Authorization: Bearer <token>" https://localhost:5000/api/users
 
 A missing or invalid token results in **401 Unauthorized**.
 
+The utility `/echo` endpoint is likewise protected and requires a valid JWT. Prometheus metrics at `/metrics` are secured with
+HTTP Basic auth; set `METRICS_BASIC_AUTH=user:pass` and scrape with `curl -u user:pass http://localhost:5000/metrics`.
+
 JWT payloads also contain a user's `role` (`user` or `admin`). The backend exposes a
 `requireRole('admin')` middleware used by admin-only endpoints such as
 `POST /api/form-template`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,4 +11,12 @@ export OTEL_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ```
 
-When enabled, visit `/metrics` on each service for Prometheus metrics. Traces are sent to the OTLP endpoint.
+Set `METRICS_BASIC_AUTH` to a `user:password` pair to enable HTTP Basic authentication on the `/metrics` endpoint. Requests
+without the correct credentials receive **401 Unauthorized**.
+
+```bash
+export METRICS_BASIC_AUTH=metrics:secret
+curl -u metrics:secret http://localhost:5000/metrics
+```
+
+When enabled, scrape `/metrics` on each service for Prometheus metrics. Traces are sent to the OTLP endpoint.

--- a/eligibility-engine/test_observability.py
+++ b/eligibility-engine/test_observability.py
@@ -2,6 +2,7 @@ import os
 from importlib import reload
 import api
 from fastapi.testclient import TestClient
+import env_setup  # ENV VALIDATION: seed env vars
 
 
 def reload_app():
@@ -13,7 +14,7 @@ def test_metrics_disabled():
     os.environ.pop('OBSERVABILITY_ENABLED', None)
     os.environ.pop('PROMETHEUS_METRICS_ENABLED', None)
     client = reload_app()
-    res = client.get('/metrics')
+    res = client.get('/metrics', headers={'X-API-Key': 'test-key'})
     assert res.status_code == 404
 
 
@@ -22,6 +23,8 @@ def test_metrics_enabled():
     os.environ['PROMETHEUS_METRICS_ENABLED'] = 'true'
     client = reload_app()
     res = client.get('/metrics')
+    assert res.status_code == 401
+    res = client.get('/metrics', headers={'X-API-Key': 'test-key'})
     assert res.status_code == 200
 
 

--- a/server/tests/observability.test.js
+++ b/server/tests/observability.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 require('./testEnvSetup');
 const { logs } = require('../utils/logger');
+const jwt = require('jsonwebtoken');
 
 async function startApp() {
   delete require.cache[require.resolve('../index')];
@@ -17,26 +18,58 @@ async function startApp() {
 test('metrics route disabled by default', async () => {
   delete process.env.OBSERVABILITY_ENABLED;
   delete process.env.PROMETHEUS_METRICS_ENABLED;
+  delete process.env.METRICS_BASIC_AUTH;
   const { server, port } = await startApp();
   const res = await fetch(`http://localhost:${port}/metrics`);
   assert.strictEqual(res.status, 404);
   server.close();
 });
 
-test('metrics route enabled with flags', async () => {
+test('metrics route requires auth when enabled', async () => {
   process.env.OBSERVABILITY_ENABLED = 'true';
   process.env.PROMETHEUS_METRICS_ENABLED = 'true';
+  process.env.METRICS_BASIC_AUTH = 'user:pass';
   const { server, port } = await startApp();
   const res = await fetch(`http://localhost:${port}/metrics`);
-  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.status, 401);
+  const auth = Buffer.from('user:pass').toString('base64');
+  const res2 = await fetch(`http://localhost:${port}/metrics`, {
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  assert.strictEqual(res2.status, 200);
   server.close();
 });
+
+async function getCsrf(port) {
+  const res = await fetch(`http://localhost:${port}/api/auth/csrf-token`, {
+    headers: { Origin: 'https://localhost:3000' },
+  });
+  const cookie = res.headers.get('set-cookie') || '';
+  const token = cookie.split(';')[0].split('=')[1];
+  return { token, cookie: cookie.split(',')[0] };
+}
 
 test('request id echoed and logged', async () => {
   process.env.REQUEST_ID_ENABLED = 'true';
   process.env.REQUEST_LOG_JSON = 'true';
   const { server, port } = await startApp();
-  const res = await fetch(`http://localhost:${port}/echo`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Request-Id': 'abc' }, body: '{}' });
+  const csrf = await getCsrf(port);
+  const token = jwt.sign(
+    { userId: '1', email: 'a', role: 'user' },
+    process.env.JWT_SECRET,
+    { expiresIn: '10m' }
+  );
+  const res = await fetch(`http://localhost:${port}/echo`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'abc',
+      'x-csrf-token': csrf.token,
+      Cookie: `${csrf.cookie}; accessToken=${token}`,
+      Origin: 'https://localhost:3000',
+    },
+    body: '{}',
+  });
   assert.strictEqual(res.headers.get('x-request-id'), 'abc');
   server.close();
   const entry = logs.find((l) => l.reqId === 'abc');


### PR DESCRIPTION
## Summary
- require authentication on test `/echo` route
- protect `/metrics` with mandatory basic auth
- document new access requirements

## Testing
- `npm --prefix server test`
- `pytest` *(fails: ForwardRef._evaluate() missing recursive_guard)*

------
https://chatgpt.com/codex/tasks/task_b_689b4583e0d083279d8883a0da089b6a