### PR TITLE
agent: drop pdf field; server-side PDF rendering

### DIFF
--- a/ai-agent/main.py
+++ b/ai-agent/main.py
@@ -138,12 +138,8 @@ async def form_fill(request_model: FormFillRequest) -> FormFillResponse:
             request_model.session_id,
             {"form": request_model.form_name, "data": normalized_data},
         )
-
-    dummy_pdf = (
-        "JVBERi0xLjEKMSAwIG9iago8PD4+CmVuZG9iagpzdGFydHhyZWYKMAolJUVPRg=="
-    )
     return FormFillResponse(
-        filled_form=filled, reasoning=reasoning, pdf=dummy_pdf
+        filled_form=filled, reasoning=reasoning
     )
 
 

--- a/ai-agent/schemas.py
+++ b/ai-agent/schemas.py
@@ -71,4 +71,3 @@ class FormFillRequest(BaseModel):
 class FormFillResponse(BaseModel):
     filled_form: Dict[str, Any]
     reasoning: Reasoning
-    pdf: Optional[str] = None

--- a/ai-agent/tests/test_form_fill_merge.py
+++ b/ai-agent/tests/test_form_fill_merge.py
@@ -14,9 +14,7 @@ def test_user_values_win_and_reasoning_logs_sources():
     data = resp.json()
     fields = data["filled_form"]["fields"]
     assert fields["employer_identification_number"] == "12-3456789"
+    assert "pdf" not in data
     steps = data["reasoning"]["reasoning_steps"]
     assert any("kept user value" in s and "employer_identification_number" in s for s in steps)
     assert any("filled" in s and "reporting_quarter" in s for s in steps)
-    import base64
-    pdf_bytes = base64.b64decode(data["pdf"])
-    assert pdf_bytes[:5] == b"%PDF-"

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -199,43 +199,41 @@ router.post('/eligibility-report', async (req, res) => {
           });
           return;
         }
-
         let url;
         logger.info('form_fill_received', {
-          hasPdf: Boolean(agentData.pdf),
           formId: formName,
+          hasFilledForm: true,
           caseId,
           requestId: req.id,
         });
 
-        const renderMode = process.env.DRAFTS_RENDER_MODE || 'server';
         let buffer;
-        if (renderMode === 'agent' && agentData.pdf) {
-          const b = Buffer.from(agentData.pdf, 'base64');
-          if (b.length > 0 && b.slice(0, 5).toString() === '%PDF-') {
-            buffer = b;
-          }
-        }
-        if (!buffer) {
-          try {
-            logger.info('pdf_render_started', {
-              formId: formName,
-              caseId,
-              requestId: req.id,
-            });
-            buffer = await renderPdf({ formId: formName, filledForm: formData });
-          } catch (err) {
-            logger.error('pdf_render_failed', {
-              formId: formName,
-              caseId,
-              error: err.stack,
-              requestId: req.id,
-            });
-            buffer = undefined;
-          }
-        }
-        if (buffer) {
+        try {
+          logger.info('pdf_render_started', {
+            formId: formName,
+            caseId,
+            requestId: req.id,
+          });
+          buffer = await renderPdf({ formId: formName, filledForm: formData });
+          const valid =
+            buffer.length > 0 &&
+            buffer.slice(0, 5).toString() === '%PDF-' &&
+            buffer.includes('%%EOF');
+          if (!valid) throw new Error('invalid_pdf');
+          logger.info('pdf_render_succeeded', {
+            formId: formName,
+            caseId,
+            size: buffer.length,
+            requestId: req.id,
+          });
           url = await saveDraft(caseId, formName, buffer, req);
+        } catch (err) {
+          logger.error('pdf_render_failed', {
+            formId: formName,
+            caseId,
+            error: err.stack || String(err),
+            requestId: req.id,
+          });
         }
         filledForms.push({
           formId: formName,

--- a/server/tests/pdfRenderer.test.js
+++ b/server/tests/pdfRenderer.test.js
@@ -5,5 +5,6 @@ test('renderPdf returns valid PDF buffer', async () => {
   expect(Buffer.isBuffer(buf)).toBe(true);
   expect(buf.length).toBeGreaterThan(0);
   expect(buf.slice(0, 5).toString()).toBe('%PDF-');
+  expect(buf.includes('%%EOF')).toBe(true);
 });
 

--- a/server/tests/pipeline.submit.test.js
+++ b/server/tests/pipeline.submit.test.js
@@ -16,7 +16,7 @@ describe('pipeline submit-case', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('renders draft when agent lacks pdf', async () => {
+  test('renders draft from filled_form', async () => {
     global.fetch
       .mockResolvedValueOnce({
         ok: true,

--- a/server/utils/drafts.js
+++ b/server/utils/drafts.js
@@ -13,11 +13,12 @@ async function saveDraft(caseId, formId, buffer, req) {
     return undefined;
   }
   const pdfSignature = buffer.slice(0, 5).toString() === '%PDF-';
-  if (!pdfSignature) {
+  const eofSignature = buffer.includes('%%EOF');
+  if (!pdfSignature || !eofSignature) {
     logger.warn('draft_invalid_pdf', {
       caseId,
       formId,
-      reason: 'invalid_signature',
+      reason: !pdfSignature ? 'invalid_signature' : 'missing_eof',
       requestId: req.id,
     });
     return undefined;


### PR DESCRIPTION
## Summary
- remove PDF from AI agent form-fill schema and responses
- render and validate PDFs on the server, logging outcomes and saving drafts
- require EOF marker when persisting drafts

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68ae2619664c832780a8b3900b367a54