### PR TITLE
Secure vault loading, logging, and pipeline tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - '27017:27017'
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=mongoAdmin
-      - MONGO_INITDB_ROOT_PASSWORD=changeMe
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
     command: ["mongod", "--auth", "--tlsMode", "requireTLS", "--tlsCertificateKeyFile", "/etc/mongo/certs/mongo.pem", "--tlsCAFile", "/etc/mongo/certs/ca.pem"]
     volumes:
       - ./mongo-certs:/etc/mongo/certs:ro
@@ -17,14 +17,14 @@ services:
     ports:
       - '5000:5000'
     environment:
-      - MONGO_URI=mongodb://mongo:27017/grants?authSource=admin&tls=true
-      - MONGO_USER=serverUser
-      - MONGO_PASS=serverPass
+      - MONGO_URI=${MONGO_URI}
+      - MONGO_USER=${MONGO_USER}
+      - MONGO_PASS=${MONGO_PASS}
       - MONGO_CA_FILE=/etc/mongo/ca.pem
-      - JWT_SECRET=devsecret
-      - AI_ANALYZER_URL=https://ai-analyzer:8000
-      - ELIGIBILITY_ENGINE_URL=https://eligibility-engine:4001
-      - AI_AGENT_URL=https://ai-agent:5001
+      - JWT_SECRET=${JWT_SECRET}
+      - AI_ANALYZER_URL=${AI_ANALYZER_URL}
+      - ELIGIBILITY_ENGINE_URL=${ELIGIBILITY_ENGINE_URL}
+      - AI_AGENT_URL=${AI_AGENT_URL}
     depends_on:
       - mongo
       - ai-agent
@@ -46,9 +46,9 @@ services:
     depends_on:
       - eligibility-engine
     environment:
-      - MONGO_URI=mongodb://mongo:27017/ai_agent?authSource=admin&tls=true
-      - MONGO_USER=agentUser
-      - MONGO_PASS=agentPass
+      - MONGO_URI=${AI_AGENT_MONGO_URI}
+      - MONGO_USER=${AI_AGENT_MONGO_USER}
+      - MONGO_PASS=${AI_AGENT_MONGO_PASS}
       - MONGO_CA_FILE=/etc/mongo/ca.pem
     volumes:
       - ./mongo-certs/ca.pem:/etc/mongo/ca.pem:ro

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -19,11 +19,13 @@ restarting the consuming service. API keys continue to support the
 `*_NEXT_API_KEY` convention for seamless rotation where both old and new keys are
 valid during the transition period.
 
+All Vault connections must use **HTTPS**; the platform will refuse to start if
+`VAULT_ADDR` is configured with `http://`.
+
 ## Server (Node.js)
 | Variable | Purpose | Example | Required | Default |
 | --- | --- | --- | --- | --- |
 | JWT_SECRET | JWT signing secret | `supersecret` | yes | - |
-| SERVER_API_KEY | API key other services use to call the server | `changeme` | yes | - |
 | AI_AGENT_API_KEY | API key for requests to AI Agent | `changeme` | yes | - |
 | AI_AGENT_NEXT_API_KEY | Next key for AI Agent during rotation | - | optional | - |
 | AI_ANALYZER_API_KEY | API key for requests to AI Analyzer | `changeme` | yes | - |

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -7,5 +7,7 @@ The platform uses centralized loggers for all services. These loggers automatica
 - Error messages from external services should be truncated to avoid leaking PII.
 - Debug endpoints like `/llm-debug/{session_id}` are disabled by default and require both authentication and an `ENABLE_DEBUG=true` environment flag.
 - Production environments should run with info logs suppressed. Set `LOG_LEVEL` to increase verbosity only when needed.
+- Client-side code uses a `safeLog` helper that truncates payloads in non-production
+  builds to prevent leaking sensitive data to browser consoles.
 
 Adhering to a formal logging policy helps ensure consistent, privacy‑preserving output across the system.

--- a/eligibility-engine/api.py
+++ b/eligibility-engine/api.py
@@ -104,7 +104,8 @@ async def check_eligibility(request: Request):
         logger.info("eligibility_check", extra={"fields": list(data.keys())})
         return result
     except Exception as e:
-        return {"error": str(e)}
+        logger.error("eligibility_check_failed", extra={"error": str(e)})
+        raise HTTPException(status_code=500, detail="internal error")
 
 
 @app.get("/grants")

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -9,20 +9,14 @@ import Protected from '@/components/Protected';
 import FormInput from '@/components/FormInput';
 import api from '@/lib/api';
 import Stepper from '@/components/Stepper';
