### PR TITLE
frontend: add form-fill API and summary action

### DIFF
--- a/frontend/src/app/dashboard/_steps/SummaryStep.tsx
+++ b/frontend/src/app/dashboard/_steps/SummaryStep.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useState } from 'react';
+import { postFormFill } from '@/lib/apiClient';
 import type { CaseSnapshot } from '@/lib/types';
 
 function formatCurrency(amount: number): string {
@@ -16,60 +18,107 @@ export default function SummaryStep({
   snapshot: CaseSnapshot;
   onRestart: () => void;
 }) {
+  const [snap, setSnap] = useState(snapshot);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerateForms() {
+    if (!snap.caseId || !snap.requiredForms) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { generatedForms } = await postFormFill(
+        snap.caseId,
+        snap.requiredForms,
+      );
+      setSnap({ ...snap, generatedForms });
+    } catch (e: any) {
+      setError(e.message ?? 'Failed to generate forms');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-bold">Summary</h2>
-      <p className="text-sm text-gray-700">Case ID: {snapshot.caseId}</p>
-      {snapshot.documents && snapshot.documents.length > 0 && (
+      <p className="text-sm text-gray-700">Case ID: {snap.caseId}</p>
+      {snap.documents && snap.documents.length > 0 && (
         <div>
           <h3 className="font-semibold">Documents</h3>
           <ul className="list-disc list-inside text-sm">
-            {snapshot.documents.map((d) => (
+            {snap.documents.map((d) => (
               <li key={d.key || d.filename}>{d.filename}</li>
             ))}
           </ul>
         </div>
       )}
-      {snapshot.eligibility && snapshot.eligibility.length > 0 && (
+      {snap.eligibility && snap.eligibility.length > 0 && (
         <div>
           <h3 className="font-semibold">Eligibility Results</h3>
           <ul className="list-disc list-inside text-sm space-y-2">
-            {snapshot.eligibility.map((r) => {
-              const grantForms = [
-                ...(r.generatedForms || []),
-                ...((snapshot.generatedForms || []).filter(
-                  (f) => f.grantId === r.name,
-                )),
-              ];
-              return (
-                <li key={r.name}>
-                  <div>
-                    {r.name}: {r.eligible === null ? 'Unknown' : r.eligible ? 'Yes' : 'No'}
-                  </div>
-                  {typeof r.estimated_amount === 'number' && (
-                    <div aria-label="Estimated amount">{formatCurrency(r.estimated_amount)}</div>
-                  )}
-                  {grantForms.length > 0 && (
-                    <ul aria-label="Generated forms" className="list-disc list-inside ml-4">
-                      {grantForms.map((f) => (
-                        <li key={f.url}>
-                          <a
-                            href={f.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {`View draft ${f.name}`}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
-              );
-            })}
+            {snap.eligibility.map((r) => (
+              <li key={r.name}>
+                <div>
+                  {r.name}: {r.eligible === null ? 'Unknown' : r.eligible ? 'Yes' : 'No'}
+                </div>
+                {typeof r.estimated_amount === 'number' && (
+                  <div aria-label="Estimated amount">{formatCurrency(r.estimated_amount)}</div>
+                )}
+                {r.generatedForms && r.generatedForms.length > 0 && (
+                  <ul aria-label="Generated forms" className="list-disc list-inside ml-4">
+                    {r.generatedForms.map((f) => (
+                      <li key={f.url}>
+                        <a
+                          href={f.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {`View draft ${f.name}`}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
           </ul>
         </div>
       )}
+      {snap.generatedForms && snap.generatedForms.length > 0 && (
+        <div>
+          <h3 className="font-semibold">Generated Forms</h3>
+          <ul className="list-disc list-inside text-sm">
+            {snap.generatedForms.map((f) => (
+              <li key={f.url}>
+                <a
+                  href={f.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {`View draft ${f.name}`}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {snap.requiredForms?.length && !snap.generatedForms?.length ? (
+        <div className="mt-3">
+          <button
+            onClick={handleGenerateForms}
+            disabled={loading}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            {loading ? 'Generating…' : 'Generate Forms'}
+          </button>
+          {error && (
+            <p role="alert" className="text-red-600 mt-2">
+              {error}
+            </p>
+          )}
+        </div>
+      ) : null}
       <button
         onClick={onRestart}
         className="px-4 py-2 bg-green-600 text-white rounded"

--- a/frontend/src/lib/normalize.ts
+++ b/frontend/src/lib/normalize.ts
@@ -52,9 +52,10 @@ export function normalizeEligibility(
       requiredForms: toArray(item.requiredForms),
       generatedForms: Array.isArray(item.generatedForms)
         ? item.generatedForms.map((f: any) => ({
-            name: f.name ?? f.formKey ?? '',
+            formId: f.formId ?? f.formKey ?? '',
+            name: f.name ?? f.formId ?? f.formKey ?? '',
             url: f.url ?? f.link ?? '',
-            grantId: f.grantId ?? f.grant_id ?? undefined,
+            version: f.version ?? f.formVersion ?? undefined,
           }))
         : undefined,
       ...(eligibility_percent !== undefined

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -30,13 +30,15 @@ export interface EligibilityItem {
 }
 
 export interface GeneratedForm {
+  formId: string;
   name: string;
   url: string;
-  grantId?: string;
+  version?: string;
 }
 
 export interface CaseSnapshot {
   caseId: string | null;
+  requiredForms?: string[];
   status?: CaseStatus;
   documents?: CaseDoc[];
   analyzerFields?: Record<string, unknown>;

--- a/frontend/tests/summary.drafts-and-amount.test.tsx
+++ b/frontend/tests/summary.drafts-and-amount.test.tsx
@@ -15,6 +15,7 @@ describe('SummaryStep', () => {
           estimated_amount: 25000,
           generatedForms: [
             {
+              formId: '941-X',
               name: '941-X draft',
               url: 'https://example.com/forms/941x.pdf',
             },

--- a/frontend/tests/summary.generate-forms.test.tsx
+++ b/frontend/tests/summary.generate-forms.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SummaryStep from '@/app/dashboard/_steps/SummaryStep';
+import type { CaseSnapshot } from '@/lib/types';
+import * as api from '@/lib/apiClient';
+
+jest.mock('@/lib/apiClient');
+
+describe('SummaryStep generate forms', () => {
+  it('generates forms when button clicked', async () => {
+    (api.postFormFill as jest.Mock).mockResolvedValue({
+      generatedForms: [
+        { formId: '941-X', name: '941-X draft', url: 'https://example.com/941x.pdf' },
+      ],
+    });
+    const snapshot: CaseSnapshot = {
+      caseId: 'c1',
+      requiredForms: ['941-X'],
+      generatedForms: [],
+      documents: [],
+      eligibility: [],
+    };
+    render(<SummaryStep snapshot={snapshot} onRestart={() => {}} />);
+    const btn = screen.getByRole('button', { name: /generate forms/i });
+    fireEvent.click(btn);
+    expect(api.postFormFill).toHaveBeenCalledWith('c1', ['941-X']);
+    const link = await screen.findByRole('link', { name: /941-x draft/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('shows error on failure', async () => {
+    (api.postFormFill as jest.Mock).mockRejectedValue(new Error('bad'));
+    const snapshot: CaseSnapshot = {
+      caseId: 'c1',
+      requiredForms: ['941-X'],
+      generatedForms: [],
+      documents: [],
+      eligibility: [],
+    };
+    render(<SummaryStep snapshot={snapshot} onRestart={() => {}} />);
+    const btn = screen.getByRole('button', { name: /generate forms/i });
+    fireEvent.click(btn);
+    await screen.findByRole('alert');
+    expect(btn).not.toBeDisabled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `postFormFill` API helper and normalize `GeneratedForm`
- expose case `requiredForms` and button in summary to generate drafts
- cover form generation flow with tests

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0abf7180832792bfe510e4fa0ddf