### PR TITLE
feat: add file upload, eligibility and questionnaire endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -62,6 +62,9 @@ const caseRouter = require('./routes/case');
 app.use('/api', caseRouter);
 app.get('/case/status', caseRouter.caseStatusHandler);
 app.use('/api', require('./routes/formTemplate'));
+app.use('/api', require('./routes/files'));
+app.use('/api', require('./routes/eligibility'));
+app.use('/api', require('./routes/questionnaire'));
 
 const PORT = env.PORT || 5000;
 

--- a/server/models/PipelineCase.js
+++ b/server/models/PipelineCase.js
@@ -1,29 +1,51 @@
 const mongoose = require('mongoose');
 
-const pipelineSchema = new mongoose.Schema({
-  // Use simple string identifiers for now since auth is not implemented
-  userId: { type: String, required: true },
-  // External case identifier provided by clients
-  caseId: { type: String, unique: true },
-  status: { type: String, default: 'received' },
-  // Raw fields extracted from the analyzer step
-  analyzer: { type: mongoose.Schema.Types.Mixed, default: {} },
-  // Normalized payload combining user answers + analyzer output
-  normalized: { type: mongoose.Schema.Types.Mixed, default: {} },
-  // Full eligibility results returned by the eligibility engine
-  eligibility: { type: mongoose.Schema.Types.Mixed, default: null },
-  documents: { type: [mongoose.Schema.Types.Mixed], default: [] },
-  generatedForms: {
-    type: [
-      {
-        formKey: String,
-        version: Number,
-        data: mongoose.Schema.Types.Mixed,
-      },
-    ],
-    default: [],
+const documentSchema = new mongoose.Schema(
+  {
+    key: String,
+    filename: String,
+    size: Number,
+    contentType: String,
+    uploadedAt: { type: Date, default: Date.now },
   },
-  createdAt: { type: Date, default: Date.now },
-});
+  { _id: false }
+);
+
+const generatedFormSchema = new mongoose.Schema(
+  {
+    formName: String,
+    payload: mongoose.Schema.Types.Mixed,
+    files: [String],
+    generatedAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
+const pipelineSchema = new mongoose.Schema(
+  {
+    // Use simple string identifiers for now since auth is not implemented
+    userId: { type: String, required: true },
+    // External case identifier provided by clients
+    caseId: { type: String, unique: true },
+    status: { type: String, default: 'open' },
+    analyzer: {
+      fields: { type: mongoose.Schema.Types.Mixed, default: {} },
+      lastUpdated: Date,
+    },
+    questionnaire: {
+      data: { type: mongoose.Schema.Types.Mixed, default: {} },
+      lastUpdated: Date,
+    },
+    eligibility: {
+      results: { type: [mongoose.Schema.Types.Mixed], default: [] },
+      requiredForms: { type: [String], default: [] },
+      lastUpdated: Date,
+    },
+    documents: { type: [documentSchema], default: [] },
+    generatedForms: { type: [generatedFormSchema], default: [] },
+    normalized: { type: mongoose.Schema.Types.Mixed, default: {} },
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: 'updatedAt' } }
+);
 
 module.exports = mongoose.model('PipelineCase', pipelineSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "echo 'no tests'",
+    "test": "jest --runInBand",
     "verify:mongo": "node scripts/verify-mongo-tls.js",
     "profile:flame": "clinic flame -- node index.js",
     "profile:doctor": "clinic doctor -- node index.js",
@@ -20,5 +20,10 @@
     "pino": "8.16.0",
     "prom-client": "15.0.0",
     "uuid": "9.0.1"
+  },
+  "devDependencies": {
+    "jest": "29.7.0",
+    "nock": "13.5.2",
+    "supertest": "6.3.4"
   }
 }

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const fetchFn =
+  global.pipelineFetch ||
+  (global.fetch
+    ? global.fetch.bind(global)
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args)));
+const { createCase, getCase, updateCase } = require('../utils/pipelineStore');
+const { getServiceHeaders } = require('../utils/serviceHeaders');
+
+const router = express.Router();
+
+function aggregateMissing(results) {
+  return [
+    ...new Set(results.flatMap((r) => r.missing_fields || [])),
+  ];
+}
+
+router.get('/eligibility-report', async (req, res) => {
+  const userId = 'dev-user';
+  const { caseId } = req.query;
+  if (!caseId) return res.status(400).json({ message: 'caseId required' });
+  const c = await getCase(userId, caseId);
+  if (!c) return res.status(404).json({ message: 'Case not found' });
+  if (!c.eligibility || !c.eligibility.results) {
+    return res.status(404).json({ message: 'Eligibility not computed' });
+  }
+  const missing = aggregateMissing(c.eligibility.results);
+  res.json({ caseId, eligibility: c.eligibility, missingFieldsSummary: missing });
+});
+
+router.post('/eligibility-report', async (req, res) => {
+  const userId = 'dev-user';
+  let { caseId, payload = {} } = req.body || {};
+  let base = payload;
+  if (caseId) {
+    const c = await getCase(userId, caseId);
+    if (!c) return res.status(404).json({ message: 'Case not found' });
+    base = { ...(c.analyzer?.fields || {}), ...payload };
+  } else {
+    caseId = await createCase(userId);
+  }
+
+  const engineBase = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
+  const engineUrl = `${engineBase.replace(/\/$/, '')}/check`;
+  const resp = await fetchFn(engineUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getServiceHeaders('ELIGIBILITY_ENGINE', req) },
+    body: JSON.stringify(base),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    return res
+      .status(502)
+      .json({ message: `Eligibility engine error ${resp.status}`, details: text });
+  }
+  const results = await resp.json();
+  const requiredForms = [
+    ...new Set(results.flatMap((r) => r.requiredForms || [])),
+  ];
+  const eligibility = {
+    results,
+    requiredForms,
+    lastUpdated: new Date().toISOString(),
+  };
+  await updateCase(caseId, { eligibility });
+  if (!req.body.caseId) {
+    await updateCase(caseId, {
+      analyzer: { fields: base, lastUpdated: new Date().toISOString() },
+    });
+  }
+  const missing = aggregateMissing(results);
+  res.json({ caseId, eligibility, missingFieldsSummary: missing });
+});
+
+module.exports = router;

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -1,0 +1,86 @@
+const express = require('express');
+const multer = require('multer');
+const FormData = require('form-data');
+const fetchFn =
+  global.pipelineFetch ||
+  (global.fetch
+    ? global.fetch.bind(global)
+    : (...args) => import('node-fetch').then(({ default: f }) => f(...args)));
+const { createCase, getCase, updateCase } = require('../utils/pipelineStore');
+const { getServiceHeaders } = require('../utils/serviceHeaders');
+
+const router = express.Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
+function isAllowed(mimetype) {
+  return ['application/pdf', 'image/jpeg', 'image/png'].includes(mimetype);
+}
+
+router.post('/files/upload', (req, res) => {
+  upload.single('file')(req, res, async (err) => {
+    if (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({ message: 'File too large' });
+      }
+      return res.status(400).json({ message: err.message });
+    }
+    if (!req.file) return res.status(400).json({ message: 'file required' });
+    if (!isAllowed(req.file.mimetype)) {
+      return res.status(400).json({ message: 'Unsupported file type' });
+    }
+
+    const userId = 'dev-user';
+    let { caseId, key } = req.body || {};
+    if (caseId) {
+      const existing = await getCase(userId, caseId);
+      if (!existing) return res.status(404).json({ message: 'Case not found' });
+    } else {
+      caseId = await createCase(userId);
+    }
+
+    const analyzerBase = process.env.AI_ANALYZER_URL || 'http://localhost:8000';
+    const analyzerUrl = `${analyzerBase.replace(/\/$/, '')}/analyze`;
+    const form = new FormData();
+    form.append('file', req.file.buffer, { filename: req.file.originalname });
+    const resp = await fetchFn(analyzerUrl, {
+      method: 'POST',
+      body: form,
+      headers: { ...form.getHeaders(), ...getServiceHeaders('AI_ANALYZER', req) },
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      return res
+        .status(502)
+        .json({ message: `AI analyzer error ${resp.status}`, details: text });
+    }
+    const fields = await resp.json();
+    const c = await getCase(userId, caseId);
+    const existingFields = (c.analyzer && c.analyzer.fields) || {};
+    const mergedFields = { ...fields, ...existingFields };
+    const now = new Date().toISOString();
+    const docMeta = {
+      key,
+      filename: req.file.originalname,
+      size: req.file.size,
+      contentType: req.file.mimetype,
+      uploadedAt: now,
+    };
+    const documents = [...(c.documents || []), docMeta];
+    await updateCase(caseId, {
+      analyzer: { fields: mergedFields, lastUpdated: now },
+      documents,
+    });
+    res.json({
+      caseId,
+      status: c.status || 'open',
+      documents,
+      analyzer: { fields: mergedFields, lastUpdated: now },
+    });
+  });
+});
+
+module.exports = router;

