### PR TITLE
frontend(summary): show estimated grant amounts and form links

### DIFF
--- a/frontend/src/app/dashboard/_steps/SummaryStep.tsx
+++ b/frontend/src/app/dashboard/_steps/SummaryStep.tsx
@@ -1,6 +1,14 @@
 'use client';
 import type { CaseSnapshot } from '@/lib/types';
 
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
 export default function SummaryStep({
   snapshot,
   onRestart,
@@ -25,12 +33,40 @@ export default function SummaryStep({
       {snapshot.eligibility && snapshot.eligibility.length > 0 && (
         <div>
           <h3 className="font-semibold">Eligibility Results</h3>
-          <ul className="list-disc list-inside text-sm">
-            {snapshot.eligibility.map((r) => (
-              <li key={r.name}>
-                {r.name}: {r.eligible === null ? 'Unknown' : r.eligible ? 'Yes' : 'No'}
-              </li>
-            ))}
+          <ul className="list-disc list-inside text-sm space-y-2">
+            {snapshot.eligibility.map((r) => {
+              const grantForms = [
+                ...(r.generatedForms || []),
+                ...((snapshot.generatedForms || []).filter(
+                  (f) => f.grantId === r.name,
+                )),
+              ];
+              return (
+                <li key={r.name}>
+                  <div>
+                    {r.name}: {r.eligible === null ? 'Unknown' : r.eligible ? 'Yes' : 'No'}
+                  </div>
+                  {typeof r.estimated_amount === 'number' && (
+                    <div aria-label="Estimated amount">{formatCurrency(r.estimated_amount)}</div>
+                  )}
+                  {grantForms.length > 0 && (
+                    <ul aria-label="Generated forms" className="list-disc list-inside ml-4">
+                      {grantForms.map((f) => (
+                        <li key={f.url}>
+                          <a
+                            href={f.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {`View draft ${f.name}`}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -147,9 +147,14 @@ export default function EligibilityReport() {
               <h2 className="font-semibold mt-4">Generated Forms</h2>
               <ul className="list-disc list-inside">
                 {snapshot.generatedForms.map((f) => (
-                  <li key={f.name}>
-                    {f.name}
-                    {f.status ? ` - ${f.status}` : ''}
+                  <li key={f.url}>
+                    <a
+                      href={f.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {`View draft ${f.name}`}
+                    </a>
                   </li>
                 ))}
               </ul>

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import { normalizeEligibility } from './normalize';
-import type { CaseSnapshot, EligibilityReport, ResultsEnvelope } from './types';
+import type {
+  CaseSnapshot,
+  EligibilityReport,
+  GeneratedForm,
+  ResultsEnvelope,
+} from './types';
 
 const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:5000';
 
@@ -81,6 +86,14 @@ export async function getEligibilityReport(caseId?: string): Promise<Eligibility
 }
 
 // -------------------- TRANSFORM CASE --------------------
+function toGeneratedForms(arr: any): GeneratedForm[] {
+  return (Array.isArray(arr) ? arr : []).map((f: any) => ({
+    name: f.name ?? f.formKey ?? '',
+    url: f.url ?? f.link ?? '',
+    grantId: f.grantId ?? f.grant_id ?? undefined,
+  }));
+}
+
 function transformCase(data: any): CaseSnapshot {
   const rawResults =
     Array.isArray(data.eligibility?.results)
@@ -102,7 +115,7 @@ function transformCase(data: any): CaseSnapshot {
     analyzerFields: data.analyzerFields || data.analyzer?.fields || {},
     questionnaire,
     eligibility: rawResults.length ? normalizeEligibility(rawResults) : [],
-    generatedForms: data.generatedForms || [],
+    generatedForms: toGeneratedForms(data.generatedForms),
     createdAt: data.createdAt,
     updatedAt: data.updatedAt,
   };

--- a/frontend/src/lib/normalize.ts
+++ b/frontend/src/lib/normalize.ts
@@ -50,6 +50,13 @@ export function normalizeEligibility(
       reasoning: toArray(item.reasoning ?? item.reasoning_steps),
       next_steps: item.next_steps ?? undefined,
       requiredForms: toArray(item.requiredForms),
+      generatedForms: Array.isArray(item.generatedForms)
+        ? item.generatedForms.map((f: any) => ({
+            name: f.name ?? f.formKey ?? '',
+            url: f.url ?? f.link ?? '',
+            grantId: f.grantId ?? f.grant_id ?? undefined,
+          }))
+        : undefined,
       ...(eligibility_percent !== undefined
         ? { eligibility_percent }
         : {}),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -26,6 +26,13 @@ export interface EligibilityItem {
   status?: 'eligible' | 'conditional' | 'ineligible';
   rationale?: string;
   certainty_level?: number;
+  generatedForms?: GeneratedForm[];
+}
+
+export interface GeneratedForm {
+  name: string;
+  url: string;
+  grantId?: string;
 }
 
 export interface CaseSnapshot {
@@ -39,7 +46,7 @@ export interface CaseSnapshot {
     lastUpdated?: string;
   };
   eligibility?: EligibilityItem[];
-  generatedForms?: Array<{ name: string; status?: string; link?: string }>;
+  generatedForms?: GeneratedForm[];
   createdAt?: string;
   updatedAt?: string;
 }

--- a/frontend/tests/summary.drafts-and-amount.test.tsx
+++ b/frontend/tests/summary.drafts-and-amount.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import SummaryStep from '@/app/dashboard/_steps/SummaryStep';
+import type { CaseSnapshot } from '@/lib/types';
+
+describe('SummaryStep', () => {
+  it('shows estimated amount and draft form link', () => {
+    const snapshot: CaseSnapshot = {
+      caseId: 'c1',
+      documents: [],
+      eligibility: [
+        {
+          name: 'ERC',
+          eligible: true,
+          missing_fields: [],
+          estimated_amount: 25000,
+          generatedForms: [
+            {
+              name: '941-X draft',
+              url: 'https://example.com/forms/941x.pdf',
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<SummaryStep snapshot={snapshot} onRestart={() => {}} />);
+
+    expect(screen.getByText('$25,000')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /941-X draft/i });
+    expect(link).toHaveAttribute('href', 'https://example.com/forms/941x.pdf');
+  });
+});


### PR DESCRIPTION
## Summary
- display estimated_amount and generated form draft links in summary step
- map generated forms and amounts in types, normalizer, and API client
- add SummaryStep UI test for amount and draft link visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae038945388327beca86a2444a8156