### PR TITLE
server(pipeline): ensure user payload overrides analyzer fields

### DIFF
--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -63,7 +63,13 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
       const fields = await resp.json();
       extracted = { ...extracted, ...fields };
     }
-    const normalized = { ...basePayload, ...extracted };
+    const overrideKeys = Object.keys(basePayload).filter((key) =>
+      Object.prototype.hasOwnProperty.call(extracted, key)
+    );
+    if (overrideKeys.length) {
+      logger.debug(`Overriding analyzer fields: ${overrideKeys.join(', ')}`);
+    }
+    const normalized = { ...extracted, ...basePayload };
     await updateCase(caseId, { status: 'analyzed', normalized, analyzer: extracted });
 
     const engineBase = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';

--- a/server/tests/e2e_analyzer_engine_smoke.test.js
+++ b/server/tests/e2e_analyzer_engine_smoke.test.js
@@ -45,3 +45,19 @@ describe('analyzer to engine smoke test', () => {
     expect(res.body.eligibility.results.length).toBeGreaterThan(0);
   });
 });
+
+describe('pipeline normalization', () => {
+  test('user overrides analyzer value', () => {
+    const extracted = { ein: '111111111', w2_employee_count: 5 };
+    const basePayload = { ein: '222222222' };
+    const normalized = { ...extracted, ...basePayload };
+    expect(normalized).toEqual({ ein: '222222222', w2_employee_count: 5 });
+  });
+
+  test('non-conflicting keys merge correctly', () => {
+    const extracted = { annual_revenue: 500000 };
+    const basePayload = { entity_type: 'C-Corp' };
+    const normalized = { ...extracted, ...basePayload };
+    expect(normalized).toEqual({ annual_revenue: 500000, entity_type: 'C-Corp' });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure user-provided payload overrides analyzer fields when normalizing case data
- log any analyzer fields overridden by user input at debug level
- add tests covering user precedence and non-conflicting key merges

## Testing
- `npx jest server/tests/e2e_analyzer_engine_smoke.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_68adf203f7fc8327a7b0f6bbcef1b951