--- a/server/routes/questionnaire.js
+++ b/server/routes/questionnaire.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const { createCase, getCase, updateCase } = require('../utils/pipelineStore');
+
+const router = express.Router();
+
+function aggregateMissing(results) {
+  return [
+    ...new Set(results.flatMap((r) => r.missing_fields || [])),
+  ];
+}
+
+router.get('/case/questionnaire', async (req, res) => {
+  const userId = 'dev-user';
+  const { caseId } = req.query;
+  if (!caseId) return res.status(400).json({ message: 'caseId required' });
+  const c = await getCase(userId, caseId);
+  if (!c) return res.status(404).json({ message: 'Case not found' });
+  const data = c.questionnaire?.data || {};
+  const missing = c.eligibility?.results ? aggregateMissing(c.eligibility.results) : [];
+  res.json({
+    caseId,
+    questionnaire: {
+      data,
+      missingFieldsHint: missing,
+      lastUpdated: c.questionnaire?.lastUpdated,
+    },
+  });
+});
+
+router.post('/case/questionnaire', async (req, res) => {
+  const userId = 'dev-user';
+  let { caseId, data } = req.body || {};
+  if (!data || typeof data !== 'object') {
+    return res.status(400).json({ message: 'data required' });
+  }
+  let c;
+  if (caseId) {
+    c = await getCase(userId, caseId);
+    if (!c) return res.status(404).json({ message: 'Case not found' });
+  } else {
+    caseId = await createCase(userId);
+    c = await getCase(userId, caseId);
+  }
+  const existingFields = (c.analyzer && c.analyzer.fields) || {};
+  const merged = { ...existingFields };
+  for (const [k, v] of Object.entries(data)) {
+    if (
+      merged[k] === undefined ||
+      merged[k] === null ||
+      merged[k] === ''
+    ) {
+      merged[k] = v;
+    }
+  }
+  const now = new Date().toISOString();
+  await updateCase(caseId, {
+    analyzer: { fields: merged, lastUpdated: now },
+    questionnaire: { data, lastUpdated: now },
+  });
+  const missing = c.eligibility?.results ? aggregateMissing(c.eligibility.results) : [];
+  res.json({
+    caseId,
+    questionnaire: { data, missingFieldsHint: missing, lastUpdated: now },
+  });
+});
+
+module.exports = router;

