### PR TITLE
Normalize missing_fields to string arrays

### DIFF
--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -100,11 +100,9 @@ export default function EligibilityReport() {
                 {r.estimated_amount !== undefined && (
                   <div>Estimated Amount: ${r.estimated_amount}</div>
                 )}
-                {r.missing_fields?.length ? (
-                  <div className="text-xs text-yellow-700">
-                    Missing: {r.missing_fields.join(', ')}
-                  </div>
-                ) : null}
+                <div className="text-xs text-yellow-700">
+                  Missing: {r.missing_fields.length ? r.missing_fields.join(', ') : '—'}
+                </div>
                 {(r.reasoning || r.rationale) && (
                   <div className="text-xs text-gray-700">
                     {(r.reasoning || r.rationale)?.join(', ')}

--- a/frontend/src/lib/normalize.ts
+++ b/frontend/src/lib/normalize.ts
@@ -1,0 +1,13 @@
+export function toArray(value: string | string[] | null | undefined): string[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+export function normalizeEligibility<T extends { missing_fields?: string | string[] }>(
+  arr: T[]
+): (Omit<T, 'missing_fields'> & { missing_fields: string[] })[] {
+  return (arr ?? []).map((item) => ({
+    ...item,
+    missing_fields: toArray(item.missing_fields),
+  }));
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -13,7 +13,7 @@ export interface EligibilityItem {
   eligible: boolean | null;
   score?: number;
   estimated_amount?: number;
-  missing_fields?: string[];
+  missing_fields: string[];
   next_steps?: string;
   requiredForms?: string[];
   reasoning?: string[] | string;
@@ -31,4 +31,22 @@ export interface CaseSnapshot {
   createdAt?: string;
   updatedAt?: string;
 }
+
+export type GrantResult = {
+  program: string;
+  eligible: boolean | null;
+  score?: number;
+  estimated_amount?: number | null;
+  requiredForms?: string[];
+  reasoning_steps?: string[];
+  clarifying_questions?: string[];
+  missing_fields: string[];
+};
+
+export type ResultsEnvelope = {
+  results: GrantResult[];
+  requiredForms: string[];
+};
+
+export type EligibilityReport = ResultsEnvelope | GrantResult[];
 

--- a/frontend/tests/eligibility-report.mapping.test.ts
+++ b/frontend/tests/eligibility-report.mapping.test.ts
@@ -1,0 +1,24 @@
+import { toArray, normalizeEligibility } from '@/lib/normalize';
+
+describe('normalize toArray', () => {
+  it('handles string', () => {
+    expect(toArray('a')).toEqual(['a']);
+  });
+  it('handles array', () => {
+    expect(toArray(['a', 'b'])).toEqual(['a', 'b']);
+  });
+  it('handles null/undefined', () => {
+    expect(toArray(undefined)).toEqual([]);
+  });
+  it('filters empties', () => {
+    expect(toArray(['', 'x'])).toEqual(['x']);
+  });
+});
+
+describe('normalizeEligibility', () => {
+  it('coerces missing_fields', () => {
+    const input = [{ program: 'p', eligible: null, missing_fields: 'x' }];
+    const out = normalizeEligibility(input);
+    expect(out[0].missing_fields).toEqual(['x']);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize eligibility API `missing_fields` to `string[]`
- add `toArray` and `normalizeEligibility` helpers
- update eligibility report view to show hyphen when no missing fields
- add tests for normalization utilities

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f2424af08327b522152cc3c0475a