### PR TITLE
feat: dynamic required documents

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -22,6 +22,11 @@ export async function initCase(): Promise<CaseSnapshot> {
   return transformCase(res.data);
 }
 
+export async function getRequiredDocuments(caseId: string): Promise<string[]> {
+  const res = await api.get(`/case/required-documents?caseId=${caseId}`);
+  return res.data.required;
+}
+
 // -------------------- FILE UPLOAD --------------------
 export async function uploadFile(formData: FormData): Promise<CaseSnapshot> {
   const res = await api.post('/files/upload', formData, {

--- a/frontend/tests/__snapshots__/upload-step.test.tsx.snap
+++ b/frontend/tests/__snapshots__/upload-step.test.tsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UploadStep renders required documents 1`] = `
+<DocumentFragment>
+  <div
+    class="space-y-4"
+  >
+    <h2
+      class="text-2xl font-bold"
+    >
+      Upload Documents
+    </h2>
+    <ul
+      class="space-y-2"
+    >
+      <li
+        class="flex items-center space-x-2 text-sm"
+      >
+        <span>
+          ⬜ Tax Returns
+        </span>
+        <input
+          data-testid="upload-Tax_Returns"
+          type="file"
+        />
+      </li>
+      <li
+        class="flex items-center space-x-2 text-sm"
+      >
+        <span>
+          ⬜ Payroll Records
+        </span>
+        <input
+          data-testid="upload-Payroll_Records"
+          type="file"
+        />
+      </li>
+    </ul>
+    <div
+      class="flex justify-between"
+    >
+      <button
+        class="px-3 py-2 rounded bg-gray-200"
+        type="button"
+      >
+        Back
+      </button>
+      <button
+        class="px-3 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+        disabled=""
+        type="button"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -11,6 +11,7 @@ describe('Dashboard wizard', () => {
     localStorage.clear();
     clearCaseId();
     (api.getStatus as jest.Mock).mockResolvedValue({ caseId: null, status: 'empty' });
+    (api.getRequiredDocuments as jest.Mock).mockResolvedValue([]);
   });
 
   it('advances from start to upload after questionnaire', async () => {

--- a/frontend/tests/upload-step.test.tsx
+++ b/frontend/tests/upload-step.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import UploadStep from '@/app/dashboard/_steps/UploadStep';
+import * as api from '@/lib/apiClient';
+import type { CaseDoc } from '@/lib/types';
+
+jest.mock('@/lib/apiClient');
+
+describe('UploadStep', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders required documents', async () => {
+    (api.getRequiredDocuments as jest.Mock).mockResolvedValue([
+      'Tax Returns',
+      'Payroll Records',
+    ]);
+    const { asFragment } = render(
+      <UploadStep
+        caseId="c1"
+        docs={[]}
+        onUploaded={jest.fn()}
+        onNext={jest.fn()}
+        onBack={jest.fn()}
+      />
+    );
+    await screen.findByText(/Tax Returns/);
+    await screen.findByText(/Payroll Records/);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('updates checklist after uploads', async () => {
+    (api.getRequiredDocuments as jest.Mock).mockResolvedValue([
+      'Tax Returns',
+      'Payroll Records',
+    ]);
+    const docs: CaseDoc[] = [];
+    (api.uploadFile as jest.Mock).mockImplementation(async (fd: FormData) => {
+      const key = fd.get('key') as string;
+      const file = fd.get('file') as File;
+      docs.push({
+        key,
+        filename: file.name,
+        size: file.size,
+        contentType: file.type,
+        uploadedAt: 'now',
+      });
+      return { caseId: 'c1', documents: docs };
+    });
+    let rerenderFn: any;
+    const handleUploaded = (snap: any) => {
+      docs.splice(0, docs.length, ...snap.documents);
+      rerenderFn(
+        <UploadStep
+          caseId="c1"
+          docs={docs}
+          onUploaded={handleUploaded}
+          onNext={jest.fn()}
+          onBack={jest.fn()}
+        />
+      );
+    };
+    const { rerender } = render(
+      <UploadStep
+        caseId="c1"
+        docs={docs}
+        onUploaded={handleUploaded}
+        onNext={jest.fn()}
+        onBack={jest.fn()}
+      />
+    );
+    rerenderFn = rerender;
+    const taxInput = await screen.findByTestId('upload-Tax_Returns');
+    const file1 = new File(['a'], 'tax.pdf', { type: 'application/pdf' });
+    fireEvent.change(taxInput, { target: { files: [file1] } });
+    await waitFor(() => expect(api.uploadFile).toHaveBeenCalled());
+    expect(screen.getByText(/Tax Returns/).textContent).toContain('✅');
+    const payrollInput = screen.getByTestId('upload-Payroll_Records');
+    const file2 = new File(['b'], 'payroll.pdf', { type: 'application/pdf' });
+    fireEvent.change(payrollInput, { target: { files: [file2] } });
+    await waitFor(() => expect(api.uploadFile).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/Payroll Records/).textContent).toContain('✅');
+    const nextBtn = screen.getByText('Next') as HTMLButtonElement;
+    await waitFor(() => expect(nextBtn.disabled).toBe(false));
+  });
+});

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { createCase, getCase } = require('../utils/pipelineStore');
+const { getRequiredDocuments } = require('../utils/requiredDocuments');
 
 const router = express.Router();
 
@@ -61,6 +62,16 @@ router.post('/case/init', async (req, res) => {
     documents: c.documents,
     normalized: c.normalized,
   });
+});
+
+router.get('/case/required-documents', async (req, res) => {
+  const { caseId } = req.query;
+  const userId = 'dev-user';
+  if (!caseId) return res.status(400).json({ error: 'caseId required' });
+  const c = await getCase(userId, caseId);
+  if (!c) return res.status(404).json({ error: 'Case not found' });
+  const requiredDocs = getRequiredDocuments(c);
+  res.json({ required: requiredDocs });
 });
 
 module.exports = router;

--- a/server/tests/case.required-documents.test.js
+++ b/server/tests/case.required-documents.test.js
@@ -1,0 +1,32 @@
+const request = require('supertest');
+process.env.SKIP_DB = 'true';
+const app = require('../index');
+const { createCase, updateCase, resetStore } = require('../utils/pipelineStore');
+
+describe('GET /api/case/required-documents', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  test('returns required documents for case', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, {
+      questionnaire: { data: { employees: 5, ownerVeteran: true } },
+    });
+    const res = await request(app).get(
+      `/api/case/required-documents?caseId=${caseId}`
+    );
+    expect(res.status).toBe(200);
+    const docs = res.body.required;
+    expect(docs).toContain('Tax Returns (last 2–3 years)');
+    expect(docs).toContain('Quarterly revenue statements (2020–2021)');
+    expect(docs).toContain('DD214 (Proof of Veteran Status)');
+  });
+
+  test('404 when case not found', async () => {
+    const res = await request(app).get(
+      '/api/case/required-documents?caseId=missing'
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/tests/required.documents.unit.test.js
+++ b/server/tests/required.documents.unit.test.js
@@ -1,0 +1,21 @@
+const { getRequiredDocuments, ALWAYS_REQUIRED } = require('../utils/requiredDocuments');
+
+describe('getRequiredDocuments', () => {
+  test('returns always required documents', () => {
+    const docs = getRequiredDocuments({ questionnaire: { data: {} } });
+    ALWAYS_REQUIRED.forEach((d) => expect(docs).toContain(d));
+  });
+
+  test('adds ERC documents when employees > 0', () => {
+    const c = { questionnaire: { data: { employees: 5 } } };
+    const docs = getRequiredDocuments(c);
+    expect(docs).toContain('Quarterly revenue statements (2020–2021)');
+    expect(docs).toContain('Government shutdown orders (if applicable)');
+  });
+
+  test('adds veteran docs when ownerVeteran true', () => {
+    const c = { questionnaire: { data: { ownerVeteran: true } } };
+    const docs = getRequiredDocuments(c);
+    expect(docs).toContain('DD214 (Proof of Veteran Status)');
+  });
+});

--- a/server/utils/requiredDocuments.js
+++ b/server/utils/requiredDocuments.js
@@ -1,0 +1,74 @@
+const ALWAYS_REQUIRED = [
+  "Tax Returns (last 2–3 years)",
+  "Payroll Records (Form 941 / W-2)",
+  "Bank Statements (last 3–6 months)",
+  "Business License / Incorporation Docs",
+  "Owner ID (Driver’s License / Passport)"
+];
+
+function hasEligibility(caseObj, name) {
+  const list = caseObj?.eligibility?.results || caseObj?.eligibility || [];
+  return Array.isArray(list) && list.some((r) => r.name === name);
+}
+
+function getRequiredDocuments(caseObj = {}) {
+  const req = new Set(ALWAYS_REQUIRED);
+  const q = caseObj.questionnaire?.data || {};
+  const fields = caseObj.analyzer?.fields || caseObj.analyzerFields || {};
+
+  const employees = Number(q.employees || q.numberOfEmployees || fields.employees || 0);
+  if (employees > 0 || hasEligibility(caseObj, "ERC")) {
+    req.add("Quarterly revenue statements (2020–2021)");
+    req.add("Government shutdown orders (if applicable)");
+  }
+
+  if (q.ownerVeteran || q.ownerSpouseVeteran) {
+    req.add("DD214 (Proof of Veteran Status)");
+    if (q.ownerSpouseVeteran) {
+      req.add("Marriage certificate (if spouse)");
+    }
+  }
+
+  const minorityEthnicities = [
+    "Black",
+    "Hispanic",
+    "Native American",
+    "Asian",
+    "Other Minority",
+  ];
+  if (
+    q.ownerGender === "Female" ||
+    minorityEthnicities.includes(q.ownerEthnicity)
+  ) {
+    req.add("Certification (if available)");
+    req.add("Ownership docs (Operating Agreement, Cap Table)");
+  }
+
+  if (q.ruralArea || q.isRural) {
+    req.add("Proof of business address (Lease / Utility Bill)");
+    req.add("Census/USDA map extract");
+  }
+
+  if (q.opportunityZone || q.isOpportunityZone) {
+    req.add("Lease or Utility Bill at OZ address");
+    req.add("IRS Form 8996 (if exists)");
+  }
+
+  if (
+    q.revenueDrop ||
+    q.revenueDropPercent ||
+    fields.revenue_drop_2020_pct ||
+    fields.revenue_drop_2021_pct ||
+    q.govShutdown ||
+    q.shutdown ||
+    fields.shutdown_2020 === 'yes' ||
+    fields.shutdown_2021 === 'yes'
+  ) {
+    req.add("Comparative revenue statements (before/after drop)");
+    req.add("Local/state shutdown orders");
+  }
+
+  return Array.from(req);
+}
+
+module.exports = { getRequiredDocuments, ALWAYS_REQUIRED };


### PR DESCRIPTION
## Summary
- add utility to compute required documents per case
- expose new `/case/required-documents` API endpoint and client helper
- show tailored document checklist in upload step with progress

## Testing
- `cd server && npm test` *(fails: sh: 1: jest: not found)*
- `cd server && npm install` *(fails: npm error code E403)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab736f02448327b2bcc7eaf70e7312