### PR TITLE
Ensure generated form drafts include metadata and accessible links

### DIFF
--- a/frontend/src/app/dashboard/_steps/SummaryStep.tsx
+++ b/frontend/src/app/dashboard/_steps/SummaryStep.tsx
@@ -67,18 +67,18 @@ export default function SummaryStep({
                 )}
                 {r.generatedForms && r.generatedForms.length > 0 && (
                   <ul aria-label="Generated forms" className="list-disc list-inside ml-4">
-                    {r.generatedForms.map((f) => (
-                      <li key={f.formId || f.name}>
-                        {f.url ? (
+                    {r.generatedForms.map((form, index) => (
+                      <li key={form.formId || index}>
+                        {form.url ? (
                           <a
-                            href={f.url}
+                            href={form.url}
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            {`View draft ${f.name}`}
+                            {`View draft (${form.name})`}
                           </a>
                         ) : (
-                          <span>Draft unavailable ({f.name})</span>
+                          'Draft unavailable'
                         )}
                       </li>
                     ))}
@@ -93,18 +93,18 @@ export default function SummaryStep({
         <div>
           <h3 className="font-semibold">Generated Forms</h3>
           <ul className="list-disc list-inside text-sm">
-            {snap.generatedForms.map((f) => (
-              <li key={f.formId || f.name}>
-                {f.url ? (
+            {snap.generatedForms.map((form, index) => (
+              <li key={form.formId || index}>
+                {form.url ? (
                   <a
-                    href={f.url}
+                    href={form.url}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {`View draft ${f.name}`}
+                    {`View draft (${form.name})`}
                   </a>
                 ) : (
-                  <span>Draft unavailable ({f.name})</span>
+                  'Draft unavailable'
                 )}
               </li>
             ))}

--- a/frontend/src/app/eligibility-report/page.tsx
+++ b/frontend/src/app/eligibility-report/page.tsx
@@ -146,18 +146,18 @@ export default function EligibilityReport() {
             <div>
               <h2 className="font-semibold mt-4">Generated Forms</h2>
               <ul className="list-disc list-inside">
-                {snapshot.generatedForms.map((f) => (
-                  <li key={f.formId || f.name}>
-                    {f.url ? (
+                {snapshot.generatedForms.map((form, index) => (
+                  <li key={form.formId || index}>
+                    {form.url ? (
                       <a
-                        href={f.url}
+                        href={form.url}
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        {`View draft ${f.name}`}
+                        {`View draft (${form.name})`}
                       </a>
                     ) : (
-                      <span>Draft unavailable ({f.name})</span>
+                      'Draft unavailable'
                     )}
                   </li>
                 ))}

--- a/frontend/tests/summary.drafts-and-amount.test.tsx
+++ b/frontend/tests/summary.drafts-and-amount.test.tsx
@@ -27,8 +27,13 @@ describe('SummaryStep', () => {
     render(<SummaryStep snapshot={snapshot} onRestart={() => {}} />);
 
     expect(screen.getByText('$25,000')).toBeInTheDocument();
-    const link = screen.getByRole('link', { name: /941-X draft/i });
-    expect(link).toHaveAttribute('href', 'https://example.com/forms/941x.pdf');
+    const link = screen.getByRole('link', {
+      name: /view draft \(941-x draft\)/i,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://example.com/forms/941x.pdf',
+    );
     expect(link).toHaveAttribute('target', '_blank');
   });
 
@@ -51,6 +56,10 @@ describe('SummaryStep', () => {
     render(<SummaryStep snapshot={snapshot} onRestart={() => {}} />);
 
     expect(screen.getByText(/Draft unavailable/i)).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /941-X draft/i })).toBeNull();
+    expect(
+      screen.queryByRole('link', {
+        name: /view draft \(941-x draft\)/i,
+      }),
+    ).toBeNull();
   });
 });

--- a/frontend/tests/summary.generate-forms.test.tsx
+++ b/frontend/tests/summary.generate-forms.test.tsx
@@ -23,7 +23,9 @@ describe('SummaryStep generate forms', () => {
     const btn = screen.getByRole('button', { name: /generate forms/i });
     fireEvent.click(btn);
     expect(api.postFormFill).toHaveBeenCalledWith('c1', ['941-X']);
-    const link = await screen.findByRole('link', { name: /941-x draft/i });
+    const link = await screen.findByRole('link', {
+      name: /view draft \(941-x draft\)/i,
+    });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('target', '_blank');
   });

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,9 @@ app.use(cors());
 app.use(express.json());
 app.use(requestId);
 
+const draftsDir = process.env.DRAFTS_DIR || '/tmp/forms';
+app.use('/forms', express.static(draftsDir));
+
 if (metricsMiddleware) app.use(metricsMiddleware);
 
 app.use(

--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -10,6 +10,7 @@ const caseSchema = new mongoose.Schema({
   generatedForms: {
     type: [
       {
+        formId: String,
         formKey: String,
         version: Number,
         data: mongoose.Schema.Types.Mixed,

--- a/server/models/PipelineCase.js
+++ b/server/models/PipelineCase.js
@@ -14,6 +14,7 @@ const documentSchema = new mongoose.Schema(
 const generatedFormSchema = new mongoose.Schema(
   {
     formName: String,
+    formId: String,
     payload: mongoose.Schema.Types.Mixed,
     files: [String],
     url: String,

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -1,6 +1,4 @@
 const express = require('express');
-const fs = require('fs');
-const path = require('path');
 const fetchFn =
   global.pipelineFetch ||
   (global.fetch
@@ -11,6 +9,7 @@ const { getServiceHeaders } = require('../utils/serviceHeaders');
 const logger = require('../utils/logger');
 const { getLatestTemplate } = require('../utils/formTemplates');
 const { validateAgainstSchema } = require('../middleware/formValidation');
+const { saveDraft } = require('../utils/drafts');
 
 const router = express.Router();
 
@@ -23,6 +22,16 @@ const supportedForms = new Set([
   'form_RD_400_8',
   'form_sf424',
 ]);
+
+const formNames = {
+  form_424A: '424A Application',
+  form_6765: 'Form 6765',
+  form_8974: 'Form 8974',
+  form_RD_400_1: 'RD 400-1',
+  form_RD_400_4: 'RD 400-4',
+  form_RD_400_8: 'RD 400-8',
+  form_sf424: 'SF-424 Application',
+};
 
 const formMap = {
   '424A': 'form_424A',
@@ -190,33 +199,17 @@ router.post('/eligibility-report', async (req, res) => {
           return;
         }
 
-        const draftsDir = process.env.DRAFTS_DIR || '/tmp/forms';
-        const filePath = path.join(draftsDir, caseId, `${formName}.pdf`);
-        try {
-          await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-          await fs.promises.writeFile(
-            filePath,
-            agentData.pdf
-              ? Buffer.from(agentData.pdf, 'base64')
-              : JSON.stringify(formData)
-          );
-        } catch (err) {
-          logger.error('form_fill_file_write_failed', {
-            formId: formName,
-            requestId: req.id,
-            error: err.stack,
-          });
-        }
-        const baseUrl = process.env.DRAFTS_BASE_URL;
-        const url = baseUrl
-          ? `${baseUrl.replace(/\/$/, '')}/drafts/${caseId}/${formName}.pdf`
-          : filePath;
+        const buffer = agentData.pdf
+          ? Buffer.from(agentData.pdf, 'base64')
+          : Buffer.from(JSON.stringify(formData));
+        const url = await saveDraft(caseId, formName, buffer, req);
         filledForms.push({
+          formId: formName,
           formKey: formName,
           version,
           data: formData,
           url,
-          name: formName,
+          name: formNames[formName] || formName,
         });
       } catch (err) {
         logger.error('form_fill_failed', {

--- a/server/tests/eligibility.report.test.js
+++ b/server/tests/eligibility.report.test.js
@@ -105,10 +105,13 @@ describe('eligibility report endpoints', () => {
       .send({ caseId });
     expect(res.status).toBe(200);
     expect(res.body.generatedForms).toHaveLength(1);
-    expect(res.body.generatedForms[0].formKey).toBe('form_424A');
+    expect(res.body.generatedForms[0].formId).toBe('form_424A');
+    expect(res.body.generatedForms[0].name).toBeTruthy();
     expect(res.body.generatedForms[0].url).toBeTruthy();
     const stored = await getCase('dev-user', caseId);
     expect(stored.generatedForms).toHaveLength(1);
+    expect(stored.generatedForms[0].formId).toBe('form_424A');
+    expect(stored.generatedForms[0].name).toBeTruthy();
     expect(stored.generatedForms[0].url).toBeTruthy();
   });
 

--- a/server/utils/drafts.js
+++ b/server/utils/drafts.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const logger = require('./logger');
+
+async function saveDraft(caseId, formId, buffer, req) {
+  if (process.env.DRAFTS_S3_BUCKET) {
+    try {
+      const { S3Client, PutObjectCommand, GetObjectCommand } = await import('@aws-sdk/client-s3');
+      const { getSignedUrl } = await import('@aws-sdk/s3-request-presigner');
+      const client = new S3Client();
+      const key = `${caseId}/${formId}.pdf`;
+      await client.send(
+        new PutObjectCommand({
+          Bucket: process.env.DRAFTS_S3_BUCKET,
+          Key: key,
+          Body: buffer,
+          ContentType: 'application/pdf',
+        }),
+      );
+      return await getSignedUrl(
+        client,
+        new GetObjectCommand({ Bucket: process.env.DRAFTS_S3_BUCKET, Key: key }),
+        { expiresIn: 3600 },
+      );
+    } catch (err) {
+      logger.warn('draft_url_generation_failed', {
+        caseId,
+        formId,
+        error: err.stack,
+        requestId: req.id,
+      });
+      return '';
+    }
+  }
+  const draftsDir = process.env.DRAFTS_DIR || '/tmp/forms';
+  const filePath = path.join(draftsDir, caseId, `${formId}.pdf`);
+  try {
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.promises.writeFile(filePath, buffer);
+  } catch (err) {
+    logger.error('form_fill_file_write_failed', {
+      caseId,
+      formId,
+      error: err.stack,
+      requestId: req.id,
+    });
+    return '';
+  }
+  try {
+    const baseUrl = process.env.DRAFTS_BASE_URL;
+    if (baseUrl) {
+      return `${baseUrl.replace(/\/$/, '')}/${caseId}/${formId}.pdf`;
+    }
+    const host = req.get ? req.get('host') : 'localhost';
+    const protocol = req.protocol || 'http';
+    return `${protocol}://${host}/forms/${caseId}/${formId}.pdf`;
+  } catch (err) {
+    logger.warn('draft_url_generation_failed', {
+      caseId,
+      formId,
+      error: err.stack,
+      requestId: req.id,
+    });
+    return '';
+  }
+}
+
+module.exports = { saveDraft };


### PR DESCRIPTION
## Summary
- serve saved form drafts from `/forms` and support S3 signed URLs
- return each generated form with `formId`, `name`, and accessible `url`
- render draft links with stable keys and fallback message when missing

## Testing
- `npm test` (frontend)
- `npm test` *(server) – jest not found*
- `npm install` *(server) – 403 Forbidden installing jest*


------
https://chatgpt.com/codex/tasks/task_b_68ae16dc91608327a71f882ad2759a36