### PR TITLE
Integrate analyzer, eligibility, and form fill pipeline

### DIFF
--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -26,6 +26,7 @@ const schemas = {
     businessName: { required: true, type: 'string', min: 1, max: 200 },
     email: { required: true, type: 'string', pattern: /^[^@]+@[^@]+\.[^@]+$/ },
     phone: { required: true, type: 'string', min: 7, max: 20 },
+    caseId: { required: false, type: 'string', min: 1, max: 100 },
   },
 };
 

--- a/server/models/PipelineCase.js
+++ b/server/models/PipelineCase.js
@@ -1,9 +1,16 @@
 const mongoose = require('mongoose');
 
 const pipelineSchema = new mongoose.Schema({
-  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  // Use simple string identifiers for now since auth is not implemented
+  userId: { type: String, required: true },
+  // External case identifier provided by clients
+  caseId: { type: String, unique: true },
   status: { type: String, default: 'received' },
+  // Raw fields extracted from the analyzer step
+  analyzer: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // Normalized payload combining user answers + analyzer output
   normalized: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // Full eligibility results returned by the eligibility engine
   eligibility: { type: mongoose.Schema.Types.Mixed, default: null },
   documents: { type: [mongoose.Schema.Types.Mixed], default: [] },
   generatedForms: {
@@ -16,7 +23,7 @@ const pipelineSchema = new mongoose.Schema({
     ],
     default: [],
   },
-  createdAt: { type: Date, default: Date.now }
+  createdAt: { type: Date, default: Date.now },
 });
 
 module.exports = mongoose.model('PipelineCase', pipelineSchema);

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -1,13 +1,27 @@
 const express = require('express');
+const { getCase, getLatestCase } = require('../utils/pipelineStore');
+
 const router = express.Router();
 
-function caseStatusHandler(req, res) {
+async function caseStatusHandler(req, res) {
+  const userId = 'dev-user';
+  const caseId = req.query.caseId;
+  let c;
+  if (caseId) {
+    c = await getCase(userId, caseId);
+  } else {
+    c = await getLatestCase(userId);
+  }
+  if (!c) return res.status(404).json({ message: 'Case not found' });
   res.json({
-    caseId: 'dev-case',
-    status: 'open',
-    requiredDocuments: [],
-    eligibility: null,
-    lastUpdated: new Date().toISOString(),
+    caseId: c.caseId,
+    createdAt: c.createdAt,
+    status: c.status,
+    analyzer: c.analyzer,
+    eligibility: c.eligibility,
+    generatedForms: c.generatedForms,
+    documents: c.documents,
+    normalized: c.normalized,
   });
 }
 

--- a/server/utils/pipelineStore.js
+++ b/server/utils/pipelineStore.js
@@ -1,16 +1,55 @@
 const PipelineCase = require('../models/PipelineCase');
 
-async function createCase(userId) {
-  const doc = await PipelineCase.create({ userId });
-  return doc.id;
+const useMemory = process.env.SKIP_DB === 'true';
+const memoryStore = new Map();
+
+async function createCase(userId, caseId) {
+  const id = caseId || `case-${Date.now()}`;
+  if (useMemory) {
+    memoryStore.set(id, {
+      caseId: id,
+      userId,
+      status: 'received',
+      analyzer: {},
+      normalized: {},
+      eligibility: null,
+      documents: [],
+      generatedForms: [],
+      createdAt: new Date(),
+    });
+    return id;
+  }
+  const doc = await PipelineCase.create({ userId, caseId: id });
+  return doc.caseId;
 }
 
 async function updateCase(caseId, updates) {
-  await PipelineCase.findByIdAndUpdate(caseId, updates, { new: true });
+  if (useMemory) {
+    const c = memoryStore.get(caseId);
+    if (c) Object.assign(c, updates);
+    return;
+  }
+  await PipelineCase.findOneAndUpdate({ caseId }, updates, { new: true });
 }
 
 async function getCase(userId, caseId) {
-  return PipelineCase.findOne({ _id: caseId });
+  if (useMemory) {
+    return memoryStore.get(caseId);
+  }
+  return PipelineCase.findOne({ caseId });
 }
 
-module.exports = { createCase, updateCase, getCase };
+async function getLatestCase(userId) {
+  if (useMemory) {
+    let latest = null;
+    for (const c of memoryStore.values()) {
+      if (c.userId === userId && (!latest || c.createdAt > latest.createdAt)) {
+        latest = c;
+      }
+    }
+    return latest;
+  }
+  return PipelineCase.findOne({ userId }).sort({ createdAt: -1 });
+}
+
+module.exports = { createCase, updateCase, getCase, getLatestCase };


### PR DESCRIPTION
## Summary
- Accept external `caseId` and keep analyzer fields plus eligibility results in each case
- Aggregate required forms from eligibility results and invoke AI Agent to auto-fill them
- Expose real case data through `/api/status/:caseId` and legacy `/api/case/status`

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_b_68a4a2eb0bb48327a221008c16f686e0