### PR TITLE
Align analyzer fields with engine schema and add coverage tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Align analyzer outputs with engine schema: completed `field_map.json` with canonical aliases and added coverage tests.

--- a/DATA_CONTRACTS.md
+++ b/DATA_CONTRACTS.md
@@ -42,24 +42,39 @@ The following table enumerates all canonical keys understood by the eligibility 
 | some_date | string | Generic date placeholder | ISO‑8601 date | No | `"2024-01-31"` | Field Map |
 | w2_employee_count | integer | Count of W‑2 employees | Convert to integer \>=0 | Yes | `25` | Both |
 | w2_part_time_count | integer | Number of part‑time W‑2 employees | Convert to integer \>=0 | No | `5` | Field Map |
+| quarterly_revenues | mapping | Nested map of yearly and quarterly revenues | Keys `YYYY` -> `Q1..Q4`; amounts normalized as currency | No | `{ "2023": { "Q1": 10000 } }` | Analyzer |
+| year_founded | integer | Year the company was founded | Accept 1800..current year | No | `2008` | Analyzer |
+| minority_owned | boolean | Business identified as minority‑owned | Parse yes/no | No | `true` | Analyzer |
+| female_owned | boolean | Business identified as woman‑owned | Parse yes/no | No | `true` | Analyzer |
+| ppp_reference | boolean | PPP loan is referenced in documents | Parse yes/no | No | `true` | Analyzer |
+| ertc_reference | boolean | ERTC reference detected in documents | Parse yes/no | No | `true` | Analyzer |
+
+## Field Synonyms & Canonical Keys
+
+| Aliases | Canonical Key |
+| --- | --- |
+| `ein` | `employer_identification_number` |
+| `employees` | `w2_employee_count` |
+| `employee_count` | `number_of_employees` |
+| `state`, `location_state` | `business_location_state` |
+| `country`, `location_country` | `business_location_country` |
+| `owner_is_veteran`, `veteran_owned` | `owner_veteran` |
+| `owner_is_spouse` | `owner_spouse` |
+| `revenue_drop_2020_pct` | `revenue_drop_2020_percent` |
+| `revenue_drop_2021_pct` | `revenue_drop_2021_percent` |
+| `shutdown_2020` | `government_shutdown_2020` |
+| `shutdown_2021` | `government_shutdown_2021` |
+| `ppp_double_dip` | `ppp_wages_double_dip` |
+| `ownership_pct` | `ownership_percentage` |
+| `biz_type` | `business_type` |
+| `economically_vulnerable` | `economically_vulnerable_area` |
 
 ## Analyzer-Only Fields
 
-These fields are currently emitted by the AI Analyzer but are not mapped in `field_map.json`.
-
-| Field | Type | Description | When Populated | Example |
-| --- | --- | --- | --- | --- |
-| quarterly_revenues | object | Nested map of yearly and quarterly revenues | When specific quarter revenue amounts are detected | `{ "2020": { "Q1": 10000 } }` |
-| year_founded | integer | Year the company was founded | When founding year is mentioned | `2008` |
-| minority_owned | boolean | Business identified as minority‑owned | When text mentions minority ownership | `true` |
-| female_owned | boolean | Business identified as woman‑owned | When text mentions female ownership | `true` |
-| veteran_owned | boolean | Business identified as veteran‑owned | When text mentions veteran ownership | `false` |
-| ppp_reference | boolean | PPP loan is referenced in documents | When OCR finds PPP keywords | `true` |
-| ertc_reference | boolean | ERTC is referenced in documents | When OCR finds ERTC keywords | `true` |
+All fields currently emitted by the AI Analyzer are represented in `field_map.json`.
 
 ## Discrepancies and Notes
 
