### PR TITLE
feat: expand analyzer field extraction

### DIFF
--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -1,8 +1,9 @@
 # AI Analyzer Service
 
 This FastAPI microservice extracts text from uploaded documents using Tesseract OCR
-and parses simple business fields. The `/analyze` endpoint accepts `application/pdf`,
-`image/png` and `image/jpeg` uploads.
+and parses business fields such as EIN, W‑2 employee counts, quarterly revenues and
+entity type. The `/analyze` endpoint accepts `application/pdf`, `image/png` and
+`image/jpeg` uploads.
 
 ## JSON / Text Input
 
@@ -13,12 +14,15 @@ The maximum text size is **100KB** and the response shape matches file uploads.
 # JSON body
 curl -X POST http://localhost:8000/analyze \
   -H "Content-Type: application/json" \
-  -d '{"text":"Revenue 1000; 10 employees; EIN 12-3456789"}'
+  -d '{"text":"EIN 12-3456789; W-2 employees: 13; Q1 2023 revenue $120k; LLC"}'
 
 # Plain text
 curl -X POST http://localhost:8000/analyze \
   -H "Content-Type: text/plain" \
-  --data-binary "Founded 2019; Employees 25"
+  --data-binary "Founded 2019; W2 employees 25"
+
+# File upload
+curl -X POST http://localhost:8000/analyze -F "file=@samples/quarterly_report.pdf"
 ```
 
 ## Local Development Setup

--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -13,6 +13,9 @@ ENV_PATH = ENV_FILE or Path(__file__).resolve().parent / f".env.{NODE_ENV}"
 class Settings(BaseSettings):
     NODE_ENV: str = "development"
     MAX_FILE_SIZE_MB: int = 5
+    MAX_TEXT_LEN: int = 100_000
+    ENABLE_SECONDARY_FIELDS: bool = True
+    TESSERACT_CMD: str | None = None
 
     model_config = SettingsConfigDict(env_file=ENV_PATH, extra="ignore")
 

--- a/ai-analyzer/nlp_parser.py
+++ b/ai-analyzer/nlp_parser.py
@@ -1,26 +1,20 @@
-"""Text normalization and field extraction helpers."""
-
-from __future__ import annotations
-
 import re
 from datetime import datetime
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple, List, Optional
 
 
 def normalize_text(text: str) -> str:
     """Return text with collapsed whitespace and printable characters only."""
     if not text:
         return ""
-    # remove non-printable characters
     text = "".join(ch for ch in text if ch.isprintable())
-    # collapse whitespace
     text = re.sub(r"\s+", " ", text)
     return text.strip()
 
 
-def _parse_number(value: str) -> int:
-    """Parse a human-friendly number string to int."""
-    value = value.lower().replace(",", "").replace("$", "").strip()
+def parse_money(value: str) -> int:
+    """Parse a human friendly currency string into whole dollars."""
+    value = value.strip().lower().replace("$", "").replace(",", "")
     multiplier = 1
     if value.endswith("m"):
         multiplier = 1_000_000
@@ -35,43 +29,278 @@ def _parse_number(value: str) -> int:
         return int(match.group()) if match else 0
 
 
-_FIELD_PATTERNS = {
-    "ein": re.compile(r"\b(\d{2}-\d{7})\b"),
-    "employees": re.compile(r"(?i)\b(?:employees?|staff)\b\D{0,30}?(\d{1,5})"),
-    "revenue": re.compile(r"(?i)(?:revenue|gross receipts|sales)\b\D{0,30}?([\$0-9,\.]+[mk]?)"),
-    "year_founded": re.compile(r"(?i)(?:founded|since)\b\D{0,10}?(\d{4})"),
+_STATE_MAP = {
+    "alabama": "AL",
+    "alaska": "AK",
+    "arizona": "AZ",
+    "arkansas": "AR",
+    "california": "CA",
+    "colorado": "CO",
+    "connecticut": "CT",
+    "delaware": "DE",
+    "florida": "FL",
+    "georgia": "GA",
+    "hawaii": "HI",
+    "idaho": "ID",
+    "illinois": "IL",
+    "indiana": "IN",
+    "iowa": "IA",
+    "kansas": "KS",
+    "kentucky": "KY",
+    "louisiana": "LA",
+    "maine": "ME",
+    "maryland": "MD",
+    "massachusetts": "MA",
+    "michigan": "MI",
+    "minnesota": "MN",
+    "mississippi": "MS",
+    "missouri": "MO",
+    "montana": "MT",
+    "nebraska": "NE",
+    "nevada": "NV",
+    "new hampshire": "NH",
+    "new jersey": "NJ",
+    "new mexico": "NM",
+    "new york": "NY",
+    "north carolina": "NC",
+    "north dakota": "ND",
+    "ohio": "OH",
+    "oklahoma": "OK",
+    "oregon": "OR",
+    "pennsylvania": "PA",
+    "rhode island": "RI",
+    "south carolina": "SC",
+    "south dakota": "SD",
+    "tennessee": "TN",
+    "texas": "TX",
+    "utah": "UT",
+    "vermont": "VT",
+    "virginia": "VA",
+    "washington": "WA",
+    "west virginia": "WV",
+    "wisconsin": "WI",
+    "wyoming": "WY",
 }
 
 
-def extract_fields(text: str) -> Tuple[Dict[str, str | int], Dict[str, float]]:
-    """Return structured fields and a simple confidence score."""
-    fields: Dict[str, str | int] = {}
-    confidence: Dict[str, float] = {}
-    if not text:
-        return fields, confidence
+def normalize_state(value: str) -> Optional[str]:
+    val = value.strip().lower()
+    if len(val) == 2 and val.upper() in _STATE_MAP.values():
+        return val.upper()
+    return _STATE_MAP.get(val)
 
-    for name, pattern in _FIELD_PATTERNS.items():
-        match = pattern.search(text)
-        if not match:
-            continue
-        raw = match.group(1)
-        if name in {"revenue", "employees"}:
-            value = _parse_number(raw)
-        elif name == "year_founded":
-            year = int(raw)
-            current = datetime.now().year
-            if 1900 <= year <= current:
-                value = year
+
+def normalize_country(value: str) -> Optional[str]:
+    val = value.strip().lower()
+    if val in {"us", "usa", "united states", "united states of america"}:
+        return "US"
+    return None
+
+
+_EIN_RE = re.compile(r"\b(?:EIN[:\s]*)?(\d{2}[- ]?\d{7})\b", re.I)
+_W2_RE = re.compile(r"\bW-?2(?:\s+employees?\b|\s+count\b|\b)\D{0,10}(\d{1,5})", re.I)
+_QUARTER_PATTERNS = [
+    re.compile(r"(Q[1-4]|Quarter\s*[1-4])\D{0,10}(20\d{2})\D{0,20}([\$0-9,\.]+[kKmM]?)", re.I),
+    re.compile(r"(20\d{2})\D{0,10}(Q[1-4]|Quarter\s*[1-4])\D{0,20}([\$0-9,\.]+[kKmM]?)", re.I),
+]
+
+_ENTITY_MAP = {
+    r"llc": "llc",
+    r"c[-\s]?corp|c corporation": "corp_c",
+    r"s[-\s]?corp|s corporation": "corp_s",
+    r"partnership|llp|lp": "partnership",
+    r"sole prop|sole proprietorship": "sole_prop",
+    r"non[-\s]?profit|not[-\s]?for[-\s]?profit|501\(c\)": "nonprofit",
+    r"coop|co-?op|cooperative": "cooperative",
+}
+
+
+def extract_ein(text: str) -> Tuple[Optional[str], float, List[str], List[Dict[str, Any]]]:
+    candidates = [m.group(1) for m in _EIN_RE.finditer(text)]
+    normalized_candidates = [c.replace(" ", "-").replace("-", "", 1) for c in candidates]
+    normalized_candidates = [f"{c[:2]}-{c[2:]}" for c in normalized_candidates]
+    value = normalized_candidates[0] if normalized_candidates else None
+    conf = 0.0
+    ambiguities: List[Dict[str, Any]] = []
+    if value:
+        conf = 0.8
+        for m in _EIN_RE.finditer(text):
+            if m.group(1).replace(" ", "-") == value:
+                before = text[max(0, m.start() - 10):m.start()].lower()
+                if "ein" in before or "employer identification" in before:
+                    conf += 0.1
+                break
+        if len(set(normalized_candidates)) > 1:
+            ambiguities.append({
+                "field": "ein",
+                "candidates": list(dict.fromkeys(normalized_candidates)),
+                "reason": "multiple EIN-like strings found",
+            })
+        conf = min(conf, 1.0)
+    return value, conf, normalized_candidates, ambiguities
+
+
+def extract_w2_count(text: str) -> Tuple[Optional[int], float]:
+    match = _W2_RE.search(text)
+    if not match:
+        return None, 0.0
+    count = int(match.group(1))
+    return count, 0.8
+
+
+def extract_quarterly_revenues(text: str) -> Tuple[Dict[str, Dict[str, int]], Dict[str, float]]:
+    revenues: Dict[str, Dict[str, int]] = {}
+    conf: Dict[str, float] = {}
+    for pattern in _QUARTER_PATTERNS:
+        for m in pattern.finditer(text):
+            g1, g2, amt = m.groups()
+            if pattern is _QUARTER_PATTERNS[0]:
+                quarter_raw, year_raw = g1, g2
             else:
-                continue
-        else:
-            value = raw
-        fields[name] = value
-        confidence[name] = 0.9
+                year_raw, quarter_raw = g1, g2
+            quarter = "Q" + re.sub(r"[^1-4]", "", quarter_raw)
+            year = year_raw
+            amount = parse_money(amt)
+            revenues.setdefault(year, {})[quarter] = amount
+            conf[f"quarterly_revenues.{year}.{quarter}"] = 0.9
+    return revenues, conf
 
-    return fields, confidence
+
+def extract_entity_type(text: str) -> Tuple[Optional[str], float]:
+    for pattern, normalized in _ENTITY_MAP.items():
+        if re.search(pattern, text, re.I):
+            return normalized, 0.85
+    return None, 0.0
 
 
-# Backwards compatibility for older imports
+def extract_year_founded(text: str) -> Tuple[Optional[int], float]:
+    m = re.search(r"(?i)(?:founded|incorporated|since)\D{0,10}(\d{4})", text)
+    if not m:
+        return None, 0.0
+    year = int(m.group(1))
+    current = datetime.now().year
+    if 1800 <= year <= current:
+        return year, 0.8
+    return None, 0.0
+
+
+def extract_annual_revenue(text: str) -> Tuple[Optional[int], float]:
+    m = re.search(r"(?i)(?:annual revenue|total revenue)\D{0,20}([\$0-9,\.]+[kKmM]?)", text)
+    if not m:
+        return None, 0.0
+    return parse_money(m.group(1)), 0.8
+
+
+def extract_location(text: str) -> Tuple[Optional[str], float, Optional[str], float]:
+    state_conf = 0.0
+    country_conf = 0.0
+    state = None
+    country = None
+    for name, abbr in _STATE_MAP.items():
+        if re.search(rf"\b{name}\b", text, re.I) or re.search(rf"\b{abbr}\b", text, re.I):
+            state = abbr
+            state_conf = 0.8
+            break
+    if re.search(r"\b(?:united states|usa|us)\b", text, re.I):
+        country = "US"
+        country_conf = 0.8
+    return state, state_conf, country, country_conf
+
+
+def extract_ownership(text: str) -> Tuple[Dict[str, Optional[bool]], Dict[str, float]]:
+    fields: Dict[str, Optional[bool]] = {
+        "minority_owned": None,
+        "female_owned": None,
+        "veteran_owned": None,
+    }
+    conf: Dict[str, float] = {}
+    if re.search(r"minority[-\s]owned", text, re.I):
+        fields["minority_owned"] = True
+        conf["minority_owned"] = 0.9
+    if re.search(r"(female|women|woman)[-\s]owned", text, re.I):
+        fields["female_owned"] = True
+        conf["female_owned"] = 0.9
+    if re.search(r"veteran[-\s]owned", text, re.I):
+        fields["veteran_owned"] = True
+        conf["veteran_owned"] = 0.9
+    return fields, conf
+
+
+def extract_credit_refs(text: str) -> Tuple[Optional[bool], float, Optional[bool], float]:
+    ppp = None
+    ppp_conf = 0.0
+    ertc = None
+    ertc_conf = 0.0
+    if re.search(r"\bPPP\b|paycheck protection program", text, re.I):
+        ppp = True
+        ppp_conf = 0.9
+    if re.search(r"\bERTC\b|employee retention tax credit", text, re.I):
+        ertc = True
+        ertc_conf = 0.9
+    return ppp, ppp_conf, ertc, ertc_conf
+
+
+def extract_fields(text: str, *, enable_secondary: bool = True) -> Tuple[Dict[str, Any], Dict[str, float], List[Dict[str, Any]]]:
+    fields: Dict[str, Any] = {}
+    confidence: Dict[str, float] = {}
+    ambiguities: List[Dict[str, Any]] = []
+
+    ein, ein_conf, _, ein_amb = extract_ein(text)
+    if ein:
+        fields["ein"] = ein
+        confidence["ein"] = ein_conf
+    ambiguities.extend(ein_amb)
+
+    w2, w2_conf = extract_w2_count(text)
+    if w2 is not None:
+        fields["w2_employee_count"] = w2
+        confidence["w2_employee_count"] = w2_conf
+
+    revs, rev_conf = extract_quarterly_revenues(text)
+    if revs:
+        fields["quarterly_revenues"] = revs
+        confidence.update(rev_conf)
+
+    entity, entity_conf = extract_entity_type(text)
+    if entity:
+        fields["entity_type"] = entity
+        confidence["entity_type"] = entity_conf
+
+    if enable_secondary:
+        year, year_conf = extract_year_founded(text)
+        if year:
+            fields["year_founded"] = year
+            confidence["year_founded"] = year_conf
+
+        annual, annual_conf = extract_annual_revenue(text)
+        if annual:
+            fields["annual_revenue"] = annual
+            confidence["annual_revenue"] = annual_conf
+
+        state, state_conf, country, country_conf = extract_location(text)
+        if state:
+            fields["location_state"] = state
+            confidence["location_state"] = state_conf
+        if country:
+            fields["location_country"] = country
+            confidence["location_country"] = country_conf
+
+        ownership, own_conf = extract_ownership(text)
+        for k, v in ownership.items():
+            if v is not None:
+                fields[k] = v
+        confidence.update(own_conf)
+
+        ppp, ppp_conf, ertc, ertc_conf = extract_credit_refs(text)
+        if ppp is not None:
+            fields["ppp_reference"] = ppp
+            confidence["ppp_reference"] = ppp_conf
+        if ertc is not None:
+            fields["ertc_reference"] = ertc
+            confidence["ertc_reference"] = ertc_conf
+
+    return fields, confidence, ambiguities
+
+
+# Backwards compatibility
 parse_fields = extract_fields
-

--- a/ai-analyzer/tests/test_nlp_parser.py
+++ b/ai-analyzer/tests/test_nlp_parser.py
@@ -1,0 +1,52 @@
+import env_setup  # noqa: F401
+from nlp_parser import (
+    extract_ein,
+    extract_w2_count,
+    extract_quarterly_revenues,
+    extract_entity_type,
+    parse_money,
+)
+
+
+def test_extract_ein_single() -> None:
+    text = "Our EIN is 12-3456789 registered"
+    value, conf, candidates, amb = extract_ein(text)
+    assert value == "12-3456789"
+    assert conf > 0.8
+    assert candidates == ["12-3456789"]
+    assert amb == []
+
+
+def test_extract_ein_multiple() -> None:
+    text = "EIN 12-3456789 duplicate 98-7654321"
+    value, _, candidates, amb = extract_ein(text)
+    assert value == "12-3456789"
+    assert len(candidates) == 2
+    assert amb and amb[0]["field"] == "ein"
+
+
+def test_w2_not_1099() -> None:
+    text = "W-2 employees: 15 and 1099 contractors 3"
+    count, conf = extract_w2_count(text)
+    assert count == 15
+    assert conf > 0
+
+
+def test_quarterly_revenues() -> None:
+    text = "Q1 2023 revenue $120k; 2022 Q4 revenue $1.2M"
+    revs, conf = extract_quarterly_revenues(text)
+    assert revs["2023"]["Q1"] == 120000
+    assert revs["2022"]["Q4"] == 1200000
+    assert conf["quarterly_revenues.2023.Q1"] == 0.9
+
+
+def test_entity_type_mapping() -> None:
+    text = "Registered as an S-Corp"
+    entity, conf = extract_entity_type(text)
+    assert entity == "corp_s"
+    assert conf > 0
+
+
+def test_parse_money_helpers() -> None:
+    assert parse_money("1.2M") == 1200000
+    assert parse_money("55k") == 55000


### PR DESCRIPTION
## Summary
- expand NLP parser to extract EIN, W-2 counts, quarterly revenues, entity types and more
- expose new fields and confidence/ambiguity handling through `/analyze`
- document JSON, text and file usage with new curl examples

## Testing
- `python -m py_compile ai-analyzer/nlp_parser.py ai-analyzer/main.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytesseract==0.3.10)*

------
https://chatgpt.com/codex/tasks/task_b_68a513840efc83278caf218591460fc1