### PR TITLE
feat: require explicit case resume on dashboard

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -8,7 +8,7 @@ export const api = axios.create({
   baseURL: `${base.replace(/\/+$/, '')}/api`,
 });
 
-export async function getStatus(caseId?: string): Promise<CaseSnapshot> {
+export async function getStatus(caseId?: string | null): Promise<CaseSnapshot> {
   if (!caseId) {
     return { caseId: null, status: 'empty' };
   }

--- a/frontend/src/lib/case-store.ts
+++ b/frontend/src/lib/case-store.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 
 interface CaseState {
-  caseId?: string;
+  caseId: string | null;
   setCaseId: (id: string) => void;
   clearCaseId: () => void;
 }
 
 export const useCaseStore = create<CaseState>((set) => ({
-  caseId: undefined,
+  caseId: null,
   setCaseId: (id: string) => {
     set({ caseId: id });
     if (typeof window !== 'undefined') {
@@ -17,7 +17,7 @@ export const useCaseStore = create<CaseState>((set) => ({
     }
   },
   clearCaseId: () => {
-    set({ caseId: undefined });
+    set({ caseId: null });
     if (typeof window !== 'undefined') {
       try {
         localStorage.removeItem('caseId');
@@ -26,10 +26,10 @@ export const useCaseStore = create<CaseState>((set) => ({
   },
 }));
 
-export function getCaseId(): string | undefined {
+export function getCaseId(loadFromStorage = false): string | null {
   const { caseId } = useCaseStore.getState();
   if (caseId) return caseId;
-  if (typeof window !== 'undefined') {
+  if (loadFromStorage && typeof window !== 'undefined') {
     try {
       const stored = localStorage.getItem('caseId');
       if (stored) {
@@ -38,7 +38,7 @@ export function getCaseId(): string | undefined {
       }
     } catch {}
   }
-  return undefined;
+  return null;
 }
 
 export function setCaseId(id: string) {
@@ -49,13 +49,4 @@ export function clearCaseId() {
   useCaseStore.getState().clearCaseId();
 }
 
-// Initialize from localStorage on the client
-if (typeof window !== 'undefined') {
-  try {
-    const stored = localStorage.getItem('caseId');
-    if (stored) {
-      useCaseStore.setState({ caseId: stored });
-    }
-  } catch {}
-}
 

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -1,14 +1,45 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Dashboard from '@/app/dashboard/page';
-import * as api from '@/lib/api';
+import { getCaseId, clearCaseId } from '@/lib/case-store';
+import * as api from '@/lib/apiClient';
 
-jest.mock('@/lib/api');
+jest.mock('@/lib/apiClient');
 
 (test as any).timeout?.(10000);
 
 describe('Dashboard', () => {
-  it('renders programs and hints', async () => {
-    (api.getStatus as jest.Mock).mockResolvedValue({
+  beforeEach(() => {
+    jest.resetAllMocks();
+    localStorage.clear();
+    clearCaseId();
+    (api.getStatus as jest.Mock).mockResolvedValue({ caseId: null, status: 'empty' });
+  });
+
+  it('shows start button on fresh load', async () => {
+    render(<Dashboard />);
+    expect(await screen.findByText('Start Application')).toBeInTheDocument();
+    expect(screen.queryByText('Resume Application')).not.toBeInTheDocument();
+  });
+
+  it('starts a new application', async () => {
+    (api.initCase as jest.Mock).mockResolvedValue({
+      caseId: 'c1',
+      status: 'open',
+      analyzerFields: {},
+      eligibility: [],
+    });
+
+    render(<Dashboard />);
+    const start = await screen.findByText('Start Application');
+    fireEvent.click(start);
+    expect(await screen.findByText(/Case ID: c1/)).toBeInTheDocument();
+    expect(getCaseId()).toBe('c1');
+  });
+
+  it('resumes a saved application', async () => {
+    localStorage.setItem('caseId', 'c1');
+    (api.getStatus as jest.Mock).mockResolvedValueOnce({ caseId: null, status: 'empty' });
+    (api.getStatus as jest.Mock).mockResolvedValueOnce({
       caseId: 'c1',
       status: 'open',
       analyzerFields: { field1: 'value' },
@@ -21,9 +52,15 @@ describe('Dashboard', () => {
         },
       ],
     });
+
     render(<Dashboard />);
-    expect(await screen.findByText('Program A')).toBeInTheDocument();
+    const resume = await screen.findByText('Resume Application');
+    fireEvent.click(resume);
+    expect(await screen.findByText(/Case ID: c1/)).toBeInTheDocument();
+    expect(getCaseId()).toBe('c1');
+    expect(screen.getByText('Program A')).toBeInTheDocument();
     expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText(/Next: Do something/)).toBeInTheDocument();
   });
 });
+

--- a/frontend/tests/documents.test.tsx
+++ b/frontend/tests/documents.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Documents from '@/app/dashboard/documents/page';
-import * as api from '@/lib/api';
+import * as api from '@/lib/apiClient';
 
-jest.mock('@/lib/api');
+jest.mock('@/lib/apiClient');
 
 (test as any).timeout?.(10000);
 

--- a/frontend/tests/eligibility-report.test.tsx
+++ b/frontend/tests/eligibility-report.test.tsx
@@ -1,12 +1,18 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import EligibilityReport from '@/app/eligibility-report/page';
-import * as api from '@/lib/api';
+import { setCaseId, clearCaseId } from '@/lib/case-store';
+import * as api from '@/lib/apiClient';
 
-jest.mock('@/lib/api');
+jest.mock('@/lib/apiClient');
 
 (test as any).timeout?.(10000);
 
 describe('EligibilityReport', () => {
+  beforeEach(() => {
+    clearCaseId();
+    setCaseId('c1');
+  });
+
   it('shows generating indicator', async () => {
     (api.getStatus as jest.Mock).mockResolvedValue({ caseId: 'c1', eligibility: [] });
     let resolve: any;


### PR DESCRIPTION
## Summary
- stop auto-hydrating caseId; require explicit resume
- add resume flow and buttons on dashboard
- update tests for new start/resume behaviour

## Testing
- `npm test --prefix frontend` *(fails: Jest encountered an unexpected token parsing TS files)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b9cc402c83278f19f5812586af3b