### PR TITLE
Harden logging and debug handling

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,11 @@
+# Secure Logging Practices
+
+The platform uses centralized loggers for all services. These loggers automatically redact sensitive fields (password, token, email, name, address, phone, IP) and hash IP addresses. To keep logs safe:
+
+- **Never** log full request bodies or user supplied content. Log only high level metadata such as field names or counts.
+- Use the provided logger modules instead of `console.log` or `print`.
+- Error messages from external services should be truncated to avoid leaking PII.
+- Debug endpoints like `/llm-debug/{session_id}` are disabled by default and require both authentication and an `ENABLE_DEBUG=true` environment flag.
+- Production environments should run with info logs suppressed. Set `LOG_LEVEL` to increase verbosity only when needed.
+
+Adhering to a formal logging policy helps ensure consistent, privacy‑preserving output across the system.

--- a/eligibility-engine/engine.py
+++ b/eligibility-engine/engine.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 import json
 from typing import List, Dict, Any
-import logging
+from common.logger import get_logger
 
 from grants_loader import load_grants
 from rules_utils import check_rules, check_rule_groups, estimate_award
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def analyze_eligibility(
@@ -102,4 +101,4 @@ if __name__ == "__main__":
     else:
         payload = {}
     for result in analyze_eligibility(payload, explain=True):
-        print(result)
+        logger.debug("sample_result", extra={"fields": list(result.keys())})

--- a/eligibility-engine/run_check.py
+++ b/eligibility-engine/run_check.py
@@ -2,17 +2,20 @@ import json
 import sys
 from pathlib import Path
 from engine import analyze_eligibility
+from common.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python run_check.py <payload.json>")
+        logger.error("usage", extra={"cmd": "python run_check.py <payload.json>"})
         sys.exit(1)
     payload_path = Path(sys.argv[1])
     with payload_path.open("r", encoding="utf-8") as f:
         data = json.load(f)
     results = analyze_eligibility(data, explain=True)
-    print(json.dumps(results, indent=2))
+    logger.info("eligibility_results", extra={"count": len(results)})
 
 
 if __name__ == "__main__":

--- a/server/config/connectDB.js
+++ b/server/config/connectDB.js
@@ -21,9 +21,11 @@ const connectDB = async () => {
       tls: true,
       tlsCAFile: process.env.MONGO_CA_FILE,
     });
-    console.log(`✅ MongoDB Connected: ${conn.connection.host}`);
+    const logger = require('../utils/logger');
+    logger.info('mongo_connected', { host: conn.connection.host });
   } catch (error) {
-    console.error(`❌ MongoDB Connection Error: ${error.message}`);
+    const logger = require('../utils/logger');
+    logger.error('mongo_error', { error: error.message });
     process.exit(1); // עצור את התהליך אם החיבור נכשל
   }
 };

--- a/server/scripts/check-coverage.js
+++ b/server/scripts/check-coverage.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
+const logger = require('../utils/logger');
 const text = fs.readFileSync(process.argv[2], 'utf8');
 const match = text.match(/# all files\s*\|\s*(\d+\.\d+)\s*\|\s*(\d+\.\d+)\s*\|\s*(\d+\.\d+)\s*\|/);
 if (!match) {
-  console.error('Coverage summary not found');
+  logger.error('coverage_summary_missing');
   process.exit(1);
 }
 const lines = parseFloat(match[1]);
@@ -10,8 +11,8 @@ const branches = parseFloat(match[2]);
 const funcs = parseFloat(match[3]);
 const threshold = 50; // coverage threshold
 if (lines < threshold || branches < threshold || funcs < threshold) {
-  console.error(`Coverage below threshold: lines ${lines}, branches ${branches}, funcs ${funcs}`);
+  logger.error('coverage_below_threshold', { lines, branches, funcs });
   process.exit(1);
 }
-console.log(`Coverage check passed: lines ${lines}, branches ${branches}, funcs ${funcs}`);
+logger.info('coverage_check_passed', { lines, branches, funcs });
 

--- a/server/scripts/migrateFormTemplates.js
+++ b/server/scripts/migrateFormTemplates.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const FormTemplate = require('../models/FormTemplate');
 const Case = require('../models/Case');
+const logger = require('../utils/logger');
 
 async function run() {
   const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/grant';
@@ -30,10 +31,10 @@ async function run() {
     await c.save();
   }
   await mongoose.disconnect();
-  console.log('migration complete');
+  logger.info('migration_complete');
 }
 
 run().catch((err) => {
-  console.error(err);
+  logger.error('migration_failed', { error: err.message });
   process.exit(1);
 });

--- a/server/scripts/verify-mongo-tls.js
+++ b/server/scripts/verify-mongo-tls.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const logger = require('../utils/logger');
 
 (async () => {
   try {
@@ -13,10 +14,10 @@ const mongoose = require('mongoose');
     if (!tlsEnabled) {
       throw new Error('TLS not enabled');
     }
-    console.log('✅ MongoDB connection verified with TLS');
+    logger.info('mongo_tls_verified');
     await conn.disconnect();
   } catch (err) {
-    console.error('❌ MongoDB verification failed:', err.message);
+    logger.error('mongo_tls_verify_failed', { error: err.message });
     process.exit(1);
   }
 })();

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -26,9 +26,11 @@ const connectDB = async () => {
     };
     const conn = await mongoose.connect(mongoURI, options);
 
-    console.log(`✅ MongoDB Connected: ${conn.connection.host}`);
+    const logger = require('./logger');
+    logger.info('mongo_connected', { host: conn.connection.host });
   } catch (error) {
-    console.error(`❌ MongoDB Error: ${error.message}`);
+    const logger = require('./logger');
+    logger.error('mongo_error', { error: error.message });
     process.exit(1);
   }
 };

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,14 +1,32 @@
 // SECURITY FIX: add recursive PII redaction and suppress info logs in production
+const crypto = require('crypto');
 const logs = [];
 const PII_PATTERNS = [/name/i, /email/i, /address/i, /phone/i, /ssn/i, /password/i, /token/i, /apikey/i];
+const EMAIL_REGEX = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+const IP_REGEX = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
+
+function anonymizeIp(ip) {
+  return crypto.createHash('sha256').update(ip).digest('hex').slice(0, 8);
+}
 
 function mask(obj) {
   if (obj === null || obj === undefined) return obj;
+  if (typeof obj === 'string') {
+    if (IP_REGEX.test(obj)) return anonymizeIp(obj);
+    if (EMAIL_REGEX.test(obj)) return '[REDACTED]';
+    return obj;
+  }
   if (Array.isArray(obj)) return obj.map((v) => mask(v));
   if (typeof obj === 'object') {
     const out = {};
     for (const [k, v] of Object.entries(obj)) {
-      out[k] = PII_PATTERNS.some((p) => p.test(k)) ? '[REDACTED]' : mask(v);
+      if (/ip/i.test(k) && typeof v === 'string') {
+        out[k] = anonymizeIp(v);
+      } else if (PII_PATTERNS.some((p) => p.test(k))) {
+        out[k] = '[REDACTED]';
+      } else {
+        out[k] = mask(v);
+      }
     }
     return out;
   }


### PR DESCRIPTION
## Summary
- expand Node and Python loggers to hash IP addresses and redact PII values
- sanitize case and pipeline routes to avoid logging request bodies and truncate external errors
- replace console logs with centralized logger and document secure logging practices

## Testing
- `npm test` (server)
- `pytest` *(fails: cannot import test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_689b9e59552c83278c525c28755d27d9