+import { safeError, safeLog } from '@/utils/logger';
 
 const logApiError = (endpoint: string, payload: unknown, err: any) => {
-  if (process.env.NODE_ENV !== 'production') {
-    const status = err?.response?.status;
-    const data = err?.response?.data ?? err?.message;
-    console.error(`API Error on ${endpoint}`, {
-      endpoint,
-      status,
-      response: data,
-      sentPayload: payload,
-    });
-    if (data?.missing) {
-      console.error('Missing fields:', data.missing);
-    }
+  const status = err?.response?.status;
+  const data = err?.response?.data ?? err?.message;
+  safeError(`API Error on ${endpoint}`, { status, response: data });
+  if (data?.missing) {
+    safeError('Missing fields', data.missing);
   }
 };
 
@@ -152,7 +146,7 @@ export default function Questionnaire() {
       };
       await api.post('/case/questionnaire', payload);
       if (process.env.NODE_ENV !== 'production') {
-        console.log('Questionnaire submitted successfully'); // SECURITY FIX: remove sensitive payload
+        safeLog('Questionnaire submitted successfully');
       }
       sessionStorage.setItem('caseStage', 'documents');
       router.push('/dashboard/documents');

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import api from '@/lib/api'; // ← Axios instance עם baseURL מוגדר
+import { safeWarn } from '@/utils/logger';
 
 interface AuthState {
   user: any;
@@ -40,7 +41,7 @@ export const useAuth = create<AuthState>((set) => ({
       const res = await api.get('/auth/me');
       set({ user: res.data });
     } catch (err) {
-      console.warn('Auth check failed:', err);
+      safeWarn('Auth check failed', err);
       set({ user: null });
     }
   },

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,41 @@
+export function safeLog(message: string, data?: unknown) {
+  if (process.env.NODE_ENV === 'production') return;
+  if (data !== undefined) {
+    try {
+      const str = typeof data === 'string' ? data : JSON.stringify(data);
+      console.log(message, str.slice(0, 100));
+    } catch {
+      console.log(message);
+    }
+  } else {
+    console.log(message);
+  }
+}
+
+export function safeError(message: string, data?: unknown) {
+  if (process.env.NODE_ENV === 'production') return;
+  if (data !== undefined) {
+    try {
+      const str = typeof data === 'string' ? data : JSON.stringify(data);
+      console.error(message, str.slice(0, 100));
+    } catch {
+      console.error(message);
+    }
+  } else {
+    console.error(message);
+  }
+}
+
+export function safeWarn(message: string, data?: unknown) {
+  if (process.env.NODE_ENV === 'production') return;
+  if (data !== undefined) {
+    try {
+      const str = typeof data === 'string' ? data : JSON.stringify(data);
+      console.warn(message, str.slice(0, 100));
+    } catch {
+      console.warn(message);
+    }
+  } else {
+    console.warn(message);
+  }
+}

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -58,7 +58,6 @@ function getBool(name, def = false) {
 
 // Required secrets
 requireString('JWT_SECRET');
-requireString('SERVER_API_KEY');
 requireString('AI_AGENT_API_KEY');
 requireString('AI_ANALYZER_API_KEY');
 requireString('ELIGIBILITY_ENGINE_API_KEY');

--- a/server/config/vaultClient.js
+++ b/server/config/vaultClient.js
@@ -1,19 +1,53 @@
-const { execSync } = require('child_process');
+const https = require('https');
+const { URL } = require('url');
 
 function loadVaultSecrets() {
-  const addr = process.env.VAULT_ADDR || 'http://127.0.0.1:8200';
+  const addr = process.env.VAULT_ADDR;
   const token = process.env.VAULT_TOKEN;
-  const path = process.env.VAULT_SECRET_PATH;
-  if (!token || !path) return;
+  const secretPath = process.env.VAULT_SECRET_PATH;
+  if (!addr || !token || !secretPath) return;
 
-  const url = `${addr}/v1/${path}`;
-  try {
-    const out = execSync(`curl -s -H "X-Vault-Token: ${token}" ${url}`);
-    const json = JSON.parse(out.toString());
-    const data = json.data && json.data.data ? json.data.data : json.data || {};
-    Object.assign(process.env, data);
-  } catch (err) {
-    throw new Error(`Failed to load secrets from Vault: ${err.message}`);
+  const url = new URL(`/v1/${secretPath}`, addr);
+  if (url.protocol !== 'https:') {
+    throw new Error('VAULT_ADDR must use https');
+  }
+
+  const sab = new SharedArrayBuffer(4);
+  const view = new Int32Array(sab);
+  let error;
+
+  const req = https.request(
+    url,
+    { headers: { 'X-Vault-Token': token } },
+    (res) => {
+      let body = '';
+      res.on('data', (d) => (body += d));
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          error = new Error(`Vault responded with status ${res.statusCode}`);
+        } else {
+          try {
+            const json = JSON.parse(body);
+            const data = json.data && json.data.data ? json.data.data : json.data || {};
+            Object.assign(process.env, data);
+          } catch (e) {
+            error = new Error(`Invalid Vault response: ${e.message}`);
+          }
+        }
+        Atomics.store(view, 0, 1);
+        Atomics.notify(view, 0);
+      });
+    }
+  );
+  req.on('error', (err) => {
+    error = err;
+    Atomics.store(view, 0, 1);
+    Atomics.notify(view, 0);
+  });
+  req.end();
+  Atomics.wait(view, 0, 0);
+  if (error) {
+    throw new Error(`Failed to load secrets from Vault: ${error.message}`);
   }
 }
 

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,11 +1,13 @@
 const jwt = require('jsonwebtoken');
 const parseCookies = require('../utils/cookies');
+const logger = require('../utils/logger');
 
 const auth = async (req, res, next) => {
   const cookies = parseCookies(req.headers.cookie || '');
   const token = cookies['accessToken'];
 
   if (!token) {
+    logger.warn('auth_missing_token', { ip: req.ip });
     return res.status(401).json({ message: 'No token, authorization denied' });
   }
 
@@ -18,7 +20,7 @@ const auth = async (req, res, next) => {
     };
     next();
   } catch (err) {
-    console.error('JWT verify failed:', err.message);
+    logger.warn('auth_token_invalid', { ip: req.ip, error: err.message });
     return res.status(401).json({ message: 'Token is not valid' });
   }
 };

--- a/server/observability/tracing.js
+++ b/server/observability/tracing.js
@@ -1,3 +1,5 @@
+const logger = require('../utils/logger');
+
 let sdk;
 function init() {
   if (process.env.OTEL_ENABLED === 'true') {
@@ -21,7 +23,7 @@ function init() {
       });
       sdk.start();
     } catch (e) {
-      console.error('OTEL init failed', e);
+      logger.error('otel_init_failed', { error: e.message });
     }
   }
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -12,11 +12,6 @@ const parseCookies = require('../utils/cookies');
 
 const router = express.Router();
 
