### PR TITLE
Refactor eligibility normalization for typed eligibility items

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -93,7 +93,6 @@ export default function Dashboard() {
                         ? 'Yes'
                         : 'No'}
                     </div>
-                    {r.score !== undefined && <div>Score: {r.score}</div>}
                     {r.estimated_amount !== undefined && (
                       <div>Estimated Amount: ${r.estimated_amount}</div>
                     )}
@@ -110,21 +109,15 @@ export default function Dashboard() {
                     {r.next_steps && (
                       <p className="text-xs text-gray-700">Next: {r.next_steps}</p>
                     )}
-                    {(r.reasoning || r.rationale) && (
+                    {r.reasoning && r.reasoning.length > 0 && (
                       <details className="text-xs">
                         <summary className="cursor-pointer">Why?</summary>
                         <div className="ml-4 mt-1">
-                          {Array.isArray(r.reasoning || r.rationale)
-                            ? (
-                                <ul className="list-disc list-inside">
-                                  {(r.reasoning || r.rationale).map((x) => (
-                                    <li key={x}>{x}</li>
-                                  ))}
-                                </ul>
-                              )
-                            : (
-                                <span>{r.reasoning || r.rationale}</span>
-                              )}
+                          <ul className="list-disc list-inside">
+                            {r.reasoning.map((x) => (
+                              <li key={x}>{x}</li>
+                            ))}
+                          </ul>
                         </div>
                       </details>
                     )}

--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -109,15 +109,9 @@ export default function EligibilityReport() {
                     : '—'}
                 </div>
 
-                {/* Reasoning/rationale safe check */}
-                {(Array.isArray(r.reasoning) && r.reasoning.length > 0) ||
-                (Array.isArray(r.rationale) && r.rationale.length > 0) ? (
+                {Array.isArray(r.reasoning) && r.reasoning.length > 0 ? (
                   <div className="text-xs text-gray-700">
-                    {Array.isArray(r.reasoning)
-                      ? r.reasoning.join(', ')
-                      : Array.isArray(r.rationale)
-                      ? r.rationale.join(', ')
-                      : ''}
+                    {r.reasoning.join(', ')}
                   </div>
                 ) : null}
 

--- a/frontend/src/lib/normalize.ts
+++ b/frontend/src/lib/normalize.ts
@@ -1,13 +1,23 @@
+import type { EligibilityItem } from './types';
+
 export function toArray(value: string | string[] | null | undefined): string[] {
   if (value == null) return [];
   return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
 }
 
-export function normalizeEligibility<T extends { missing_fields?: string | string[] }>(
-  arr: T[]
-): (Omit<T, 'missing_fields'> & { missing_fields: string[] })[] {
+export function normalizeEligibility(
+  arr: Array<Record<string, any>> | null | undefined
+): EligibilityItem[] {
   return (arr ?? []).map((item) => ({
-    ...item,
+    name: item.name ?? item.program ?? '',
+    eligible: typeof item.eligible === 'boolean' ? item.eligible : null,
     missing_fields: toArray(item.missing_fields),
+    estimated_amount:
+      typeof item.estimated_amount === 'number'
+        ? item.estimated_amount
+        : undefined,
+    reasoning: toArray(item.reasoning ?? item.reasoning_steps),
+    next_steps: item.next_steps ?? undefined,
+    requiredForms: toArray(item.requiredForms),
   }));
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,13 +11,11 @@ export interface CaseDoc {
 export interface EligibilityItem {
   name: string;
   eligible: boolean | null;
-  score?: number;
-  estimated_amount?: number;
   missing_fields: string[];
+  estimated_amount?: number;
+  reasoning?: string[];
   next_steps?: string;
   requiredForms?: string[];
-  reasoning?: string[] | string;
-  rationale?: string[];
 }
 
 export interface CaseSnapshot {
@@ -32,21 +30,10 @@ export interface CaseSnapshot {
   updatedAt?: string;
 }
 
-export type GrantResult = {
-  program: string;
-  eligible: boolean | null;
-  score?: number;
-  estimated_amount?: number | null;
-  requiredForms?: string[];
-  reasoning_steps?: string[];
-  clarifying_questions?: string[];
-  missing_fields: string[];
-};
-
 export type ResultsEnvelope = {
-  results: GrantResult[];
+  results: EligibilityItem[];
   requiredForms: string[];
 };
 
-export type EligibilityReport = ResultsEnvelope | GrantResult[];
+export type EligibilityReport = ResultsEnvelope | EligibilityItem[];
 

--- a/frontend/tests/eligibility-report.mapping.test.ts
+++ b/frontend/tests/eligibility-report.mapping.test.ts
@@ -21,4 +21,33 @@ describe('normalizeEligibility', () => {
     const out = normalizeEligibility(input);
     expect(out[0].missing_fields).toEqual(['x']);
   });
+  it('handles nullish input', () => {
+    expect(normalizeEligibility(null)).toEqual([]);
+    expect(normalizeEligibility(undefined)).toEqual([]);
+  });
+  it('preserves and normalizes fields', () => {
+    const input = [
+      {
+        program: 'p',
+        eligible: true,
+        missing_fields: null,
+        estimated_amount: 100,
+        reasoning: 'because',
+        next_steps: null,
+        requiredForms: 'formA',
+      },
+    ];
+    const out = normalizeEligibility(input);
+    expect(out).toEqual([
+      {
+        name: 'p',
+        eligible: true,
+        missing_fields: [],
+        estimated_amount: 100,
+        reasoning: ['because'],
+        next_steps: undefined,
+        requiredForms: ['formA'],
+      },
+    ]);
+  });
 });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "types": [
-      "node"
+      "node",
+      "jest",
+      "@testing-library/jest-dom"
     ],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- normalize eligibility responses into strict `EligibilityItem` objects
- simplify API to return normalized eligibility data without casts
- update dashboard and report pages to use new reasoning arrays
- add normalization tests for missing fields and null inputs

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68a5fc663e80832795c7e32fb1140537