### PR TITLE
server(files): ensure new analyzer values overwrite existing fields

### DIFF
--- a/server/tests/files.upload.test.js
+++ b/server/tests/files.upload.test.js
@@ -8,6 +8,7 @@ describe('POST /api/files/upload', () => {
   beforeEach(() => {
     process.env.SKIP_DB = 'true';
     resetStore();
+    global.fetch.mockReset();
   });
 
   test('uploads valid pdf and returns case snapshot', async () => {
@@ -37,5 +38,91 @@ describe('POST /api/files/upload', () => {
       .post('/api/files/upload')
       .attach('file', Buffer.alloc(6 * 1024 * 1024), 'big.pdf');
     expect(res.status).toBe(413);
+  });
+});
+
+describe('file upload merge', () => {
+  beforeEach(() => {
+    process.env.SKIP_DB = 'true';
+    resetStore();
+    global.fetch.mockReset();
+  });
+
+  test('new analyzer values overwrite old fields', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ein: '111111111' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ein: '222222222' }),
+      });
+
+    const first = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.from('%PDF'), 'first.pdf');
+    const caseId = first.body.caseId;
+
+    const second = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('%PDF'), 'second.pdf');
+
+    expect(second.body.analyzerFields.ein).toBe('222222222');
+  });
+
+  test('existing fields preserved if not in new set', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ w2_employee_count: 5 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ein: '222222222' }),
+      });
+
+    const first = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.from('%PDF'), 'first.pdf');
+    const caseId = first.body.caseId;
+
+    const second = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('%PDF'), 'second.pdf');
+
+    expect(second.body.analyzerFields).toEqual({
+      w2_employee_count: 5,
+      ein: '222222222',
+    });
+  });
+
+  test('non-overlapping fields merged correctly', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ annual_revenue: 500000 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ entity_type: 'C-Corp' }),
+      });
+
+    const first = await request(app)
+      .post('/api/files/upload')
+      .attach('file', Buffer.from('%PDF'), 'first.pdf');
+    const caseId = first.body.caseId;
+
+    const second = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('%PDF'), 'second.pdf');
+
+    expect(second.body.analyzerFields).toEqual({
+      annual_revenue: 500000,
+      entity_type: 'C-Corp',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix file upload merge order so new analyzer values override existing fields
- log analyzer fields that are overwritten
- add regression tests for file upload field merging

## Testing
- `npm test --prefix server` *(fails: jest not found)*
- `npm install --prefix server` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68adf4f7aef08327a43eb62218785d32