### PR TITLE
feat(ai-analyzer): manual .env loading

### DIFF
--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -1,12 +1,18 @@
 # ENV VALIDATION: centralized env settings for ai-analyzer
-from dotenv import load_dotenv
 import os
 from pydantic import BaseSettings, FilePath
 
-load_dotenv()
-
 if os.environ.get("NODE_ENV") != "production":
-    print("🔹 Development mode – skipping Vault and TLS")
+    print("🔹 Development mode – loading .env manually")
+    try:
+        with open(".env") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    key, value = line.split("=", 1)
+                    os.environ[key.strip()] = value.strip()
+    except FileNotFoundError:
+        print("⚠️ .env file not found – continuing with existing environment variables")
 else:
     from common.vault import load_vault_secrets
     load_vault_secrets()

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -3,7 +3,6 @@ pillow==9.5.0
 fastapi==0.95.2
 uvicorn==0.22.0
 hvac==1.2.1
-python-dotenv==1.0.1
 pytest==8.0.2
 coverage==7.4.0
 flake8==6.1.0


### PR DESCRIPTION
## Summary
- manually parse `.env` when NODE_ENV != "production"
- remove python-dotenv from ai-analyzer dependencies

## Testing
- `pip install -r ai-analyzer/requirements.txt`
- `pytest ai-analyzer` *(fails: ForwardRef._evaluate missing recursive_guard; ModuleNotFoundError: common)*

------
https://chatgpt.com/codex/tasks/task_b_689cbf2cf26483278a8dae6edea27884