### PR TITLE
fix: handle empty values in merge

### DIFF
--- a/ai-agent/tests/test_merge_utils.py
+++ b/ai-agent/tests/test_merge_utils.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+import pytest
+
+# Allow importing modules from the ai-agent service directory
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from utils.merge import merge_preserving_user
+
+
+@pytest.mark.parametrize("empty", [None, "", [], {}, ()])
+def test_empty_values_are_overwritten(empty):
+    user = {"field": empty}
+    inferred = {"field": "inferred"}
+    merged, steps = merge_preserving_user(user, inferred)
+
+    assert merged["field"] == "inferred"
+    assert any('filled "field" from inference' in s for s in steps)
+
+
+def test_non_empty_values_are_preserved():
+    user = {"field": "user"}
+    inferred = {"field": "inferred"}
+    merged, steps = merge_preserving_user(user, inferred)
+
+    assert merged["field"] == "user"
+    assert any('kept user value for "field"' in s for s in steps)
+

--- a/ai-agent/utils/merge.py
+++ b/ai-agent/utils/merge.py
@@ -3,7 +3,20 @@ from copy import deepcopy
 from typing import Any, Dict, Tuple, List
 
 
-EMPTY_VALUES = {None, "", [], {}, ()}
+def is_empty(value: Any) -> bool:
+    """Return ``True`` if ``value`` should be considered empty.
+
+    ``None`` and ``""`` are treated as empty, as well as any empty iterable or
+    mapping such as ``list``, ``tuple``, ``set`` or ``dict``. This mirrors the
+    behaviour expected by :func:`merge_preserving_user` without relying on
+    unhashable types inside a set at import time.
+    """
+
+    if value is None or value == "":
+        return True
+    if isinstance(value, (list, tuple, set, frozenset, dict)) and len(value) == 0:
+        return True
+    return False
 
 
 def merge_preserving_user(
@@ -18,7 +31,7 @@ def merge_preserving_user(
     merged = deepcopy(user_payload)
     steps: List[str] = []
     for key, value in inferred.items():
-        if key not in merged or merged[key] in EMPTY_VALUES:
+        if key not in merged or is_empty(merged[key]):
             merged[key] = value
             steps.append(f'filled "{key}" from inference')
         else:


### PR DESCRIPTION
## Summary
- add dedicated empty-value helper to avoid unhashable set elements
- use helper in merge to overwrite user fields only when truly empty
- test merge utility for consistent handling of empty values

## Testing
- `pytest ai-agent/tests/test_merge_utils.py -q`
- `pytest ai-agent/tests/test_form_fill_merge.py -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `uvicorn main:app --reload --port 8003` *(fails: Form data requires "python-multipart" to be installed.)*


------
https://chatgpt.com/codex/tasks/task_b_68a7610c0b348327b19919ea30b53b7b