--- a/server/tests/eligibility.report.test.js
+++ b/server/tests/eligibility.report.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../index');
+const { createCase, updateCase, resetStore } = require('../utils/pipelineStore');
+
+describe('eligibility report endpoints', () => {
+  beforeEach(() => {
+    process.env.SKIP_DB = 'true';
+    resetStore();
+    nock.cleanAll();
+  });
+
+  test('POST computes and stores eligibility', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, { analyzer: { fields: { a: 1 } } });
+    nock('http://localhost:4001')
+      .post('/check')
+      .reply(200, [
+        { program: 'p1', requiredForms: ['f1'], missing_fields: ['m1'] },
+        { program: 'p2', requiredForms: ['f2'], missing_fields: ['m2'] },
+      ]);
+    const res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { b: 2 } });
+    expect(res.status).toBe(200);
+    expect(res.body.eligibility.results).toHaveLength(2);
+    expect(res.body.eligibility.requiredForms.sort()).toEqual(['f1', 'f2']);
+  });
+
+  test('GET returns latest eligibility', async () => {
+    const caseId = await createCase('dev-user');
+    const eligibility = {
+      results: [{ program: 'p', requiredForms: ['f1'], missing_fields: ['m'] }],
+      requiredForms: ['f1'],
+      lastUpdated: new Date().toISOString(),
+    };
+    await updateCase(caseId, { eligibility });
+    const res = await request(app)
+      .get('/api/eligibility-report')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    expect(res.body.eligibility.requiredForms).toEqual(['f1']);
+    expect(res.body.missingFieldsSummary).toEqual(['m']);
+  });
+
+  test('engine error propagates', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, { analyzer: { fields: {} } });
+    nock('http://localhost:4001').post('/check').reply(500, 'fail');
+    const res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId });
+    expect(res.status).toBe(502);
+  });
+});

