### PR TITLE
chore: log upload form details

### DIFF
--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -61,6 +61,13 @@ router.post('/files/upload', (req, res) => {
     if (caseId) form.append('caseId', caseId);
     if (key) form.append('key', key);
 
+    if (process.env.NODE_ENV !== 'production') {
+      for (const [key] of form) {
+        console.log(`[files.upload] form field: ${key}`);
+      }
+      console.log('[files.upload] form headers:', form.getHeaders());
+    }
+
     let resp;
     try {
       resp = await fetchFn(analyzerUrl, {


### PR DESCRIPTION
## Summary
- log upload form fields and headers to debug AI analyzer requests

## Testing
- `npm test` *(fails: jest: not found)*
- `curl -F "file=@test.pdf" http://localhost:8002/analyze` *(fails: Failed to connect to localhost port 8002)*

------
https://chatgpt.com/codex/tasks/task_b_68adcd03e4c08327a4235de67692fbb1