### PR TITLE
feat: improve MongoDB connection logging

### DIFF
--- a/server/config/connectDB.js
+++ b/server/config/connectDB.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const logger = require('../utils/logger');
 
 const connectDB = async () => {
   try {
@@ -28,13 +29,17 @@ const connectDB = async () => {
       console.log('🔹 Connecting to MongoDB using URI only (development mode)');
     }
 
+    const maskedURI = mongoURI.replace(/:\/\/[^@]*@/, '://****@');
+    console.log(`Connecting to MongoDB at ${maskedURI}`);
+
     const conn = await mongoose.connect(mongoURI, options);
-    const logger = require('../utils/logger');
+    console.log(`✅ MongoDB connection established (host: ${conn.connection.host})`);
     logger.info('mongo_connected', { host: conn.connection.host });
   } catch (error) {
-    const logger = require('../utils/logger');
-    logger.error('mongo_error', { error: error.message });
-    process.exit(1); // עצור את התהליך אם החיבור נכשל
+    console.error('❌ MongoDB connection failed');
+    console.error(error.stack);
+    logger.error('mongo_error', { error: error.stack });
+    throw error; // caller decides how to handle
   }
 };
 

--- a/server/index.js
+++ b/server/index.js
@@ -208,14 +208,15 @@ function startServer() {
 }
 
 if (process.env.SKIP_DB !== 'true') {
-  console.log('DEBUG_STARTUP: Before connecting to MongoDB');
+  console.log('DEBUG_STARTUP: Attempting MongoDB connection...');
   connectDB()
     .then(() => {
       console.log('DEBUG_STARTUP: MongoDB connection successful');
       startServer();
     })
     .catch((err) => {
-      logger.error('❌ Failed to connect to MongoDB', { error: err.message });
+      logger.error('❌ Failed to connect to MongoDB', { error: err.stack });
+      console.error('DEBUG_STARTUP: MongoDB connection failed');
       process.exit(1);
     });
 }

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const logger = require('./logger');
 
 const connectDB = async () => {
   try {
@@ -30,14 +31,18 @@ const connectDB = async () => {
       console.log('🔹 Connecting to MongoDB using URI only (development mode)');
     }
 
-    const conn = await mongoose.connect(mongoURI, options);
+    const maskedURI = mongoURI.replace(/:\/\/[^@]*@/, '://****@');
+    console.log(`Connecting to MongoDB at ${maskedURI}`);
 
-    const logger = require('./logger');
+    const conn = await mongoose.connect(mongoURI, options);
+    console.log(`✅ MongoDB connection established (host: ${conn.connection.host})`);
+
     logger.info('mongo_connected', { host: conn.connection.host });
   } catch (error) {
-    const logger = require('./logger');
-    logger.error('mongo_error', { error: error.message });
-    process.exit(1);
+    console.error('❌ MongoDB connection failed');
+    console.error(error.stack);
+    logger.error('mongo_error', { error: error.stack });
+    throw error;
   }
 };
 


### PR DESCRIPTION
## Summary
- improve diagnostic logging in both connectDB helpers, masking sensitive URI parts
- rethrow MongoDB connection errors instead of exiting to let caller decide
- add DEBUG_STARTUP logs around MongoDB connection attempt in server startup

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689e5f222420832795a0874f1b257d7b