### PR TITLE
feat: support text input for analyze

### DIFF
--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -4,6 +4,23 @@ This FastAPI microservice extracts text from uploaded documents using Tesseract 
 and parses simple business fields. The `/analyze` endpoint accepts `application/pdf`,
 `image/png` and `image/jpeg` uploads.
 
+## JSON / Text Input
+
+The `/analyze` endpoint also accepts raw text via JSON or `text/plain` payloads.
+The maximum text size is **100KB** and the response shape matches file uploads.
+
+```bash
+# JSON body
+curl -X POST http://localhost:8000/analyze \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Revenue 1000; 10 employees; EIN 12-3456789"}'
+
+# Plain text
+curl -X POST http://localhost:8000/analyze \
+  -H "Content-Type: text/plain" \
+  --data-binary "Founded 2019; Employees 25"
+```
+
 ## Local Development Setup
 
 ```bash

--- a/ai-analyzer/nlp_parser.py
+++ b/ai-analyzer/nlp_parser.py
@@ -1,19 +1,49 @@
-"""Very small NLP helper for field extraction."""
+"""Text normalization and field extraction helpers."""
 
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Dict, Tuple
 
 
+def normalize_text(text: str) -> str:
+    """Return text with collapsed whitespace and printable characters only."""
+    if not text:
+        return ""
+    # remove non-printable characters
+    text = "".join(ch for ch in text if ch.isprintable())
+    # collapse whitespace
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _parse_number(value: str) -> int:
+    """Parse a human-friendly number string to int."""
+    value = value.lower().replace(",", "").replace("$", "").strip()
+    multiplier = 1
+    if value.endswith("m"):
+        multiplier = 1_000_000
+        value = value[:-1]
+    elif value.endswith("k"):
+        multiplier = 1_000
+        value = value[:-1]
+    try:
+        return int(float(value) * multiplier)
+    except ValueError:
+        match = re.search(r"\d+", value)
+        return int(match.group()) if match else 0
+
+
 _FIELD_PATTERNS = {
-    "revenue": re.compile(r"revenue\s*[:\-\$]?\s*([\d,]+)", re.I),
-    "employees": re.compile(r"(\d+)\s+employees", re.I),
-    "year_founded": re.compile(r"(\d{4})"),
+    "ein": re.compile(r"\b(\d{2}-\d{7})\b"),
+    "employees": re.compile(r"(?i)\b(?:employees?|staff)\b\D{0,30}?(\d{1,5})"),
+    "revenue": re.compile(r"(?i)(?:revenue|gross receipts|sales)\b\D{0,30}?([\$0-9,\.]+[mk]?)"),
+    "year_founded": re.compile(r"(?i)(?:founded|since)\b\D{0,10}?(\d{4})"),
 }
 
 
-def parse_fields(text: str) -> Tuple[Dict[str, str | int], Dict[str, float]]:
+def extract_fields(text: str) -> Tuple[Dict[str, str | int], Dict[str, float]]:
     """Return structured fields and a simple confidence score."""
     fields: Dict[str, str | int] = {}
     confidence: Dict[str, float] = {}
@@ -21,12 +51,27 @@ def parse_fields(text: str) -> Tuple[Dict[str, str | int], Dict[str, float]]:
         return fields, confidence
 
     for name, pattern in _FIELD_PATTERNS.items():
-        m = pattern.search(text)
-        if m:
-            val = m.group(1)
-            if name in {"revenue", "employees"}:
-                val = int(val.replace(",", ""))
-            fields[name] = val
-            confidence[name] = 0.9
+        match = pattern.search(text)
+        if not match:
+            continue
+        raw = match.group(1)
+        if name in {"revenue", "employees"}:
+            value = _parse_number(raw)
+        elif name == "year_founded":
+            year = int(raw)
+            current = datetime.now().year
+            if 1900 <= year <= current:
+                value = year
+            else:
+                continue
+        else:
+            value = raw
+        fields[name] = value
+        confidence[name] = 0.9
 
     return fields, confidence
+
+
+# Backwards compatibility for older imports
+parse_fields = extract_fields
+

--- a/ai-analyzer/ocr_utils.py
+++ b/ai-analyzer/ocr_utils.py
@@ -19,13 +19,13 @@ def extract_text(file_bytes: bytes) -> str:
         try:  # pragma: no cover - relies on external binaries
             image = Image.open(io.BytesIO(file_bytes))
             text = pytesseract.image_to_string(image)
-            return text
+            return text.strip()
         except Exception:
             pass
 
     # Fallback to simple decoding
     try:
-        return file_bytes.decode("utf-8")
+        return file_bytes.decode("utf-8").strip()
     except Exception:
         # Final fallback for binary files
         return "sample extracted text"

--- a/ai-analyzer/tests/test_analyze.py
+++ b/ai-analyzer/tests/test_analyze.py
@@ -1,0 +1,66 @@
+import io
+
+import pytest
+import env_setup  # noqa: F401
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_analyze_json_happy_path() -> None:
+    resp = client.post(
+        "/analyze",
+        json={"text": "Revenue 1000; 10 employees; EIN 12-3456789"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["revenue"] == 1000
+    assert data["employees"] == 10
+    assert data["ein"] == "12-3456789"
+    assert data["source"] == "text"
+
+
+def test_analyze_text_plain_happy_path() -> None:
+    headers = {"Content-Type": "text/plain"}
+    resp = client.post(
+        "/analyze",
+        data="Founded 2019\nEmployees: 25",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["year_founded"] == 2019
+    assert data["employees"] == 25
+
+
+def test_analyze_text_empty() -> None:
+    headers = {"Content-Type": "text/plain"}
+    resp = client.post("/analyze", data="", headers=headers)
+    assert resp.status_code == 400
+
+
+def test_analyze_text_oversize() -> None:
+    headers = {"Content-Type": "text/plain"}
+    resp = client.post("/analyze", data="a" * 100_001, headers=headers)
+    assert resp.status_code == 400
+
+
+def test_analyze_multipart_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_extract_text(_: bytes) -> str:
+        return "Revenue 5000"
+
+    monkeypatch.setattr("ocr_utils.extract_text", mock_extract_text)
+
+    file_content = io.BytesIO(b"dummy")
+    resp = client.post(
+        "/analyze",
+        files={"file": ("test.png", file_content, "image/png")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["revenue"] == 5000
+    assert data["source"] == "file"
+


### PR DESCRIPTION
## Summary
- extend /analyze to accept JSON and plain text bodies
- normalize and extract EIN, revenue, employees, and founded year
- document new JSON/text usage and add tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytesseract==0.3.10)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68a4c93010c883278f8909c5412d38a6