### PR TITLE
server: validate and store pdf drafts

### DIFF
--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -199,10 +199,11 @@ router.post('/eligibility-report', async (req, res) => {
           return;
         }
 
-        const buffer = agentData.pdf
-          ? Buffer.from(agentData.pdf, 'base64')
-          : Buffer.from(JSON.stringify(formData));
-        const url = await saveDraft(caseId, formName, buffer, req);
+        let url;
+        if (agentData.pdf) {
+          const buffer = Buffer.from(agentData.pdf, 'base64');
+          url = await saveDraft(caseId, formName, buffer, req);
+        }
         filledForms.push({
           formId: formName,
           formKey: formName,

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -133,10 +133,11 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
         return res.status(400).json({ errors: validationErrors });
       }
 
-      const buffer = agentData.pdf
-        ? Buffer.from(agentData.pdf, 'base64')
-        : Buffer.from(JSON.stringify(formData));
-      const url = await saveDraft(caseId, formName, buffer, req);
+      let url;
+      if (agentData.pdf) {
+        const buffer = Buffer.from(agentData.pdf, 'base64');
+        url = await saveDraft(caseId, formName, buffer, req);
+      }
       filledForms.push({
         formId: formName,
         formKey: formName,

--- a/server/tests/drafts.test.js
+++ b/server/tests/drafts.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const { saveDraft } = require('../utils/drafts');
+const logger = require('../utils/logger');
+
+const base64Pdf = 'JVBERi0xLjEKMSAwIG9iago8PD4+CmVuZG9iagpzdGFydHhyZWYKMAolJUVPRg==';
+
+function mockReq() {
+  return {
+    id: 'test',
+    get: () => 'localhost',
+    protocol: 'http',
+  };
+}
+
+describe('drafts.saveDraft', () => {
+  const tmpDir = path.join(__dirname, 'tmp');
+  beforeEach(() => {
+    process.env.DRAFTS_DIR = tmpDir;
+    logger.logs.length = 0;
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('writes valid pdf and returns url', async () => {
+    const buffer = Buffer.from(base64Pdf, 'base64');
+    const url = await saveDraft('case1', 'form1', buffer, mockReq());
+    expect(url).toMatch(/case1\/form1\.pdf$/);
+    const filePath = path.join(tmpDir, 'case1', 'form1.pdf');
+    const contents = await fs.promises.readFile(filePath);
+    expect(contents.slice(0,5).toString()).toBe('%PDF-');
+    const log = logger.logs.find((l) => l.message === 'draft_saved');
+    expect(log).toBeDefined();
+    expect(log.size).toBeGreaterThan(0);
+  });
+
+  test('returns undefined and logs when invalid', async () => {
+    const buffer = Buffer.from('not a pdf');
+    const url = await saveDraft('case2', 'form1', buffer, mockReq());
+    expect(url).toBeUndefined();
+    const log = logger.logs.find((l) => l.message === 'draft_invalid_pdf');
+    expect(log).toBeDefined();
+  });
+});

--- a/server/tests/pipeline.submit.test.js
+++ b/server/tests/pipeline.submit.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+const path = require('path');
+const fs = require('fs');
+process.env.SKIP_DB = 'true';
+const app = require('../index');
+const { resetStore } = require('../utils/pipelineStore');
+
+describe('pipeline submit-case', () => {
+  const tmpDir = path.join(__dirname, 'tmp-pipeline');
+  beforeEach(() => {
+    process.env.DRAFTS_DIR = tmpDir;
+    resetStore();
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('does not create draft when agent lacks pdf', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ requiredForms: ['form_424A'] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ filled_form: { foo: 'bar' } }),
+      });
+
+    const res = await request(app)
+      .post('/api/submit-case')
+      .field('businessName', 'Biz')
+      .field('email', 'a@b.com')
+      .field('phone', '1234567');
+
+    expect(res.status).toBe(200);
+    expect(res.body.generatedForms[0].url).toBeUndefined();
+    const filePath = path.join(tmpDir, res.body.caseId, 'form_424A.pdf');
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+});

--- a/server/utils/drafts.js
+++ b/server/utils/drafts.js
@@ -3,6 +3,25 @@ const path = require('path');
 const logger = require('./logger');
 
 async function saveDraft(caseId, formId, buffer, req) {
+  if (!buffer || buffer.length === 0) {
+    logger.warn('draft_invalid_pdf', {
+      caseId,
+      formId,
+      reason: 'empty_buffer',
+      requestId: req.id,
+    });
+    return undefined;
+  }
+  const pdfSignature = buffer.slice(0, 5).toString() === '%PDF-';
+  if (!pdfSignature) {
+    logger.warn('draft_invalid_pdf', {
+      caseId,
+      formId,
+      reason: 'invalid_signature',
+      requestId: req.id,
+    });
+    return undefined;
+  }
   if (process.env.DRAFTS_S3_BUCKET) {
     try {
       const { S3Client, PutObjectCommand, GetObjectCommand } = await import('@aws-sdk/client-s3');
@@ -17,11 +36,20 @@ async function saveDraft(caseId, formId, buffer, req) {
           ContentType: 'application/pdf',
         }),
       );
-      return await getSignedUrl(
+      const url = await getSignedUrl(
         client,
         new GetObjectCommand({ Bucket: process.env.DRAFTS_S3_BUCKET, Key: key }),
         { expiresIn: 3600 },
       );
+      logger.info('draft_saved', {
+        caseId,
+        formId,
+        path: `s3://${process.env.DRAFTS_S3_BUCKET}/${key}`,
+        size: buffer.length,
+        pdfSignature,
+        requestId: req.id,
+      });
+      return url;
     } catch (err) {
       logger.warn('draft_url_generation_failed', {
         caseId,
@@ -29,7 +57,7 @@ async function saveDraft(caseId, formId, buffer, req) {
         error: err.stack,
         requestId: req.id,
       });
-      return '';
+      return undefined;
     }
   }
   const draftsDir = process.env.DRAFTS_DIR || '/tmp/forms';
@@ -37,6 +65,25 @@ async function saveDraft(caseId, formId, buffer, req) {
   try {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     await fs.promises.writeFile(filePath, buffer);
+    const stat = await fs.promises.stat(filePath);
+    if (!stat.size) {
+      await fs.promises.unlink(filePath).catch(() => {});
+      logger.warn('draft_invalid_pdf', {
+        caseId,
+        formId,
+        reason: 'empty_file',
+        requestId: req.id,
+      });
+      return undefined;
+    }
+    logger.info('draft_saved', {
+      caseId,
+      formId,
+      path: filePath,
+      size: stat.size,
+      pdfSignature,
+      requestId: req.id,
+    });
   } catch (err) {
     logger.error('form_fill_file_write_failed', {
       caseId,
@@ -44,7 +91,7 @@ async function saveDraft(caseId, formId, buffer, req) {
       error: err.stack,
       requestId: req.id,
     });
-    return '';
+    return undefined;
   }
   try {
     const baseUrl = process.env.DRAFTS_BASE_URL;
@@ -61,7 +108,7 @@ async function saveDraft(caseId, formId, buffer, req) {
       error: err.stack,
       requestId: req.id,
     });
-    return '';
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- validate PDF buffers before saving drafts and log results
- remove JSON-as-PDF fallback in eligibility and pipeline routes
- add tests for draft handling and no-URL behavior when PDFs missing

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1bfe291883278b6f9770dc49ef8e