### PR TITLE
chore: add startup debug logs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@
 
 // ===== Load & Validate ENV =====
 const env = require('./config/env'); // Loads .env and validates values
+console.log('DEBUG: Environment variables loaded');
 console.log('=== Loaded ENV Variables ===');
 console.log({
   PORT: env.PORT,
@@ -196,6 +197,7 @@ function startServer() {
       logger.info(`🔐 HTTPS server running on port ${PORT}`);
     });
   } else {
+    console.log('DEBUG: Before app.listen');
     app.listen(PORT, () => {
       logger.info(`🚀 Server running on port ${PORT}`);
     });
@@ -203,8 +205,12 @@ function startServer() {
 }
 
 if (process.env.SKIP_DB !== 'true') {
+  console.log('DEBUG: Before Mongo connection');
   connectDB()
-    .then(startServer)
+    .then(() => {
+      console.log('DEBUG: After Mongo connection');
+      startServer();
+    })
     .catch((err) => {
       logger.error('❌ Failed to connect to MongoDB', { error: err.message });
       process.exit(1);


### PR DESCRIPTION
## Summary
- add debug checkpoints for env load, Mongo connection, and server start

## Testing
- `node server/index.js` (fails: Cannot find module 'dotenv')
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_b_689e579451188327ac796365e9b25806