### PR TITLE
ai-agent: ensure user profile overrides analyzer fields in /check

### DIFF
--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -80,7 +80,13 @@ async def check(request_model: AgentCheckRequest) -> AgentCheckResponse:
     if request_model.profile:
         payload.update(request_model.profile.model_dump(exclude_none=True))
     if request_model.analyzer_fields:
-        payload.update(request_model.analyzer_fields)
+        filled_keys: list[str] = []
+        for k, v in request_model.analyzer_fields.items():
+            if k not in payload or payload[k] in (None, ""):
+                payload[k] = v
+                filled_keys.append(k)
+        if filled_keys:
+            logger.debug("analyzer_backfill", extra={"keys": filled_keys})
 
     normalized_profile, norm_steps = normalize_dates_in_mapping(payload)
 

--- a/ai-agent/tests/test_check_merge.py
+++ b/ai-agent/tests/test_check_merge.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+import main
+
+client = TestClient(main.app)
+
+
+def test_user_overrides_analyzer():
+    payload = {
+        "profile": {"ein": "222222222"},
+        "analyzer_fields": {"ein": "111111111"},
+    }
+    resp = client.post("/check", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["normalized_profile"]["ein"] == "222222222"
+
+
+def test_analyzer_fills_missing():
+    payload = {
+        "profile": {},
+        "analyzer_fields": {"entity_type": "LLC"},
+    }
+    resp = client.post("/check", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["normalized_profile"]["entity_type"] == "LLC"
+
+
+def test_mixed_merge():
+    payload = {
+        "profile": {"ein": "222222222"},
+        "analyzer_fields": {"ein": "111111111", "year_founded": 2019},
+    }
+    resp = client.post("/check", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["normalized_profile"]["ein"] == "222222222"
+    assert data["normalized_profile"]["year_founded"] == 2019


### PR DESCRIPTION
## Summary
- ensure analyzer fields only fill missing profile data in `/check`
- add debug logging for analyzer-populated keys
- add tests verifying merge precedence

## Testing
- `PYTHONPATH=ai-agent pytest ai-agent/tests -q`


------
https://chatgpt.com/codex/tasks/task_b_68adf3d5911c8327bcc628accd1d66b5