### PR TITLE
fix: adjust imports and env encoding for ai-agent

### DIFF
--- a/ai-agent/config.py
+++ b/ai-agent/config.py
@@ -19,7 +19,7 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 if NODE_ENV != "production":
     env_file = Path(__file__).resolve().parent / ".env"
     if env_file.exists():
-        for line in env_file.read_text().splitlines():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line or line.startswith("#"):
                 continue

--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -41,10 +41,7 @@ from session_memory import append_memory, get_missing_fields, save_draft_form, g
 from nlp_utils import llm_semantic_inference, llm_complete
 from grants_loader import load_grants
 
-try:
-    from .config import settings  # type: ignore
-except ImportError:  # pragma: no cover - script execution
-    from config import settings  # type: ignore
+from config import settings  # type: ignore
 
 
 def get_api_keys() -> list[str]:

--- a/ai-agent/nlp_utils.py
+++ b/ai-agent/nlp_utils.py
@@ -7,10 +7,7 @@ try:
     import openai  # type: ignore
 except Exception:  # pragma: no cover - openai optional for tests
     openai = None  # type: ignore
-try:
-    from .config import settings  # type: ignore
-except ImportError:  # pragma: no cover - script execution
-    from config import settings  # type: ignore
+from config import settings  # type: ignore
 OPENAI_API_KEY = getattr(settings, "OPENAI_API_KEY", None)
 if openai and OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY

--- a/ai-agent/session_memory.py
+++ b/ai-agent/session_memory.py
@@ -2,10 +2,7 @@
 from typing import Dict, Any, List
 from pymongo import MongoClient
 import os
-try:
-    from .config import settings  # type: ignore
-except ImportError:  # pragma: no cover
-    from config import settings  # type: ignore
+from config import settings  # type: ignore
 
 # Require explicit credentials and TLS for all connections.
 # When running tests without database credentials, the client is not created.

--- a/eligibility-engine/api.py
+++ b/eligibility-engine/api.py
@@ -9,10 +9,7 @@ import uuid
 from pathlib import Path
 from prometheus_client import Histogram, CONTENT_TYPE_LATEST, generate_latest
 from common.logger import get_logger, audit_log
-try:
-    from .config import settings  # type: ignore
-except ImportError:  # pragma: no cover
-    from config import settings  # type: ignore
+from config import settings  # type: ignore
 
 CURRENT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(CURRENT_DIR.parent))


### PR DESCRIPTION
## Summary
- replace relative imports with absolute `config` imports
- read `.env` using UTF-8 encoding to avoid decoding errors
- ensure eligibility-engine uses absolute config import

## Testing
- `PYTHONPATH=.. pytest` (ai-agent)
- `PYTHONPATH=.. pytest` (eligibility-engine) *(fails: ForwardRef._evaluate missing recursive_guard)*
- `PYTHONPATH=.. timeout 5 python -m uvicorn main:app --reload --port 8001`


------
https://chatgpt.com/codex/tasks/task_b_689cd7ba99d4832784293659f18bff50