### PR TITLE
Redirect login to dashboard and add 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ The backend uses `AI_ANALYZER_URL`, `ELIGIBILITY_ENGINE_URL` and `AI_AGENT_URL` 
 4. When all documents are uploaded, click **Submit for Analysis** to see eligibility results.
 
 ![Dashboard Flow](frontend/public/dashboard-placeholder.svg)
-![Login Screen](frontend/public/login-placeholder.svg)
 ![Document Upload](frontend/public/upload-placeholder.svg)
 
 ## Docker Compose

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,6 @@
+// Redirect /login to /dashboard
+import { redirect } from 'next/navigation';
+
+export default function LoginRedirect() {
+  redirect('/dashboard');
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,9 @@
+export default function NotFound() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Page not found</h1>
+      <p className="mt-2">This page doesn’t exist.</p>
+      <a className="underline mt-4 inline-block" href="/dashboard">Go to Dashboard</a>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
       <p className="mb-8">Accelerate your funding process with AI-powered tools.</p>
       <div className="space-x-4">
         <a href="/register" className="px-4 py-2 bg-blue-600 text-white rounded">Get Started</a>
-        <a href="/login" className="px-4 py-2 border rounded">Login</a>
+        <a href="/dashboard" className="px-4 py-2 border rounded">Dashboard</a>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- redirect legacy `/login` route to `/dashboard`
- add friendly not-found page
- update homepage links and docs to drop stale login references

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4921fc3488327a2cebbae4ca2c0e1