### PR TITLE
Avoid normalizing date fields in form fill

### DIFF
--- a/ai-agent/fill_form.py
+++ b/ai-agent/fill_form.py
@@ -308,7 +308,13 @@ def _fill_template(
         if k in data and reasoning is not None:
             reasoning.append(f"{k} provided by user")
         if isinstance(value, str):
-            _, value = normalize_text_field(k, value)
+            # Skip normalization for date-like fields to avoid stripping
+            # separators. ``normalize_text_field`` would treat values such as
+            # "2024-10-19" as numeric and convert them to ``2024``. For
+            # any explicitly typed date field or keys containing "date", we
+            # therefore keep the original string value.
+            if ftype != "date" and "date" not in k.lower():
+                _, value = normalize_text_field(k, value)
         if value is None:
             if k in optional:
                 value = optional[k]

--- a/ai-agent/tests/test_form_fill_merge.py
+++ b/ai-agent/tests/test_form_fill_merge.py
@@ -48,3 +48,16 @@ def test_user_overrides_analyzer_field():
     data = resp.json()
     fields = data["filled_form"]["fields"]
     assert fields["employer_identification_number"] == "98-7654321"
+
+
+def test_date_fields_preserved():
+    resp = client.post(
+        "/form-fill",
+        json={
+            "form_name": "form_8974",
+            "user_payload": {"income_tax_period_ending_date": "2024-05-01"},
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["filled_form"]["fields"]
+    assert data["income_tax_period_ending_date"] == "2024-05-01"


### PR DESCRIPTION
## Summary
- Skip text normalization for date fields in `_fill_template`
- Add regression test ensuring date fields keep their `YYYY-MM-DD` format

## Testing
- `PYTHONPATH=ai-agent pytest ai-agent/tests/test_form_fill_merge.py::test_date_fields_preserved ai-agent/tests/test_check_dates.py::test_dd_mm_yyyy_normalized -q`
- `PYTHONPATH=ai-agent python - <<'PY'
from fastapi.testclient import TestClient
import main
client=TestClient(main.app)
resp=client.post('/form-fill', json={'form_name':'form_8974','user_payload':{'date_income_tax_return_was_filed':'10/11/2024'}})
print('status', resp.status_code)
print('filled', resp.json()['filled_form']['fields']['date_income_tax_return_was_filed'])
PY`

------
https://chatgpt.com/codex/tasks/task_b_68ae5a513f548327bc5da163b1babdc7