### PR TITLE
Handle envelope responses from eligibility engine

### DIFF
--- a/server/tests/eligibility.report.test.js
+++ b/server/tests/eligibility.report.test.js
@@ -10,14 +10,14 @@ describe('eligibility report endpoints', () => {
     global.fetch = jest.fn();
   });
 
-  test('POST computes and stores eligibility', async () => {
+  test('POST aggregates required forms from array response', async () => {
     const caseId = await createCase('dev-user');
     await updateCase(caseId, { analyzer: { fields: { a: 1 } } });
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => [
-        { program: 'p1', requiredForms: ['f1'], missing_fields: ['m1'] },
-        { program: 'p2', requiredForms: ['f2'], missing_fields: ['m2'] },
+        { program: 'p1', requiredForms: ['941-X'], missing_fields: ['m1'] },
+        { program: 'p2', requiredForms: ['424A'], missing_fields: ['m2'] },
       ],
     });
     const res = await request(app)
@@ -27,12 +27,36 @@ describe('eligibility report endpoints', () => {
     expect(Array.isArray(res.body.eligibility.results)).toBe(true);
     expect(res.body.eligibility.results).toHaveLength(2);
     expect(Array.isArray(res.body.eligibility.requiredForms)).toBe(true);
-    expect(res.body.eligibility.requiredForms.sort()).toEqual(['f1', 'f2']);
+    expect(res.body.eligibility.requiredForms).toEqual(
+      expect.arrayContaining(['941-X', '424A'])
+    );
 
     const statusRes = await request(app).get(`/api/status/${caseId}`);
     expect(statusRes.status).toBe(200);
     expect(statusRes.body.analyzerFields).toBeDefined();
     expect(Array.isArray(statusRes.body.eligibility.results)).toBe(true);
+  });
+
+  test('POST aggregates required forms from envelope response', async () => {
+    const caseId = await createCase('dev-user');
+    await updateCase(caseId, { analyzer: { fields: { a: 1 } } });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { program: 'p1', requiredForms: ['941-X'], missing_fields: [] },
+        ],
+        requiredForms: ['SF-424'],
+      }),
+    });
+    const res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: {} });
+    expect(res.status).toBe(200);
+    expect(res.body.eligibility.results).toHaveLength(1);
+    expect(res.body.eligibility.requiredForms).toEqual(
+      expect.arrayContaining(['941-X', 'SF-424'])
+    );
   });
 
   test('GET returns latest eligibility', async () => {
@@ -53,17 +77,19 @@ describe('eligibility report endpoints', () => {
     expect(res.body.analyzerFields).toBeDefined();
   });
 
-  test('engine error propagates', async () => {
+  test('engine error propagates with details', async () => {
     const caseId = await createCase('dev-user');
     await updateCase(caseId, { analyzer: { fields: {} } });
     global.fetch.mockResolvedValueOnce({
       ok: false,
-      status: 500,
-      text: async () => 'fail',
+      status: 422,
+      text: async () => JSON.stringify({ error: 'bad' }),
     });
     const res = await request(app)
       .post('/api/eligibility-report')
       .send({ caseId });
     expect(res.status).toBe(502);
+    expect(res.body.message).toBe('Eligibility engine error');
+    expect(res.body.details).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Normalize eligibility engine responses to handle both envelope and array shapes
- Aggregate required form IDs from envelope and results; add logging and error handling
- Test eligibility report route with array, envelope, and error responses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68adde3bb2508327a59670edde54ea18