### PR TITLE
feat: add global upload validation

### DIFF
--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -12,6 +12,7 @@ ENV_FILE = os.getenv("ENV_FILE")
 ENV_PATH = ENV_FILE or Path(__file__).resolve().parent / f".env.{NODE_ENV}"
 class Settings(BaseSettings):
     NODE_ENV: str = "development"
+    MAX_FILE_SIZE_MB: int = 5
 
     model_config = SettingsConfigDict(env_file=ENV_PATH, extra="ignore")
 

--- a/ai-analyzer/tests/test_analyze.py
+++ b/ai-analyzer/tests/test_analyze.py
@@ -64,3 +64,23 @@ def test_analyze_multipart_file(monkeypatch: pytest.MonkeyPatch) -> None:
     assert data["revenue"] == 5000
     assert data["source"] == "file"
 
+
+def test_analyze_multipart_invalid_type() -> None:
+    file_content = io.BytesIO(b"dummy")
+    resp = client.post(
+        "/analyze",
+        files={"file": ("test.exe", file_content, "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"].startswith("Invalid file type")
+
+
+def test_analyze_multipart_file_too_large() -> None:
+    big_content = io.BytesIO(b"a" * (5 * 1024 * 1024 + 1))
+    resp = client.post(
+        "/analyze",
+        files={"file": ("big.png", big_content, "image/png")},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "File too large. Maximum allowed size is 5MB."
+

--- a/ai-analyzer/tests/test_ocr.py
+++ b/ai-analyzer/tests/test_ocr.py
@@ -1,0 +1,55 @@
+import io
+
+import pytest
+import env_setup  # noqa: F401
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def _patch_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyPytesseract:
+        @staticmethod
+        def image_to_string(_: object) -> str:
+            return "text"
+
+    class DummyImage:
+        @staticmethod
+        def open(_: io.BytesIO) -> object:  # pragma: no cover - simple stub
+            return object()
+
+    monkeypatch.setattr("main.pytesseract", DummyPytesseract)
+    monkeypatch.setattr("main.Image", DummyImage)
+
+
+def test_ocr_image_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_ocr(monkeypatch)
+    resp = client.post(
+        "/ocr-image",
+        files={"file": ("test.png", io.BytesIO(b"dummy"), "image/png")},
+    )
+    assert resp.status_code == 200
+    assert "text" in resp.json()
+
+
+def test_ocr_image_invalid_type() -> None:
+    resp = client.post(
+        "/ocr-image",
+        files={"file": ("test.exe", io.BytesIO(b"dummy"), "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"].startswith("Invalid file type")
+
+
+def test_ocr_image_file_too_large() -> None:
+    big_content = io.BytesIO(b"a" * (5 * 1024 * 1024 + 1))
+    resp = client.post(
+        "/ocr-image",
+        files={"file": ("big.png", big_content, "image/png")},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "File too large. Maximum allowed size is 5MB."
+

--- a/ai-analyzer/upload_utils.py
+++ b/ai-analyzer/upload_utils.py
@@ -1,0 +1,46 @@
+"""Utilities for validating uploaded files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+from config import settings  # type: ignore
+
+
+ALLOWED_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".bmp",
+    ".tiff",
+    ".gif",
+    ".pdf",
+    ".txt",
+    ".docx",
+}
+
+
+def validate_upload(file: UploadFile) -> None:
+    """Validate file extension and size of an upload.
+
+    Raises:
+        HTTPException: if the file type or size is invalid.
+    """
+
+    ext = Path(file.filename or "").suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        allowed = ", ".join(sorted(ALLOWED_EXTENSIONS))
+        msg = f"Invalid file type. Supported formats are: {allowed}"
+        raise HTTPException(status_code=400, detail=msg)
+
+    file.file.seek(0, os.SEEK_END)
+    size = file.file.tell()
+    file.file.seek(0)
+    max_bytes = settings.MAX_FILE_SIZE_MB * 1024 * 1024
+    if size > max_bytes:
+        msg = f"File too large. Maximum allowed size is {settings.MAX_FILE_SIZE_MB}MB."
+        raise HTTPException(status_code=400, detail=msg)
+


### PR DESCRIPTION
## Summary
- add centralized `validate_upload` for file type and size restrictions
- enforce upload validation in OCR and analysis endpoints
- return consistent JSON error responses

## Testing
- `pytest ai-analyzer/tests` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_68a51040b9b88327a4c051f39fe28f75