### PR TITLE
chore: default analyzer to 8002 and add smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All service calls exchange JSON payloads, are logged, and bubble up descriptive 
 Environment variables configuring service locations:
 
 ```
-AI_ANALYZER_URL=https://ai-analyzer:8000
+AI_ANALYZER_URL=http://localhost:8002
 ELIGIBILITY_ENGINE_URL=https://eligibility-engine:4001
 AI_AGENT_URL=https://ai-agent:5001
 ```
@@ -119,7 +119,7 @@ The frontend interacts with a simpler set of endpoints that manage a user's inâ€
    pip install -r requirements.txt
    # optional: specify path to the Tesseract binary
    export TESSERACT_CMD=/usr/bin/tesseract
-   python -m uvicorn main:app --port 8000
+   python -m uvicorn main:app --port 8002
    ```
 3. Start the AI agent service
    ```bash
@@ -138,6 +138,28 @@ The frontend interacts with a simpler set of endpoints that manage a user's inâ€
    cd eligibility-engine
    python -m pytest
    ```
+
+### Analyzer upload smoke test
+
+1. Start services:
+   - Analyzer: `uvicorn main:app --port 8002 --reload` (in `ai-analyzer/`)
+   - Server: `npm start` (in `server/`)
+   - (Optional) Frontend: `npm run dev` (in `frontend/`)
+
+2. Health checks:
+   - Analyzer: `curl http://localhost:8002/healthz` â†’ `{"status":"ok"}`
+   - Server:   `curl http://localhost:5000/healthz` â†’ `{"status":"ok"}`
+
+3. Upload a PDF:
+
+   ```bash
+   curl -X POST "http://localhost:5000/api/files/upload" \\
+     -F "file=@/absolute/path/to/sample.pdf" \\
+     -F "caseId=case-local-smoke" \\
+     -F "key=Bank Statements"
+   ```
+
+   Expected: HTTP 200 with JSON containing `analyzerFields` or at minimum `raw_text_preview`.
 
 The `ai-agent` service can parse free-form notes and uploaded documents, infer missing fields
 and provide human readable summaries. Eligibility results now include a `next_steps` field

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -47,7 +47,7 @@ All Vault connections must use **HTTPS**; the platform will refuse to start if
 | OPENAI_API_KEY | OpenAI API key | `sk-...` | yes | - |
 | FRONTEND_URL | Allowed frontend origin | `https://localhost:3000` | yes | - |
 | ELIGIBILITY_ENGINE_URL | Eligibility engine URL | `https://localhost:4001` | yes | - |
-| AI_ANALYZER_URL | Analyzer URL | `https://localhost:4002` | yes | - |
+| AI_ANALYZER_URL | Analyzer URL | `http://localhost:8002` | yes | - |
 | AI_AGENT_URL | Agent URL | `https://localhost:5001` | yes | - |
 | MONGO_URI | MongoDB connection string | `mongodb://mongo:27017/grants?authSource=admin&tls=true` | yes | - |
 | MONGO_USER | Mongo username | `user` | yes | - |

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,8 @@
 PORT=5000
 FRONTEND_URL=http://localhost:3000
 ELIGIBILITY_ENGINE_URL=http://eligibility-engine:4001
-AI_ANALYZER_URL=http://ai-analyzer:8000
+# AI Analyzer base URL (FastAPI)
+AI_ANALYZER_URL=http://localhost:8002
+# NOTE: Port 8002 is the default. Update only if you run the analyzer on a different port.
 AI_AGENT_URL=http://ai-agent:5001
 MONGO_URI=mongodb://mongo:27017/grants

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -9,7 +9,7 @@ try {
 
 process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost';
 process.env.ELIGIBILITY_ENGINE_URL = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
-process.env.AI_ANALYZER_URL = process.env.AI_ANALYZER_URL || 'http://localhost:8000';
+process.env.AI_ANALYZER_URL = process.env.AI_ANALYZER_URL || 'http://localhost:8002';
 process.env.AI_AGENT_URL = process.env.AI_AGENT_URL || 'http://localhost:9001';
 process.env.MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/test';
 process.env.PORT = process.env.PORT || '3000';

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -45,8 +45,13 @@ router.post('/files/upload', (req, res) => {
       caseId = await createCase(userId);
     }
 
-    const analyzerBase = process.env.AI_ANALYZER_URL || 'http://localhost:8000';
-    const analyzerUrl = `${analyzerBase.replace(/\/$/, '')}/analyze`;
+    const analyzerBase = (process.env.AI_ANALYZER_URL || 'http://localhost:8002').replace(/\/$/, '');
+    const analyzerUrl = `${analyzerBase}/analyze`;
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(`[files.upload] analyzerUrl=${analyzerUrl}`);
+    }
+
     const form = new FormData();
     form.append('file', new Blob([req.file.buffer]), req.file.originalname);
     if (caseId) form.append('caseId', caseId);

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -44,7 +44,7 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
     }));
     await updateCase(caseId, { documents: docMeta });
 
-    const analyzerBase = process.env.AI_ANALYZER_URL || 'http://localhost:8000';
+    const analyzerBase = process.env.AI_ANALYZER_URL || 'http://localhost:8002';
     const analyzerUrl = `${analyzerBase.replace(/\/$/, '')}/analyze`;
     let extracted = {};
     for (const file of req.files) {


### PR DESCRIPTION
## Summary
- default server analyzer URL to port 8002 and log resolved endpoint
- update environment examples and docs to reference analyzer on 8002
- document analyzer upload smoke test

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_68aca98993a08327ae2f1c83ac39bf0d