### PR TITLE
feat: extract payroll total from analyzer text

### DIFF
--- a/DATA_CONTRACTS.md
+++ b/DATA_CONTRACTS.md
@@ -27,7 +27,7 @@ The following table enumerates all canonical keys understood by the eligibility 
 | owner_spouse_veteran | boolean | Owner's spouse is a veteran | Parse yes/no | Yes | `true` | Field Map |
 | owner_veteran | boolean | Business owner is a veteran | Parse yes/no | Yes | `true` | Field Map |
 | ownership_percentage | integer | Percent of business owned by applicant | Accept 0‑100; strip `%` | Yes | `100` | Field Map |
-| payroll_total | integer | Total payroll for relevant period | Strip `$`/`,` and store whole USD | No | `1200000` | Field Map |
+| payroll_total | integer | Company-wide payroll for the most recent year | Remove `$`, commas, parentheses; expand `k/m`; store whole USD | No | `1234567` | Field Map |
 | ppp_wages_double_dip | boolean | PPP wages reused for credits | Parse yes/no | No | `false` | Field Map |
 | project_cost | integer | Cost of proposed project | Strip `$`/`,` and store whole USD | Yes | `250000` | Field Map |
 | project_type | string | Type of project (e.g., solar, r&D) | Lowercase string | Yes | `"solar_installation"` | Field Map |

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -39,9 +39,18 @@ eligibility engine after normalization. Common field names include:
 | `employees` | `13` |
 | `revenue_drop_2020_pct` | `55%` |
 | `annual_revenue` | `$1,200,000` |
+| `payroll_total` | `$950k` |
 
 Additional aliases are documented in
 `eligibility-engine/contracts/field_map.json`.
+
+### Payroll Total Extraction
+
+The analyzer detects company‑wide payroll totals using phrases like "Total Payroll",
+"Payroll Total", "Gross Payroll", "Total Wages" and "Total Compensation". Amounts
+may appear in forms such as `$1,234,567.89`, `950k`, `2.3M` or with parentheses
+`($120,000)`. All values are normalized to whole USD before being returned as
+`payroll_total`.
 
 ## Local Development Setup
 


### PR DESCRIPTION
## Summary
- add payroll total extraction with currency normalization and ambiguity handling
- surface payroll totals in analyzer field output
- document payroll extraction patterns and extend unit tests

## Testing
- `PYTHONPATH=ai-analyzer pytest ai-analyzer/tests/test_nlp_parser.py`

------
https://chatgpt.com/codex/tasks/task_b_68ab7beef3a48327b4eba3ae4b9f3486