### PR TITLE
Fix bare key field handling in form filler

### DIFF
--- a/ai-agent/fill_form.py
+++ b/ai-agent/fill_form.py
@@ -257,10 +257,14 @@ def _fill_template(
         "expected_file",
     }
     for k, spec in fields.items():
-        if isinstance(spec, dict) and not (FIELD_KEYS & spec.keys()):
-            merged[k] = _fill_template(spec, data, reasoning)
-            continue
         if isinstance(spec, dict):
+            if (
+                "fields" in spec
+                or "sections" in spec
+                or (not (FIELD_KEYS & spec.keys()) and any(isinstance(v, dict) for v in spec.values()))
+            ):
+                merged[k] = _fill_template(spec, data, reasoning)
+                continue
             default = spec.get("default", "")
             required = spec.get("required", True)
             ftype = spec.get("type", "text")


### PR DESCRIPTION
## Summary
- correctly treat field specs that only provide a key as actual form fields

## Testing
- `python - <<'PY'
import json, sys
sys.path.append('ai-agent')
from fill_form import fill_form
result = fill_form('form_RD_400_4', {'entity_type': 'LLC'})
print(json.dumps(result['fields'], indent=2, sort_keys=True))
PY`
- `PYTHONPATH=ai-agent pytest ai-agent/tests -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae581d34388327b0ce92e3ccb791cf