### PR TITLE
codemod: update imports from @/lib/api to @/lib/apiClient

### DIFF
--- a/frontend/src/app/dashboard/documents/page.tsx
+++ b/frontend/src/app/dashboard/documents/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getStatus, uploadFile } from '@/lib/api';
+import { getStatus, uploadFile } from '@/lib/apiClient';
 import { getCaseId, setCaseId } from '@/lib/case-store';
 import type { CaseSnapshot, CaseDoc } from '@/lib/types';
 import { safeError } from '@/utils/logger';

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getStatus } from '@/lib/api';
+import { getStatus } from '@/lib/apiClient';
 import { getCaseId, setCaseId } from '@/lib/case-store';
 import type { CaseSnapshot } from '@/lib/types';
 import { safeError } from '@/utils/logger';

--- a/frontend/src/app/dashboard/questionnaire/page.tsx
+++ b/frontend/src/app/dashboard/questionnaire/page.tsx
@@ -6,7 +6,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import FormInput from '@/components/FormInput';
-import { getStatus, postQuestionnaire } from '@/lib/api';
+import { getStatus, postQuestionnaire } from '@/lib/apiClient';
 import Stepper from '@/components/Stepper';
 import { safeError, safeLog } from '@/utils/logger';
 import { getCaseId, setCaseId } from '@/lib/case-store';

--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getStatus, postEligibilityReport } from '@/lib/api';
+import { getStatus, postEligibilityReport } from '@/lib/apiClient';
 import { getCaseId, setCaseId } from '@/lib/case-store';
 import type { CaseSnapshot } from '@/lib/types';
 import { safeError } from '@/utils/logger';

--- a/package.json
+++ b/package.json
@@ -12,5 +12,10 @@
     "morgan": "1.10.1",
     "multer": "2.0.2",
     "form-data": "4.0.4"
+  },
+  "devDependencies": {
+    "@babel/parser": "^7.25.9",
+    "glob": "^10.4.5",
+    "recast": "^0.23.9"
   }
 }

--- a/scripts/rename-api-imports.js
+++ b/scripts/rename-api-imports.js
@@ -46,22 +46,15 @@ files.forEach((file) => {
     (n) => n.type === 'ImportDeclaration'
   );
 
-  const hasApiClientImport = importDeclarations.some((d) =>
-    typeof d.source.value === 'string' && d.source.value.endsWith('apiClient')
-  );
-  if (hasApiClientImport) {
-    return; // skip file
-  }
-
   let fileChanged = false;
 
   importDeclarations.forEach((decl) => {
     const val = decl.source.value;
-    if (typeof val === 'string' && val.endsWith('/api')) {
-      const newVal = val.replace(/\/api$/, '/apiClient');
+    if (typeof val === 'string' && val === '@/lib/api') {
+      const newVal = '@/lib/apiClient';
       const quote =
-        (decl.source.extra && decl.source.extra.raw && decl.source.extra.raw[0] === '\'')
-          ? '\''
+        decl.source.extra && decl.source.extra.raw && decl.source.extra.raw[0] === "'"
+          ? "'"
           : '"';
       decl.source.value = newVal;
       if (decl.source.extra) {


### PR DESCRIPTION
## Summary
- add codemod script to rewrite `@/lib/api` imports to `@/lib/apiClient`
- replace existing frontend imports with `@/lib/apiClient`
- document new dependencies for the codemod

## Testing
- `node scripts/rename-api-imports.js --root frontend/src --dry` *(fails: Cannot find module 'glob')*
- `npm i -D recast @babel/parser glob` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fparser)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b098ecf08327ad3ddbc3f19fba2c