### PR TITLE
chore(server): run jest via npm test

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "jest --runInBand",
+    "test": "jest",
     "verify:mongo": "node scripts/verify-mongo-tls.js",
     "profile:flame": "clinic flame -- node index.js",
     "profile:doctor": "clinic doctor -- node index.js",


### PR DESCRIPTION
## Summary
- replace the server test script to invoke `jest`

## Testing
- `npm test --prefix server` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac925995348327b2a053dd873a5eb9