### PR TITLE
feat: add OpenAI analyzer endpoint

### DIFF
--- a/ai-analyzer/.env
+++ b/ai-analyzer/.env
@@ -2,3 +2,5 @@ NODE_ENV=development
 AI_ANALYZER_API_KEY=dev-analyzer-key
 TLS_CERT_PATH=dummy-cert
 TLS_KEY_PATH=dummy-key
+USE_AI_ANALYZER=false
+OPENAI_API_KEY=

--- a/ai-analyzer/.env.example
+++ b/ai-analyzer/.env.example
@@ -1,1 +1,6 @@
 # Example environment for ai-analyzer (no security configuration required)
+NODE_ENV=development
+# set to "true" to enable the OpenAI-powered endpoint
+USE_AI_ANALYZER=false
+# your OpenAI API key when USE_AI_ANALYZER=true
+OPENAI_API_KEY=

--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -3,7 +3,9 @@
 This FastAPI microservice extracts text from uploaded documents using Tesseract OCR
 and parses business fields such as EIN, W‑2 employee counts, quarterly revenues and
 entity type. The `/analyze` endpoint accepts `.pdf`, `.docx`, `.txt`, `.png`, `.jpeg`,
-`.jpg` and `.bmp` uploads.
+`.jpg` and `.bmp` uploads. A separate `/analyze-ai` endpoint can be enabled with
+`USE_AI_ANALYZER=true` and an `OPENAI_API_KEY`; it sends OCR text to OpenAI for
+richer field extraction.
 
 Set `TESSERACT_CMD` to the path of the Tesseract executable if it's not
 already available on your `PATH`.
