### PR TITLE
Fix multipart file upload forwarding

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -29,9 +29,7 @@ export async function getRequiredDocuments(caseId: string): Promise<string[]> {
 
 // -------------------- FILE UPLOAD --------------------
 export async function uploadFile(formData: FormData): Promise<CaseSnapshot> {
-  const res = await api.post('/files/upload', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
+  const res = await api.post('/files/upload', formData);
   return transformCase(res.data);
 }
 


### PR DESCRIPTION
## Summary
- remove manual multipart header so Axios adds boundary automatically
- forward uploads using Node's built-in `FormData` and `Blob` instead of `form-data`

## Testing
- `npm test` (frontend)
- `npm test` (server) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68add346b5408327abf2a2e828a0202e