### PR TITLE
fix: add utils logger alias

### DIFF
--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -3,7 +3,7 @@ export function safeLog(...args: any[]) {
   try {
     console.log(...args);
   } catch {
-    /* ignore */
+    /* no-op */
   }
 }
 
@@ -11,6 +11,6 @@ export function safeError(...args: any[]) {
   try {
     console.error(...args);
   } catch {
-    /* ignore */
+    /* no-op */
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -24,14 +24,8 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/components/*": [
-        "src/components/*"
-      ],
-      "@/lib/*": [
-        "src/lib/*"
-      ],
-      "@/hooks/*": [
-        "src/hooks/*"
+      "@/*": [
+        "src/*"
       ]
     },
     "plugins": [
@@ -42,8 +36,7 @@
   },
   "include": [
     "next-env.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx",
+    "src/**/*",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- fix unsafe logger fallback comment and ensure utility exists
- simplify tsconfig path alias to allow `@/utils/logger`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a49d9d83a08327bc8c839bff4cb92a