### PR TITLE
Lock analyzer dependencies and configure tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  analyzer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install analyzer deps
+        working-directory: ai-analyzer
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run analyzer tests
+        working-directory: ai-analyzer
+        run: pytest -q

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -67,11 +67,20 @@ $env:PYTHONPATH=".."
 python -m uvicorn main:app --port 8000
 ```
 
-## Running tests
+## Tests & Lint
 
-Install the dependencies and run the test suite:
-
-```bash
+```powershell
+# Windows (PowerShell)
+python -m venv .\venv
+.\venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-pytest
+
+# Run tests
+pytest -q
+
+# Lint (flake8)
+flake8
+
+# Run service locally
+uvicorn ai_analyzer.main:app --host 0.0.0.0 --port 8000
 ```

--- a/ai-analyzer/ai_analyzer/__init__.py
+++ b/ai-analyzer/ai_analyzer/__init__.py
@@ -1,0 +1,4 @@
+"""Compatibility package to expose modules in parent directory as ai_analyzer."""
+from pathlib import Path
+
+__path__ = [str(Path(__file__).resolve().parent.parent)]

--- a/ai-analyzer/pytest.ini
+++ b/ai-analyzer/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -1,11 +1,27 @@
-pytesseract==0.3.10
-pillow==9.5.0
+# Core
 fastapi==0.115.6
+starlette==0.41.3
 uvicorn==0.22.0
-pytest==8.0.2
-coverage==7.4.0
-flake8==6.1.0
+
+# OCR & PDF
+pytesseract==0.3.10
+Pillow==9.5.0
+pdfplumber==0.11.0
+pdfminer.six==20231228
+pypdfium2==4.30.0
+
+# Config & utils
 pydantic==2.9.2
 pydantic-settings==2.3.4
 PyYAML==6.0.2
-pdfplumber==0.11.0
+packaging==25.0
+
+# Testing
+pytest==8.0.2
+coverage==7.4.0
+httpx==0.28.1
+python-multipart==0.0.20
+flake8==6.1.0
+
+# Metrics
+prometheus-client==0.21.1


### PR DESCRIPTION
## Summary
- pin analyzer requirements including httpx and prometheus metrics
- add pytest configuration and compatibility package for imports
- refactor analyzer app for flake8 compliance and document local test flow
- add workflow running analyzer pytest suite and server jest tests

## Testing
- `pip install -r ai-analyzer/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `flake8 ai-analyzer/main.py`

------
https://chatgpt.com/codex/tasks/task_b_68abb69f9f5c8327938536e54f856a9c