### PR TITLE
feat: skip vault in development

### DIFF
--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -1,9 +1,15 @@
 # ENV VALIDATION: centralized env settings for ai-analyzer
+from dotenv import load_dotenv
+import os
 from pydantic import BaseSettings, FilePath
-from common.vault import load_vault_secrets
 
-# Load secrets from Vault before settings are evaluated
-load_vault_secrets()
+load_dotenv()
+
+if os.environ.get("NODE_ENV") != "production":
+    print("🔹 Development mode – skipping Vault and TLS")
+else:
+    from common.vault import load_vault_secrets
+    load_vault_secrets()
 
 class Settings(BaseSettings):
     AI_ANALYZER_API_KEY: str

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -3,6 +3,7 @@ pillow==9.5.0
 fastapi==0.95.2
 uvicorn==0.22.0
 hvac==1.2.1
+python-dotenv==1.0.1
 pytest==8.0.2
 coverage==7.4.0
 flake8==6.1.0


### PR DESCRIPTION
## Summary
- load .env files by default for ai-analyzer
- skip Vault secrets in development
- document dotenv dependency

## Testing
- `pip install python-dotenv` (failed: Could not find a version that satisfies the requirement python-dotenv)
- `PYTHONPATH=. pytest ai-analyzer/tests` (fail: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard')

------
https://chatgpt.com/codex/tasks/task_b_689cba7525748327bd6c0973463be98b