-* **Analyzer-only fields:** The analyzer emits `quarterly_revenues`, `year_founded`, `minority_owned`, `female_owned`, `veteran_owned`, `ppp_reference`, and `ertc_reference`, but these do not appear in `field_map.json`. If the eligibility engine needs them, they should be added to the field map.
 * **Engine-only fields:** Many canonical fields such as `gov_shutdown`, `revenue_drop_percent`, and ownership attributes are defined in `field_map.json` but are not currently produced by the analyzer.
 
 ### Optional and Secondary Fields

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -1,151 +1,211 @@
 {
-  "ein": {
-    "target": "employer_identification_number",
-    "type": "ein",
-    "pattern": "^\\d{2}-?\\d{7}$"
-  },
   "employer_identification_number": {
+    "aliases": ["ein"],
     "target": "employer_identification_number",
     "type": "ein",
-    "pattern": "^\\d{2}-?\\d{7}$"
-  },
-  "employees": {
-    "target": "w2_employee_count",
-    "type": "int",
-    "min": 0
+    "normalize": {
+      "pattern": "^\\d{2}-?\\d{7}$"
+    }
   },
   "w2_employee_count": {
+    "aliases": ["employees"],
     "target": "w2_employee_count",
     "type": "int",
-    "min": 0
+    "normalize": {
+      "min": 0
+    }
   },
-  "country": {
+  "business_location_country": {
+    "aliases": ["country", "location_country"],
     "target": "business_location_country",
     "type": "string"
   },
-  "revenue_drop_2020_pct": {
+  "business_location_state": {
+    "aliases": ["state", "location_state"],
+    "target": "business_location_state",
+    "type": "string"
+  },
+  "revenue_drop_2020_percent": {
+    "aliases": ["revenue_drop_2020_pct"],
     "target": "revenue_drop_2020_percent",
     "type": "percent"
   },
-  "revenue_drop_2021_pct": {
+  "revenue_drop_2021_percent": {
+    "aliases": ["revenue_drop_2021_pct"],
     "target": "revenue_drop_2021_percent",
     "type": "percent"
   },
-  "shutdown_2020": {
+  "government_shutdown_2020": {
+    "aliases": ["shutdown_2020"],
     "target": "government_shutdown_2020",
     "type": "bool"
   },
-  "shutdown_2021": {
+  "government_shutdown_2021": {
+    "aliases": ["shutdown_2021"],
     "target": "government_shutdown_2021",
     "type": "bool"
   },
   "qualified_wages_2020": {
+    "aliases": [],
     "target": "qualified_wages_2020",
     "type": "currency"
   },
   "qualified_wages_2021": {
+    "aliases": [],
     "target": "qualified_wages_2021",
     "type": "currency"
   },
-  "ppp_double_dip": {
+  "ppp_wages_double_dip": {
+    "aliases": ["ppp_double_dip"],
     "target": "ppp_wages_double_dip",
     "type": "bool"
   },
-  "owner_is_veteran": {
+  "owner_veteran": {
+    "aliases": ["owner_is_veteran", "veteran_owned"],
     "target": "owner_veteran",
     "type": "bool"
   },
-  "owner_is_spouse": {
+  "owner_spouse": {
+    "aliases": ["owner_is_spouse"],
     "target": "owner_spouse",
     "type": "bool"
   },
   "owner_spouse_veteran": {
+    "aliases": [],
     "target": "owner_spouse_veteran",
     "type": "bool"
   },
-  "ownership_pct": {
+  "ownership_percentage": {
+    "aliases": ["ownership_pct"],
     "target": "ownership_percentage",
     "type": "percent"
   },
-  "employee_count": {
+  "number_of_employees": {
+    "aliases": ["employee_count"],
     "target": "number_of_employees",
     "type": "int"
   },
   "annual_revenue": {
+    "aliases": [],
     "target": "annual_revenue",
     "type": "currency"
   },
-  "state": {
-    "target": "business_location_state",
-    "type": "string"
-  },
-  "economically_vulnerable": {
+  "economically_vulnerable_area": {
+    "aliases": ["economically_vulnerable"],
     "target": "economically_vulnerable_area",
     "type": "bool"
   },
-  "biz_type": {
+  "business_type": {
+    "aliases": ["biz_type"],
     "target": "business_type",
     "type": "string"
   },
   "service_area_population": {
+    "aliases": [],
     "target": "service_area_population",
     "type": "int"
   },
   "income_level": {
+    "aliases": [],
     "target": "income_level",
     "type": "string"
   },
   "project_type": {
+    "aliases": [],
     "target": "project_type",
     "type": "string"
   },
   "project_cost": {
+    "aliases": [],
     "target": "project_cost",
     "type": "currency"
   },
   "revenue_drop_percent": {
+    "aliases": [],
     "target": "revenue_drop_percent",
     "type": "percent"
   },
   "gov_shutdown": {
+    "aliases": [],
     "target": "gov_shutdown",
     "type": "bool"
   },
   "w2_part_time_count": {
+    "aliases": [],
     "target": "w2_part_time_count",
     "type": "int",
-    "min": 0
+    "normalize": {
+      "min": 0
+    }
   },
   "payroll_total": {
+    "aliases": [],
     "target": "payroll_total",
     "type": "currency"
   },
   "received_ppp": {
+    "aliases": [],
     "target": "received_ppp",
     "type": "bool"
   },
   "rural_area": {
+    "aliases": [],
     "target": "rural_area",
     "type": "bool"
   },
   "opportunity_zone": {
+    "aliases": [],
     "target": "opportunity_zone",
     "type": "bool"
   },
   "some_date": {
+    "aliases": [],
     "target": "some_date",
     "type": "date"
   },
   "bool_yes": {
+    "aliases": [],
     "target": "bool_yes",
     "type": "bool"
   },
   "bool_no": {
+    "aliases": [],
     "target": "bool_no",
     "type": "bool"
   },
   "entity_type": {
+    "aliases": [],
     "target": "entity_type",
     "type": "string"
+  },
+  "quarterly_revenues": {
+    "aliases": [],
+    "target": "quarterly_revenues",
+    "type": "mapping"
+  },
+  "year_founded": {
+    "aliases": [],
+    "target": "year_founded",
+    "type": "int"
+  },
+  "minority_owned": {
+    "aliases": [],
+    "target": "minority_owned",
+    "type": "bool"
+  },
+  "female_owned": {
+    "aliases": [],
+    "target": "female_owned",
+    "type": "bool"
+  },
+  "ppp_reference": {
+    "aliases": [],
+    "target": "ppp_reference",
+    "type": "bool"
+  },
+  "ertc_reference": {
+    "aliases": [],
+    "target": "ertc_reference",
+    "type": "bool"
   }
 }

--- a/eligibility-engine/tests/contract/test_field_map_coverage.py
+++ b/eligibility-engine/tests/contract/test_field_map_coverage.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+
+def load_field_map() -> dict:
+    path = Path(__file__).resolve().parents[2] / "contracts" / "field_map.json"
+    with path.open() as f:
+        return json.load(f)
+
+
+def load_analyzer_fields() -> list:
+    path = Path(__file__).resolve().parents[1] / "fixtures" / "analyzer_known_fields.json"
+    with path.open() as f:
+        return json.load(f)
+
+
+def load_canonical_fields() -> set:
+    path = Path(__file__).resolve().parents[3] / "DATA_CONTRACTS.md"
+    fields = set()
+    with path.open() as f:
+        in_table = False
+        for line in f:
+            if line.startswith("| Field "):
+                in_table = True
+                continue
+            if in_table:
+                if not line.strip() or line.startswith("##"):
+                    break
+                parts = [p.strip() for p in line.split("|")]
+                if len(parts) > 2 and parts[1] and parts[1] != "---":
+                    fields.add(parts[1])
+    return fields
+
+
+def test_analyzer_fields_covered():
+    field_map = load_field_map()
+    analyzer_fields = set(load_analyzer_fields())
+    aliases = set()
+    for target, info in field_map.items():
+        aliases.add(target)
+        aliases.update(info.get("aliases", []))
+    missing = sorted(analyzer_fields - aliases)
+    assert not missing, f"Missing mappings for: {missing}"
+
+
+def test_no_orphan_targets():
+    field_map = load_field_map()
+    canonical = load_canonical_fields()
+    orphan = [k for k, v in field_map.items() if v.get("target") not in canonical]
+    assert not orphan, f"Orphan targets found: {orphan}"

--- a/eligibility-engine/tests/contract/test_normalization_examples.py
+++ b/eligibility-engine/tests/contract/test_normalization_examples.py
@@ -1,3 +1,7 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 from normalization.ingest import normalize_payload
 
 
@@ -8,7 +12,10 @@ def test_basic_normalization():
         'ein': '123456789',
         'some_date': '12/31/2024',
         'bool_yes': 'yes',
-        'bool_no': 'n'
+        'bool_no': 'n',
+        'payroll_total': '($1.2M)',
+        'revenue_drop_2020_pct': '0.4',
+        'shutdown_2020': 'Yes'
     }
     normalized = normalize_payload(raw)
     assert normalized['ownership_percentage'] == 55.0
@@ -17,3 +24,6 @@ def test_basic_normalization():
     assert normalized['some_date'] == '2024-12-31'
     assert normalized['bool_yes'] is True
     assert normalized['bool_no'] is False
+    assert normalized['payroll_total'] == 1200000
+    assert normalized['revenue_drop_2020_percent'] == 40.0
+    assert normalized['government_shutdown_2020'] is True

--- a/eligibility-engine/tests/fixtures/analyzer_known_fields.json
+++ b/eligibility-engine/tests/fixtures/analyzer_known_fields.json
@@ -1,0 +1,16 @@
+[
+  "ein",
+  "w2_employee_count",
+  "quarterly_revenues",
+  "entity_type",
+  "year_founded",
+  "annual_revenue",
+  "payroll_total",
+  "location_state",
+  "location_country",
+  "minority_owned",
+  "female_owned",
+  "veteran_owned",
+  "ppp_reference",
+  "ertc_reference"
+]


### PR DESCRIPTION
## Summary
- canonicalize `field_map.json` with aliases for analyzer and UI keys
- document canonical keys and synonyms in `DATA_CONTRACTS.md`
- add tests validating analyzer coverage and normalization examples

## Testing
- `pytest eligibility-engine/tests/contract -q`

------
https://chatgpt.com/codex/tasks/task_b_68ab7e8166c483279fedf5a766ea2d09