### PR TITLE
Reject .txt file uploads

### DIFF
--- a/server/tests/files.upload.test.js
+++ b/server/tests/files.upload.test.js
@@ -29,6 +29,7 @@ describe('POST /api/files/upload', () => {
       .post('/api/files/upload')
       .attach('file', Buffer.from('hello'), 'test.txt');
     expect(res.status).toBe(400);
+    expect(res.body).toEqual({ message: 'Unsupported file type' });
   });
 
   test('rejects oversized file', async () => {

--- a/shared/file_types.json
+++ b/shared/file_types.json
@@ -1,3 +1,3 @@
 {
-  "extensions": [".pdf", ".docx", ".txt", ".png", ".jpeg", ".jpg", ".bmp"]
+  "extensions": [".pdf", ".docx", ".png", ".jpeg", ".jpg", ".bmp"]
 }


### PR DESCRIPTION
## Summary
- disallow TXT uploads by removing `.txt` from allowed extensions
- assert server rejects `.txt` uploads with an "Unsupported file type" message

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac95319db48327bd5ff975849f7075