-// Quick test route to verify router is active
-router.get('/test', (req, res) => {
-  res.send('Auth route is active!');
-});
-
 // SECURITY FIX: provide CSRF token for initial auth requests
 router.get('/csrf-token', (req, res) => {
   const csrfToken = generateCsrfToken();

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -3,7 +3,7 @@ const multer = require('multer');
 const FormData = require('form-data');
 const fs = require('fs');
 const path = require('path');
-const fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
+const fetchFn = global.pipelineFetch || (global.fetch ? global.fetch.bind(global) : (...args) => import('node-fetch').then(({ default: f }) => f(...args)));
 const createAgent = require('../utils/tlsAgent');
 const auth = require('../middleware/authMiddleware');
 const { createCase, updateCase, getCase } = require('../utils/pipelineStore');
@@ -69,7 +69,7 @@ router.post('/submit-case', auth, upload.any(), validate(schemas.pipelineSubmit)
         ...getServiceHeaders('AI_ANALYZER'),
       };
       if (req.id) analyzerHeaders['X-Request-Id'] = req.id;
-      const resp = await fetch(analyzerUrl, {
+      const resp = await fetchFn(analyzerUrl, {
         method: 'POST',
         body: form,
         headers: analyzerHeaders,
@@ -99,7 +99,7 @@ router.post('/submit-case', auth, upload.any(), validate(schemas.pipelineSubmit)
       ...getServiceHeaders('ELIGIBILITY_ENGINE'),
     };
     if (req.id) engineHeaders['X-Request-Id'] = req.id;
-    const eligResp = await fetch(engineUrl, {
+    const eligResp = await fetchFn(engineUrl, {
       method: 'POST',
       headers: engineHeaders,
       body: JSON.stringify(normalized),
@@ -126,7 +126,7 @@ router.post('/submit-case', auth, upload.any(), validate(schemas.pipelineSubmit)
         ...getServiceHeaders('AI_AGENT'),
       };
       if (req.id) agentHeaders['X-Request-Id'] = req.id;
-      const agentResp = await fetch(agentUrl, {
+      const agentResp = await fetchFn(agentUrl, {
         method: 'POST',
         headers: agentHeaders,
         body: JSON.stringify({ form_name: formName, user_payload: normalized }),

--- a/server/tests/env.test.js
+++ b/server/tests/env.test.js
@@ -15,7 +15,6 @@ test('env validation parses values', () => {
   const dummy = path.join(__filename);
   const env = {
     JWT_SECRET: 'a',
-    SERVER_API_KEY: 'b',
     AI_AGENT_API_KEY: 'c1',
     AI_ANALYZER_API_KEY: 'c2',
     ELIGIBILITY_ENGINE_API_KEY: 'c3',
@@ -41,7 +40,6 @@ test('env validation rejects non-https service URLs', () => {
   const dummy = path.join(__filename);
   const env = {
     JWT_SECRET: 'a',
-    SERVER_API_KEY: 'b',
     AI_AGENT_API_KEY: 'c1',
     AI_ANALYZER_API_KEY: 'c2',
     ELIGIBILITY_ENGINE_API_KEY: 'c3',

--- a/server/tests/pipeline.test.js
+++ b/server/tests/pipeline.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const FormData = require('form-data');
+
+require('./testEnvSetup');
+process.env.NODE_ENV = 'test';
+
+const app = require('../index');
+
+async function getCsrf(port) {
+  const res = await fetch(`http://localhost:${port}/api/auth/csrf-token`);
+  const cookie = res.headers.get('set-cookie') || '';
+  const token = cookie.split(';')[0].split('=')[1];
+  return { cookie: cookie.split(',')[0], token };
+}
+
+test('submit-case rejects missing CSRF', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const form = new FormData();
+  const res = await fetch(`http://localhost:${port}/api/submit-case`, { method: 'POST', body: form });
+  assert.strictEqual(res.status, 403);
+  server.close();
+});
+
+test('submit-case requires auth', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const csrf = await getCsrf(port);
+  const form = new FormData();
+  form.append('businessName', 'Biz');
+  form.append('email', 'user@example.com');
+  const res = await fetch(`http://localhost:${port}/api/submit-case`, {
+    method: 'POST',
+    headers: {
+      ...form.getHeaders(),
+      'x-csrf-token': csrf.token,
+      Cookie: csrf.cookie,
+      Origin: 'https://localhost:3000',
+    },
+    body: form,
+  });
+  assert.strictEqual(res.status, 401);
+  server.close();
+});

--- a/server/tests/testEnvSetup.js
+++ b/server/tests/testEnvSetup.js
@@ -1,7 +1,6 @@
 // ENV VALIDATION: helper to seed required env vars for tests
 const dummy = __filename;
 process.env.JWT_SECRET = 'test';
-process.env.SERVER_API_KEY = 'test';
 process.env.AI_AGENT_API_KEY = 'test';
 process.env.AI_ANALYZER_API_KEY = 'test';
 process.env.ELIGIBILITY_ENGINE_API_KEY = 'test';

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fetch = (...args) => import('node-fetch').then(({ default: f }) => f(...args));
 const createAgent = require('./tlsAgent');
 const Case = require('../models/Case');
+const logger = require('./logger');
 
 function loadGrantConfig() {
   const configPath = path.join(__dirname, '../../eligibility-engine/grants_config.json');
@@ -136,7 +137,7 @@ async function computeDocuments(answers = {}) {
         });
     }
   } catch (err) {
-    console.error('computeDocuments failed:', err.message);
+    logger.error('compute_documents_failed', { error: err.message });
   }
 
   return docs;


### PR DESCRIPTION
## Summary
- replace shell-based vault secret loading with HTTPS client requiring secure VAULT_ADDR
- centralize auth logging and remove public test routes
- sanitize client logs and externalize secrets in docker-compose
- add basic pipeline route tests and document HTTPS vault requirements

## Testing
- `node --test tests/pipeline.test.js`
- `npm test` *(server)*
- `pytest` *(eligibility-engine, fails: ModuleNotFoundError: No module named 'common')*

------
https://chatgpt.com/codex/tasks/task_b_689ba7ba597c8327aa942ac0ba5e34c2