### PR TITLE
fix: migrate BaseSettings import to pydantic-settings

### DIFF
--- a/ai-agent/config.py
+++ b/ai-agent/config.py
@@ -1,5 +1,6 @@
 # ENV VALIDATION: centralized env settings for ai-agent
-from pydantic import BaseSettings, AnyUrl, FilePath, Field
+from pydantic_settings import BaseSettings
+from pydantic import AnyUrl, FilePath, Field
 import os
 
 # ``common`` lives one directory above this service. When tests import the

--- a/ai-agent/requirements.txt
+++ b/ai-agent/requirements.txt
@@ -8,3 +8,4 @@ pymongo==4.6.3
 pytest==8.0.2
 coverage==7.4.0
 flake8==6.1.0
+pydantic-settings

--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -1,7 +1,7 @@
 # ENV VALIDATION: centralized env settings for ai-analyzer
 import os
 from pathlib import Path
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 # Determine which env file to load. Order of resolution:
 # 1. ENV_FILE if set

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -5,3 +5,4 @@ uvicorn==0.22.0
 pytest==8.0.2
 coverage==7.4.0
 flake8==6.1.0
+pydantic-settings

--- a/eligibility-engine/config.py
+++ b/eligibility-engine/config.py
@@ -1,5 +1,5 @@
 # ENV VALIDATION: centralized env settings for eligibility-engine
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 import os
 from pathlib import Path
 from dotenv import load_dotenv

--- a/eligibility-engine/requirements.txt
+++ b/eligibility-engine/requirements.txt
@@ -4,3 +4,4 @@ pytest==8.0.2
 coverage==7.4.0
 flake8==6.1.0
 prometheus-client==0.20.0
+pydantic-settings


### PR DESCRIPTION
## Summary
- use `pydantic-settings` as the source of `BaseSettings`
- include `pydantic-settings` in service requirements

## Testing
- `pytest` (eligibility-engine)
- `pytest` (ai-agent)
- `pytest` (ai-analyzer)


------
https://chatgpt.com/codex/tasks/task_b_68a35c26fafc832783561e70f946ada9