### PR TITLE
Expose questionnaire fields in status and support PDF OCR

### DIFF
--- a/ai-analyzer/ocr_utils.py
+++ b/ai-analyzer/ocr_utils.py
@@ -6,6 +6,11 @@ import io
 from typing import Optional
 
 try:  # pragma: no cover - external dependency may be missing
+    import pdfplumber  # type: ignore
+except Exception:  # pragma: no cover - gracefully handle missing libs
+    pdfplumber = None  # type: ignore
+
+try:  # pragma: no cover - external dependency may be missing
     import pytesseract  # type: ignore
     from PIL import Image  # type: ignore
 except Exception:  # pragma: no cover - gracefully handle missing libs
@@ -14,7 +19,16 @@ except Exception:  # pragma: no cover - gracefully handle missing libs
 
 
 def extract_text(file_bytes: bytes) -> str:
-    """Return extracted text using Tesseract when available."""
+    """Return extracted text using PDF or image OCR when available."""
+    if file_bytes[:4] == b"%PDF" and pdfplumber:
+        try:  # pragma: no cover - depends on external library
+            with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
+                text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+            if text.strip():
+                return text.strip()
+        except Exception:
+            pass
+
     if pytesseract and Image:
         try:  # pragma: no cover - relies on external binaries
             image = Image.open(io.BytesIO(file_bytes))
@@ -25,8 +39,8 @@ def extract_text(file_bytes: bytes) -> str:
 
     # Fallback to simple decoding
     try:
-        return file_bytes.decode("utf-8").strip()
+        return file_bytes.decode("utf-8", errors="ignore").strip()
     except Exception:
         # Final fallback for binary files
-        return "sample extracted text"
+        return ""
 

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -8,3 +8,4 @@ flake8==6.1.0
 pydantic==2.9.2
 pydantic-settings==2.3.4
 PyYAML==6.0.2
+pdfplumber==0.11.0

--- a/ai-analyzer/tests/payroll_records_bluewave_fixed.pdf
+++ b/ai-analyzer/tests/payroll_records_bluewave_fixed.pdf
@@ -1,0 +1,38 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 84 >>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(EIN 12-3456789) Tj
+0 -20 Td
+(Q1 2023 revenue $120000) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000374 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+454
+%%EOF

--- a/ai-analyzer/tests/test_analyze_expanded.py
+++ b/ai-analyzer/tests/test_analyze_expanded.py
@@ -1,9 +1,5 @@
 import io
-
-import pytest
-import env_setup  # noqa: F401
-from fastapi.testclient import TestClient
-import io
+from pathlib import Path
 
 import pytest
 import env_setup  # noqa: F401
@@ -92,4 +88,25 @@ def test_analyze_multipart_file_too_large() -> None:
     )
     assert resp.status_code == 400
     assert resp.json()["error"] == "File too large. Maximum allowed size is 5MB."
+
+
+def test_analyze_pdf_sample() -> None:
+    with open(
+        Path(__file__).parent / "payroll_records_bluewave_fixed.pdf", "rb"
+    ) as f:
+        resp = client.post(
+            "/analyze",
+            files={
+                "file": (
+                    "payroll_records_bluewave_fixed.pdf",
+                    f,
+                    "application/pdf",
+                )
+            },
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ein"] == "12-3456789"
+    assert data["quarterly_revenues"]["2023"]["Q1"] == 120000
+    assert data["source"] == "file"
 

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -9,7 +9,7 @@ export const api = axios.create({
 });
 
 export async function getStatus(caseId?: string): Promise<CaseSnapshot> {
-  const url = caseId ? `/status/${caseId}` : '/case/status';
+  const url = `/case/status${caseId ? `?caseId=${caseId}` : ''}`;
   const res = await api.get(url);
   return transformCase(res.data);
 }
@@ -78,12 +78,18 @@ function transformCase(data: any): CaseSnapshot {
       ? data.eligibility
       : [];
 
+  const questionnaire = {
+    data: data.questionnaire?.data || {},
+    missingFieldsHint: data.questionnaire?.missingFieldsHint || [],
+    lastUpdated: data.questionnaire?.lastUpdated,
+  };
+
   return {
     caseId: data.caseId,
     status: data.status,
     documents: data.documents || [],
     analyzerFields: data.analyzerFields || data.analyzer?.fields || {},
-    questionnaire: data.questionnaire || {},
+    questionnaire,
     eligibility: rawResults.length ? normalizeEligibility(rawResults) : [],
     generatedForms: data.generatedForms || [],
     createdAt: data.createdAt,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -23,7 +23,11 @@ export interface CaseSnapshot {
   status?: CaseStatus;
   documents?: CaseDoc[];
   analyzerFields?: Record<string, unknown>;
-  questionnaire?: { data?: Record<string, any>; lastUpdated?: string };
+  questionnaire?: {
+    data?: Record<string, any>;
+    missingFieldsHint?: string[];
+    lastUpdated?: string;
+  };
   eligibility?: EligibilityItem[];
   generatedForms?: Array<{ name: string; status?: string; link?: string }>;
   createdAt?: string;

--- a/server/tests/case.status.test.js
+++ b/server/tests/case.status.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+process.env.SKIP_DB = 'true';
+const app = require('../index');
+const { createCase, updateCase, resetStore } = require('../utils/pipelineStore');
+
+describe('case status endpoint', () => {
+  beforeEach(() => {
+    process.env.SKIP_DB = 'true';
+    resetStore();
+  });
+
+  test('returns questionnaire and analyzer fields', async () => {
+    const caseId = await createCase('dev-user');
+    const now = new Date().toISOString();
+    await updateCase(caseId, {
+      analyzer: { fields: { ein: '11-1111111' }, lastUpdated: now },
+      questionnaire: { data: { foo: 'bar' }, lastUpdated: now },
+      eligibility: { results: [{ missing_fields: ['a'] }], lastUpdated: now },
+    });
+    const res = await request(app)
+      .get('/api/case/status')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    expect(res.body.analyzerFields).toEqual({ ein: '11-1111111' });
+    expect(res.body.questionnaire.data).toEqual({ foo: 'bar' });
+    expect(res.body.questionnaire.missingFieldsHint).toEqual(['a']);
+  });
+});


### PR DESCRIPTION
## Summary
- include questionnaire details in `/case/status` and `/status/:caseId`
- extract text from PDF uploads using pdfplumber
- add analyzer test PDF and map questionnaire data on the client

## Testing
- ⚠️ `npm test` (server) *(missing jest)*
- ⚠️ `pytest` (ai-analyzer) *(missing httpx)*
- ⚠️ `npm test` (frontend) *(jest configuration error)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b3acff5c83278f16df932ef9da6b