### PR TITLE
feat: add case init endpoint and reset logic

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -9,8 +9,16 @@ export const api = axios.create({
 });
 
 export async function getStatus(caseId?: string): Promise<CaseSnapshot> {
-  const url = `/case/status${caseId ? `?caseId=${caseId}` : ''}`;
+  if (!caseId) {
+    return { caseId: null, status: 'empty' };
+  }
+  const url = `/case/status?caseId=${caseId}`;
   const res = await api.get(url);
+  return transformCase(res.data);
+}
+
+export async function initCase(): Promise<CaseSnapshot> {
+  const res = await api.post('/case/init');
   return transformCase(res.data);
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,4 +1,10 @@
-export type CaseStatus = 'open' | 'submitted' | 'processing' | 'complete' | 'error';
+export type CaseStatus =
+  | 'empty'
+  | 'open'
+  | 'submitted'
+  | 'processing'
+  | 'complete'
+  | 'error';
 
 export interface CaseDoc {
   key?: string;
@@ -19,7 +25,7 @@ export interface EligibilityItem {
 }
 
 export interface CaseSnapshot {
-  caseId: string;
+  caseId: string | null;
   status?: CaseStatus;
   documents?: CaseDoc[];
   analyzerFields?: Record<string, unknown>;

--- a/server/tests/case.status.test.js
+++ b/server/tests/case.status.test.js
@@ -25,4 +25,17 @@ describe('case status endpoint', () => {
     expect(res.body.questionnaire.data).toEqual({ foo: 'bar' });
     expect(res.body.questionnaire.missingFieldsHint).toEqual(['a']);
   });
+
+  test('returns empty status when no caseId provided', async () => {
+    const res = await request(app).get('/api/case/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ caseId: null, status: 'empty' });
+  });
+
+  test('init endpoint creates new case', async () => {
+    const res = await request(app).post('/api/case/init');
+    expect(res.status).toBe(200);
+    expect(res.body.caseId).toBeTruthy();
+    expect(res.body.status).toBe('open');
+  });
 });


### PR DESCRIPTION
## Summary
- add `/case/init` endpoint and return empty status when no case
- allow API client to init cases and skip status fetch when none
- show Start Application button until case is created

## Testing
- `cd server && npm test` *(fails: jest not found)*
- `cd server && npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `cd frontend && npm test` *(fails: Jest encountered an unexpected token)*
- `cd frontend && npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68a8b650d6f483279a57b361e48e1728