@@ -27,6 +29,10 @@ curl -X POST http://localhost:8000/analyze \
 # File upload
 curl -X POST http://localhost:8000/analyze -F "file=@samples/quarterly_report.pdf"
 ```
+
+## OpenAI-Powered Extraction
+
+Set `USE_AI_ANALYZER=true` and provide `OPENAI_API_KEY` to enable the `/analyze-ai` endpoint. It accepts the same inputs as `/analyze` but uses OpenAI to fill a structured JSON response.
 
 ## Field Names Emitted
 

--- a/ai-analyzer/config.py
+++ b/ai-analyzer/config.py
@@ -10,13 +10,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 NODE_ENV = os.getenv("NODE_ENV", "development")
 ENV_FILE = os.getenv("ENV_FILE")
 ENV_PATH = ENV_FILE or Path(__file__).resolve().parent / f".env.{NODE_ENV}"
+
+
 class Settings(BaseSettings):
     NODE_ENV: str = "development"
     MAX_FILE_SIZE_MB: int = 5
     MAX_TEXT_LEN: int = 100_000
     ENABLE_SECONDARY_FIELDS: bool = True
     TESSERACT_CMD: str | None = None
+    USE_AI_ANALYZER: bool = False
+    OPENAI_API_KEY: str | None = None
 
     model_config = SettingsConfigDict(env_file=ENV_PATH, extra="ignore")
+
 
 settings = Settings()

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -1,16 +1,54 @@
 from fastapi import FastAPI, UploadFile, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.concurrency import run_in_threadpool
 import sys
 from pathlib import Path
 from typing import Any
 import io
 import cgi
+import json
+import time
 from pydantic import BaseModel, constr
 from ai_analyzer.ocr_utils import extract_text, OCRExtractionError
 from ai_analyzer.nlp_parser import extract_fields, normalize_text
 from ai_analyzer.config import settings  # type: ignore
 from ai_analyzer.upload_utils import validate_upload
+try:  # pragma: no cover - optional OpenAI dependency
+    from openai import OpenAI  # type: ignore
+    openai_client = (
+        OpenAI(api_key=settings.OPENAI_API_KEY)
+        if settings.OPENAI_API_KEY
+        else None
+    )
+except Exception:  # pragma: no cover - legacy or missing libs
+    try:
+        import openai  # type: ignore
+        if settings.OPENAI_API_KEY:
+            openai.api_key = settings.OPENAI_API_KEY
+
+            class _LegacyClient:
+                chat = type(
+                    "Chat",
+                    (),
+                    {
+                        "completions": type(
+                            "Comp",
+                            (),
+                            {
+                                "create": staticmethod(
+                                    openai.ChatCompletion.create
+                                )
+                            },
+                        )
+                    },
+                )
+
+            openai_client = _LegacyClient()  # type: ignore
+        else:
+            openai_client = None
+    except Exception:  # pragma: no cover
+        openai_client = None
 
 try:  # pragma: no cover - external dependency may be missing
     import pytesseract  # type: ignore
@@ -199,6 +237,85 @@ async def analyze(request: Request):
     raise HTTPException(status_code=400, detail="Unsupported Content-Type")
 
 
+@app.post("/analyze-ai")
+async def analyze_ai(request: Request):
+    if not settings.USE_AI_ANALYZER:
+        raise HTTPException(status_code=503, detail="AI analyzer disabled")
+    ctype = request.headers.get("content-type", "")
+
+    if "application/json" in ctype:
+        try:
+            payload = await request.json()
+        except Exception as exc:  # pragma: no cover
+            raise HTTPException(
+                status_code=422, detail="Invalid JSON"
+            ) from exc
+        try:
+            req = TextAnalyzeRequest(**payload)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=422, detail="Invalid JSON shape"
+            ) from exc
+        return await analyze_ai_text_flow(req.text, source="text")
+
+    if "text/plain" in ctype:
+        raw = await request.body()
+        if len(raw) > settings.MAX_TEXT_LEN:
+            raise HTTPException(status_code=400, detail="Text exceeds limit")
+        body_text = raw.decode("utf-8", errors="replace").strip()
+        if not body_text:
+            raise HTTPException(status_code=400, detail="Provide file or text")
+        return await analyze_ai_text_flow(body_text, source="text")
+
+    if "multipart/form-data" in ctype:
+        body = await request.body()
+        env = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": ctype,
+            "CONTENT_LENGTH": str(len(body)),
+        }
+        form = cgi.FieldStorage(
+            fp=io.BytesIO(body), environ=env, keep_blank_values=True
+        )
+        text_val = None
+        upload_bytes = None
+        filename = None
+        content_type_file = None
+        if "text" in form and not getattr(form["text"], "filename", None):
+            text_val = form["text"].value
+        if "file" in form:
+            field = form["file"]
+            if getattr(field, "filename", None):
+                filename = field.filename
+                content_type_file = field.type
+                upload_bytes = field.file.read()
+        if text_val and text_val.strip():
+            if len(text_val.encode("utf-8")) > settings.MAX_TEXT_LEN:
+                raise HTTPException(
+                    status_code=400, detail="Text exceeds limit"
+                )
+            return await analyze_ai_text_flow(text_val.strip(), source="text")
+        if upload_bytes is None:
+            raise HTTPException(status_code=400, detail="Provide file or text")
+        upload = UploadFile(io.BytesIO(upload_bytes), filename=filename)
+        validate_upload(upload)
+        try:
+            extracted = extract_text(upload_bytes)
+        except OCRExtractionError as exc:
+            logger.exception("extract_text failed")
+            raise HTTPException(
+                status_code=500, detail="Failed to extract text"
+            ) from exc
+        return await analyze_ai_text_flow(
+            extracted,
+            source="file",
+            filename=filename,
+            content_type=content_type_file,
+        )
+
+    raise HTTPException(status_code=400, detail="Unsupported Content-Type")
+
+
 async def analyze_text_flow(
     text: str,
     *,
@@ -254,6 +371,92 @@ async def analyze_text_flow(
         extra["content_type"] = content_type
     logger.info("analyze", extra=extra)
     return response
+
+
+EXPECTED_FIELDS = [
+    "ein",
+    "w2_employee_count",
+    "quarterly_revenues",
+    "entity_type",
+    "year_founded",
+    "annual_revenue",
+    "location_state",
+    "location_country",
+    "minority_owned",
+    "female_owned",
+    "veteran_owned",
+    "ppp_reference",
+    "ertc_reference",
+]
+
+
+async def call_openai_structured(text: str) -> dict[str, Any]:
+    if not openai_client:
+        raise HTTPException(status_code=500, detail="OpenAI not configured")
+    system_prompt = (
+        "Extract structured business fields from the user's text. "
+        "Always return a JSON object with the keys: ein, w2_employee_count, "
+        "quarterly_revenues, entity_type, year_founded, annual_revenue, "
+        "location_state, location_country, minority_owned, female_owned, "
+        "veteran_owned, ppp_reference, ertc_reference. Use null for unknown."
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": text},
+    ]
+    last_exc: Exception | None = None
+    for _ in range(3):
+        try:
+            resp = await run_in_threadpool(
+                lambda: openai_client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=messages,
+                    response_format={"type": "json_object"},
+                    timeout=15,
+                )
+            )
+            return json.loads(resp.choices[0].message.content)
+        except TypeError:  # older openai versions
+            resp = await run_in_threadpool(
+                lambda: openai_client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=messages,
+                    timeout=15,
+                )
+            )
+            return json.loads(resp.choices[0].message.content)
+        except Exception as exc:  # pragma: no cover
+            last_exc = exc
+            time.sleep(1)
+    logger.exception("openai call failed")
+    raise HTTPException(
+        status_code=500, detail="Failed to extract using AI"
+    ) from last_exc
+
+
+async def analyze_ai_text_flow(
+    text: str,
+    *,
+    source: str,
+    filename: str | None = None,
+    content_type: str | None = None,
+) -> dict[str, Any]:
+    structured = await call_openai_structured(text)
+    structured.setdefault("quarterly_revenues", {})
+    for q in ["Q1", "Q2", "Q3", "Q4"]:
+        structured["quarterly_revenues"].setdefault(q, None)
+    for key in EXPECTED_FIELDS:
+        if key != "quarterly_revenues":
+            structured.setdefault(key, None)
+    structured["raw_text_preview"] = text[:2000]
+    structured["source"] = source
+    extra = {"source": source}
+    if filename:
+        extra["upload_filename"] = filename
+    if content_type:
+        extra["content_type"] = content_type
+    logger.info("analyze_ai", extra=extra)
+    return structured
 
 if __name__ == "__main__":
     import uvicorn

--- a/ai-analyzer/requirements.txt
+++ b/ai-analyzer/requirements.txt
@@ -15,6 +15,7 @@ pydantic==2.9.2
 pydantic-settings==2.3.4
 PyYAML==6.0.2
 packaging==25.0
+openai>=1.0.0
 
 # Testing
 pytest==8.0.2

--- a/ai-analyzer/tests/env_setup.py
+++ b/ai-analyzer/tests/env_setup.py
@@ -7,9 +7,11 @@ vars = {
     "AI_ANALYZER_API_KEY": "test-key",
     "TLS_CERT_PATH": str(dummy),
     "TLS_KEY_PATH": str(dummy),
+    "USE_AI_ANALYZER": "true",
+    "OPENAI_API_KEY": "test-key",
     "SECURITY_ENFORCEMENT_LEVEL": "dev",
     "DISABLE_VAULT": "true",
     "ENABLE_RATE_LIMIT": "false",
 }
-for k,v in vars.items():
+for k, v in vars.items():
     os.environ.setdefault(k, v)

--- a/ai-analyzer/tests/test_analyze_ai.py
+++ b/ai-analyzer/tests/test_analyze_ai.py
@@ -1,0 +1,47 @@
+import json
+import env_setup  # noqa: F401
+from fastapi.testclient import TestClient
+import ai_analyzer.main as main
+
+client = TestClient(main.app)
+
+
+def test_analyze_ai_json(monkeypatch):
+    sample = {
+        "ein": "12-3456789",
+        "w2_employee_count": 5,
+        "quarterly_revenues": {"Q1": 1.0, "Q2": 2.0, "Q3": 3.0, "Q4": 4.0},
+        "entity_type": "LLC",
+        "year_founded": 2020,
+        "annual_revenue": 1000.0,
+        "location_state": "CA",
+        "location_country": "US",
+        "minority_owned": True,
+        "female_owned": False,
+        "veteran_owned": False,
+        "ppp_reference": None,
+        "ertc_reference": None,
+    }
+
+    class DummyResp:
+        choices = [
+            type(
+                "C",
+                (),
+                {"message": type("M", (), {"content": json.dumps(sample)})()},
+            )
+        ]
+
+    def fake_create(**_):
+        return DummyResp()
+
+    monkeypatch.setattr(
+        main.openai_client.chat.completions, "create", fake_create
+    )
+
+    resp = client.post("/analyze-ai", json={"text": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ein"] == "12-3456789"
+    assert data["raw_text_preview"] == "hello"
+    assert data["source"] == "text"


### PR DESCRIPTION
## Summary
- add `/analyze-ai` endpoint that uses OpenAI to extract structured document fields
- configure `USE_AI_ANALYZER` and `OPENAI_API_KEY` env vars to toggle the feature
- document new AI-powered workflow and cover with tests

## Testing
- `pytest`
- `flake8 main.py tests/test_analyze_ai.py tests/env_setup.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_68ac7890e56883279fc96538e2f78d3b