### PR TITLE
Unify file-type validation across services

### DIFF
--- a/DATA_CONTRACTS.md
+++ b/DATA_CONTRACTS.md
@@ -2,6 +2,10 @@
 
 This document defines the canonical schema for fields produced by the AI Analyzer and consumed by the Eligibility Engine. It provides a single source of truth so developers and tests stay aligned.
 
+## Supported Upload Formats
+
+Both the Server API and AI Analyzer accept the following file extensions: `.pdf`, `.docx`, `.txt`, `.png`, `.jpeg`, `.jpg`, `.bmp`.
+
 ## Canonical Fields
 
 The following table enumerates all canonical keys understood by the eligibility engine. Each field lists its data type, normalization rules, whether it is required by any grant program, and where it currently originates.

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -2,8 +2,8 @@
 
 This FastAPI microservice extracts text from uploaded documents using Tesseract OCR
 and parses business fields such as EIN, W‑2 employee counts, quarterly revenues and
-entity type. The `/analyze` endpoint accepts `application/pdf`, `image/png` and
-`image/jpeg` uploads.
+entity type. The `/analyze` endpoint accepts `.pdf`, `.docx`, `.txt`, `.png`, `.jpeg`,
+`.jpg` and `.bmp` uploads.
 
 Set `TESSERACT_CMD` to the path of the Tesseract executable if it's not
 already available on your `PATH`.

--- a/ai-analyzer/upload_utils.py
+++ b/ai-analyzer/upload_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 from pathlib import Path
 
 from fastapi import HTTPException, UploadFile
@@ -10,17 +11,9 @@ from fastapi import HTTPException, UploadFile
 from config import settings  # type: ignore
 
 
-ALLOWED_EXTENSIONS = {
-    ".jpg",
-    ".jpeg",
-    ".png",
-    ".bmp",
-    ".tiff",
-    ".gif",
-    ".pdf",
-    ".txt",
-    ".docx",
-}
+FILE_TYPES_PATH = Path(__file__).resolve().parents[1] / "shared" / "file_types.json"
+with open(FILE_TYPES_PATH) as f:
+    ALLOWED_EXTENSIONS = set(json.load(f)["extensions"])
 
 
 def validate_upload(file: UploadFile) -> None:

--- a/server/README.md
+++ b/server/README.md
@@ -5,6 +5,8 @@ Multipart form fields:
 - `file` – document to analyze
 - optional `caseId`
 
+Supported file extensions: `.pdf`, `.docx`, `.txt`, `.png`, `.jpeg`, `.jpg`, `.bmp`.
+
 Response: case snapshot including `caseId`, `documents` array and any extracted `analyzerFields`.
 
 ### `POST /api/questionnaire`

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const multer = require('multer');
 const FormData = require('form-data');
+const path = require('path');
+
+const { extensions: allowedExtensions } = require('../../shared/file_types.json');
 const fetchFn =
   global.pipelineFetch ||
   (global.fetch
@@ -16,8 +19,9 @@ const upload = multer({
   limits: { fileSize: 5 * 1024 * 1024 },
 });
 
-function isAllowed(mimetype) {
-  return ['application/pdf', 'image/jpeg', 'image/png'].includes(mimetype);
+function isAllowed(filename) {
+  const ext = path.extname(filename).toLowerCase();
+  return allowedExtensions.includes(ext);
 }
 
 router.post('/files/upload', (req, res) => {
@@ -29,7 +33,7 @@ router.post('/files/upload', (req, res) => {
       return res.status(400).json({ message: err.message });
     }
     if (!req.file) return res.status(400).json({ message: 'file required' });
-    if (!isAllowed(req.file.mimetype)) {
+    if (!isAllowed(req.file.originalname)) {
       return res.status(400).json({ message: 'Unsupported file type' });
     }
 

--- a/shared/file_types.json
+++ b/shared/file_types.json
@@ -1,0 +1,3 @@
+{
+  "extensions": [".pdf", ".docx", ".txt", ".png", ".jpeg", ".jpg", ".bmp"]
+}


### PR DESCRIPTION
## Summary
- centralize allowed file extensions in `shared/file_types.json`
- reference shared extension list from server upload route and ai-analyzer utils
- document supported file types in server, ai-analyzer, and data contracts README

## Testing
- `npm test` *(fails: jest not installed)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pdfplumber==0.11.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68ab8e04e64c8327b76bd92685803c5f