### PR TITLE
chore: package ai-analyzer for imports

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Optional, Any
 import io
 from pydantic import BaseModel, constr
-from ocr_utils import extract_text, OCRExtractionError
-from nlp_parser import extract_fields, normalize_text
-from config import settings  # type: ignore
-from upload_utils import validate_upload
+from ai_analyzer.ocr_utils import extract_text, OCRExtractionError
+from ai_analyzer.nlp_parser import extract_fields, normalize_text
+from ai_analyzer.config import settings  # type: ignore
+from ai_analyzer.upload_utils import validate_upload
 
 try:  # pragma: no cover - external dependency may be missing
     import pytesseract  # type: ignore

--- a/ai-analyzer/tests/test_analyze_expanded.py
+++ b/ai-analyzer/tests/test_analyze_expanded.py
@@ -5,7 +5,7 @@ import pytest
 import env_setup  # noqa: F401
 from fastapi.testclient import TestClient
 
-from main import app
+from ai_analyzer.main import app
 
 
 client = TestClient(app)
@@ -55,8 +55,9 @@ def test_analyze_text_oversize() -> None:
 def test_analyze_multipart_file(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_extract_text(_: bytes) -> str:
         return "Q1 2023 revenue $5000; EIN 11-1111111"
-    monkeypatch.setattr("ocr_utils.extract_text", mock_extract_text)
-    monkeypatch.setattr("main.extract_text", mock_extract_text)
+
+    monkeypatch.setattr("ai_analyzer.ocr_utils.extract_text", mock_extract_text)
+    monkeypatch.setattr("ai_analyzer.main.extract_text", mock_extract_text)
 
     file_content = io.BytesIO(b"dummy")
     resp = client.post(

--- a/ai-analyzer/tests/test_nlp_parser.py
+++ b/ai-analyzer/tests/test_nlp_parser.py
@@ -1,5 +1,5 @@
 import env_setup  # noqa: F401
-from nlp_parser import (
+from ai_analyzer.nlp_parser import (
     extract_ein,
     extract_w2_count,
     extract_quarterly_revenues,

--- a/ai-analyzer/tests/test_ocr.py
+++ b/ai-analyzer/tests/test_ocr.py
@@ -4,7 +4,7 @@ import pytest
 import env_setup  # noqa: F401
 from fastapi.testclient import TestClient
 
-from main import app
+from ai_analyzer.main import app
 
 
 client = TestClient(app)
@@ -23,7 +23,7 @@ def _patch_ocr(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> None:
         def open(_: io.BytesIO) -> object:  # pragma: no cover - simple stub
             return object()
 
-    for module in ("main", "ocr_utils"):
+    for module in ("ai_analyzer.main", "ai_analyzer.ocr_utils"):
         monkeypatch.setattr(f"{module}.pytesseract", DummyPytesseract)
         monkeypatch.setattr(f"{module}.Image", DummyImage)
 

--- a/ai-analyzer/upload_utils.py
+++ b/ai-analyzer/upload_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from fastapi import HTTPException, UploadFile
 
-from config import settings  # type: ignore
+from ai_analyzer.config import settings  # type: ignore
 
 
 FILE_TYPES_PATH = Path(__file__).resolve().parents[1] / "shared" / "file_types.json"

--- a/ai_analyzer/__init__.py
+++ b/ai_analyzer/__init__.py
@@ -1,0 +1,9 @@
+"""Compatibility package for ai-analyzer.
+
+This package makes the modules located in the legacy ``ai-analyzer``
+folder importable as ``ai_analyzer``.
+"""
+from pathlib import Path
+
+# Allow importing submodules from the ``ai-analyzer`` directory.
+__path__ = [str(Path(__file__).resolve().parent.parent / "ai-analyzer")]


### PR DESCRIPTION
## Summary
- add package markers for ai-analyzer
- adjust tests and modules to import via `ai_analyzer`
- provide shim package so legacy layout remains importable

## Testing
- `pytest --rootdir=. ai-analyzer/tests -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68ab9879b3c48327b3384ebf7fbe8ab8