### PR TITLE
fix FastAPI dependency declarations in ai-agent

### DIFF
--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -65,7 +65,10 @@ class FormFillRequest(BaseModel):
     session_id: str | None = None
 
 
-app = FastAPI(title="AI Agent Service", dependencies=[Depends(require_internal_key), rate_limiter("ai-agent")])
+app = FastAPI(
+    title="AI Agent Service",
+    dependencies=[Depends(require_internal_key), Depends(rate_limiter("ai-agent"))],
+)
 try:
     app.middleware("http")(request_id_middleware)
 except AttributeError:


### PR DESCRIPTION
## Summary
- wrap rate limiter dependency with `Depends()` in ai-agent's FastAPI app

## Testing
- `pytest` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard')*


------
https://chatgpt.com/codex/tasks/task_b_68a34a3476a08327b20a2fc9fb58e603