--- a/server/tests/files.upload.test.js
+++ b/server/tests/files.upload.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const nock = require('nock');
+const app = require('../index');
+const { resetStore } = require('../utils/pipelineStore');
+
+describe('POST /api/files/upload', () => {
+  beforeEach(() => {
+    process.env.SKIP_DB = 'true';
+    resetStore();
+    nock.cleanAll();
+  });
+
+  test('uploads valid pdf and returns case snapshot', async () => {
+    nock('http://localhost:8000').post('/analyze').reply(200, { foo: 'bar' });
+    const res = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.from('%PDF'), 'test.pdf');
+    expect(res.status).toBe(200);
+    expect(res.body.caseId).toBeDefined();
+    expect(res.body.documents).toHaveLength(1);
+    expect(res.body.analyzer.fields.foo).toBe('bar');
+  });
+
+  test('rejects bad content type', async () => {
+    const res = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.from('hello'), 'test.txt');
+    expect(res.status).toBe(400);
+  });
+
+  test('rejects oversized file', async () => {
+    const res = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.alloc(6 * 1024 * 1024), 'big.pdf');
+    expect(res.status).toBe(413);
+  });
+});

--- a/server/tests/questionnaire.test.js
+++ b/server/tests/questionnaire.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const app = require('../index');
+const { createCase, updateCase, getCase, resetStore } = require('../utils/pipelineStore');
+
+describe('questionnaire endpoints', () => {
+  beforeEach(() => {
+    process.env.SKIP_DB = 'true';
+    resetStore();
+  });
+
+  test('POST saves questionnaire and merges missing fields', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, { analyzer: { fields: { existing: 'keep', empty: '' } } });
+    const res = await request(app)
+      .post('/api/case/questionnaire')
+      .send({ caseId, data: { existing: 'new', empty: 'filled', newField: 'val' } });
+    expect(res.status).toBe(200);
+    const c = await getCase('dev-user', caseId);
+    expect(c.analyzer.fields).toEqual({ existing: 'keep', empty: 'filled', newField: 'val' });
+    expect(c.questionnaire.data.newField).toBe('val');
+  });
+
+  test('GET returns questionnaire with missingFieldsHint', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, {
+      questionnaire: { data: { foo: 'bar' }, lastUpdated: new Date().toISOString() },
+      eligibility: {
+        results: [
+          { missing_fields: ['a', 'b'] },
+          { missing_fields: ['b', 'c'] },
+        ],
+        requiredForms: [],
+        lastUpdated: new Date().toISOString(),
+      },
+    });
+    const res = await request(app)
+      .get('/api/case/questionnaire')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    expect(res.body.questionnaire.missingFieldsHint.sort()).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `POST /api/files/upload` to forward documents to analyzer and store metadata
- expose eligibility report via `/api/eligibility-report` with compute + fetch
- persist questionnaire data through `/api/case/questionnaire`
- expand case model and store for analyzer, questionnaire, and eligibility fields
- cover new endpoints with Jest tests

## Testing
- `npm test --prefix server` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a6071a0883279b467f93bbb9ddeb