### PR TITLE
Expose FastAPI app in eligibility engine

### DIFF
--- a/eligibility-engine/engine.py
+++ b/eligibility-engine/engine.py
@@ -1,12 +1,22 @@
 from pathlib import Path
 import json
 from typing import List, Dict, Any
+
+from fastapi import FastAPI
+
 from common.logger import get_logger
 
 from grants_loader import load_grants
 from rules_utils import check_rules, check_rule_groups, estimate_award
 
+app = FastAPI()
+
 logger = get_logger(__name__)
+
+
+@app.get("/healthz")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}
 
 
 def analyze_eligibility(


### PR DESCRIPTION
## Summary
- define FastAPI `app` in `eligibility-engine/engine.py`
- add basic `/healthz` endpoint for service health checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `PYTHONPATH=.. timeout 5 uvicorn engine:app --reload --host 0.0.0.0 --port 4001`

------
https://chatgpt.com/codex/tasks/task_b_68a8a19401088327a2024c3955869194