### PR TITLE
Allow configurable Tesseract path in analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ ELIGIBILITY_ENGINE_URL=https://eligibility-engine:4001
 AI_AGENT_URL=https://ai-agent:5001
 ```
 
+The AI analyzer optionally reads `TESSERACT_CMD` to locate the Tesseract OCR binary
+if it isn't on the system `PATH`.
+
 ### Case Management API
 
 The frontend interacts with a simpler set of endpoints that manage a user's inâ€‘progress case:
@@ -114,6 +117,8 @@ The frontend interacts with a simpler set of endpoints that manage a user's inâ€
    ```bash
    cd ai-analyzer
    pip install -r requirements.txt
+   # optional: specify path to the Tesseract binary
+   export TESSERACT_CMD=/usr/bin/tesseract
    python -m uvicorn main:app --port 8000
    ```
 3. Start the AI agent service

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -5,6 +5,9 @@ and parses business fields such as EIN, W‑2 employee counts, quarterly revenue
 entity type. The `/analyze` endpoint accepts `application/pdf`, `image/png` and
 `image/jpeg` uploads.
 
+Set `TESSERACT_CMD` to the path of the Tesseract executable if it's not
+already available on your `PATH`.
+
 ## JSON / Text Input
 
 The `/analyze` endpoint also accepts raw text via JSON or `text/plain` payloads.
@@ -47,6 +50,8 @@ echo "" > dummy-cert
 echo "" > dummy-key
 cat > .env <<'EOF'
 NODE_ENV=development
+# optional: path to the Tesseract executable
+TESSERACT_CMD=/usr/bin/tesseract
 EOF
 
 $env:PYTHONPATH=".."

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -14,7 +14,8 @@ from upload_utils import validate_upload
 try:  # pragma: no cover - external dependency may be missing
     import pytesseract  # type: ignore
     from PIL import Image  # type: ignore
-    pytesseract.pytesseract.tesseract_cmd = r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
+    if settings.TESSERACT_CMD:
+        pytesseract.pytesseract.tesseract_cmd = settings.TESSERACT_CMD
 except Exception:  # pragma: no cover - gracefully handle missing libs
     pytesseract = None  # type: ignore
     Image = None  # type: ignore


### PR DESCRIPTION
## Summary
- make ai-analyzer read TESSERACT_CMD env var for Tesseract binary
- document optional TESSERACT_CMD usage in READMEs

## Testing
- `pytest` *(fails: starlette.testclient requires httpx; install attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68ab77f6337483278823161c381c2abd