### PR TITLE
feat: add SF-424A form support

### DIFF
--- a/ai-agent/form_templates/form_424A.json
+++ b/ai-agent/form_templates/form_424A.json
@@ -1,6 +1,545 @@
 {
   "form_name": "form_424A",
   "fields": [
-    { "key": "applicant_name", "prompt": "Provide the applicant's legal name." }
+    {
+      "key": "a_row1_program"
+    },
+    {
+      "key": "a_row1_assistance_listing"
+    },
+    {
+      "key": "a_row1_unobligated_federal"
+    },
+    {
+      "key": "a_row1_unobligated_non_federal"
+    },
+    {
+      "key": "a_row1_new_federal"
+    },
+    {
+      "key": "a_row1_new_non_federal"
+    },
+    {
+      "key": "a_row1_total"
+    },
+    {
+      "key": "a_row2_program"
+    },
+    {
+      "key": "a_row2_assistance_listing"
+    },
+    {
+      "key": "a_row2_unobligated_federal"
+    },
+    {
+      "key": "a_row2_unobligated_non_federal"
+    },
+    {
+      "key": "a_row2_new_federal"
+    },
+    {
+      "key": "a_row2_new_non_federal"
+    },
+    {
+      "key": "a_row2_total"
+    },
+    {
+      "key": "a_row3_program"
+    },
+    {
+      "key": "a_row3_assistance_listing"
+    },
+    {
+      "key": "a_row3_unobligated_federal"
+    },
+    {
+      "key": "a_row3_unobligated_non_federal"
+    },
+    {
+      "key": "a_row3_new_federal"
+    },
+    {
+      "key": "a_row3_new_non_federal"
+    },
+    {
+      "key": "a_row3_total"
+    },
+    {
+      "key": "a_row4_program"
+    },
+    {
+      "key": "a_row4_assistance_listing"
+    },
+    {
+      "key": "a_row4_unobligated_federal"
+    },
+    {
+      "key": "a_row4_unobligated_non_federal"
+    },
+    {
+      "key": "a_row4_new_federal"
+    },
+    {
+      "key": "a_row4_new_non_federal"
+    },
+    {
+      "key": "a_row4_total"
+    },
+    {
+      "key": "a_row5_program"
+    },
+    {
+      "key": "a_row5_assistance_listing"
+    },
+    {
+      "key": "a_row5_unobligated_federal"
+    },
+    {
+      "key": "a_row5_unobligated_non_federal"
+    },
+    {
+      "key": "a_row5_new_federal"
+    },
+    {
+      "key": "a_row5_new_non_federal"
+    },
+    {
+      "key": "a_row5_total"
+    },
+    {
+      "key": "b_personnel_col1"
+    },
+    {
+      "key": "b_personnel_col2"
+    },
+    {
+      "key": "b_personnel_col3"
+    },
+    {
+      "key": "b_personnel_col4"
+    },
+    {
+      "key": "b_personnel_col5"
+    },
+    {
+      "key": "b_personnel_total"
+    },
+    {
+      "key": "b_fringe_benefits_col1"
+    },
+    {
+      "key": "b_fringe_benefits_col2"
+    },
+    {
+      "key": "b_fringe_benefits_col3"
+    },
+    {
+      "key": "b_fringe_benefits_col4"
+    },
+    {
+      "key": "b_fringe_benefits_col5"
+    },
+    {
+      "key": "b_fringe_benefits_total"
+    },
+    {
+      "key": "b_travel_col1"
+    },
+    {
+      "key": "b_travel_col2"
+    },
+    {
+      "key": "b_travel_col3"
+    },
+    {
+      "key": "b_travel_col4"
+    },
+    {
+      "key": "b_travel_col5"
+    },
+    {
+      "key": "b_travel_total"
+    },
+    {
+      "key": "b_equipment_col1"
+    },
+    {
+      "key": "b_equipment_col2"
+    },
+    {
+      "key": "b_equipment_col3"
+    },
+    {
+      "key": "b_equipment_col4"
+    },
+    {
+      "key": "b_equipment_col5"
+    },
+    {
+      "key": "b_equipment_total"
+    },
+    {
+      "key": "b_supplies_col1"
+    },
+    {
+      "key": "b_supplies_col2"
+    },
+    {
+      "key": "b_supplies_col3"
+    },
+    {
+      "key": "b_supplies_col4"
+    },
+    {
+      "key": "b_supplies_col5"
+    },
+    {
+      "key": "b_supplies_total"
+    },
+    {
+      "key": "b_contractual_col1"
+    },
+    {
+      "key": "b_contractual_col2"
+    },
+    {
+      "key": "b_contractual_col3"
+    },
+    {
+      "key": "b_contractual_col4"
+    },
+    {
+      "key": "b_contractual_col5"
+    },
+    {
+      "key": "b_contractual_total"
+    },
+    {
+      "key": "b_construction_col1"
+    },
+    {
+      "key": "b_construction_col2"
+    },
+    {
+      "key": "b_construction_col3"
+    },
+    {
+      "key": "b_construction_col4"
+    },
+    {
+      "key": "b_construction_col5"
+    },
+    {
+      "key": "b_construction_total"
+    },
+    {
+      "key": "b_other_col1"
+    },
+    {
+      "key": "b_other_col2"
+    },
+    {
+      "key": "b_other_col3"
+    },
+    {
+      "key": "b_other_col4"
+    },
+    {
+      "key": "b_other_col5"
+    },
+    {
+      "key": "b_other_total"
+    },
+    {
+      "key": "b_total_direct_col1"
+    },
+    {
+      "key": "b_total_direct_col2"
+    },
+    {
+      "key": "b_total_direct_col3"
+    },
+    {
+      "key": "b_total_direct_col4"
+    },
+    {
+      "key": "b_total_direct_col5"
+    },
+    {
+      "key": "b_total_direct_total"
+    },
+    {
+      "key": "b_indirect_col1"
+    },
+    {
+      "key": "b_indirect_col2"
+    },
+    {
+      "key": "b_indirect_col3"
+    },
+    {
+      "key": "b_indirect_col4"
+    },
+    {
+      "key": "b_indirect_col5"
+    },
+    {
+      "key": "b_indirect_total"
+    },
+    {
+      "key": "b_totals_col1"
+    },
+    {
+      "key": "b_totals_col2"
+    },
+    {
+      "key": "b_totals_col3"
+    },
+    {
+      "key": "b_totals_col4"
+    },
+    {
+      "key": "b_totals_col5"
+    },
+    {
+      "key": "b_totals_total"
+    },
+    {
+      "key": "b_program_income_col1"
+    },
+    {
+      "key": "b_program_income_col2"
+    },
+    {
+      "key": "b_program_income_col3"
+    },
+    {
+      "key": "b_program_income_col4"
+    },
+    {
+      "key": "b_program_income_col5"
+    },
+    {
+      "key": "b_program_income_total"
+    },
+    {
+      "key": "c_row8_program"
+    },
+    {
+      "key": "c_row8_applicant"
+    },
+    {
+      "key": "c_row8_state"
+    },
+    {
+      "key": "c_row8_other"
+    },
+    {
+      "key": "c_row8_totals"
+    },
+    {
+      "key": "c_row9_program"
+    },
+    {
+      "key": "c_row9_applicant"
+    },
+    {
+      "key": "c_row9_state"
+    },
+    {
+      "key": "c_row9_other"
+    },
+    {
+      "key": "c_row9_totals"
+    },
+    {
+      "key": "c_row10_program"
+    },
+    {
+      "key": "c_row10_applicant"
+    },
+    {
+      "key": "c_row10_state"
+    },
+    {
+      "key": "c_row10_other"
+    },
+    {
+      "key": "c_row10_totals"
+    },
+    {
+      "key": "c_row11_program"
+    },
+    {
+      "key": "c_row11_applicant"
+    },
+    {
+      "key": "c_row11_state"
+    },
+    {
+      "key": "c_row11_other"
+    },
+    {
+      "key": "c_row11_totals"
+    },
+    {
+      "key": "c_row12_program"
+    },
+    {
+      "key": "c_row12_applicant"
+    },
+    {
+      "key": "c_row12_state"
+    },
+    {
+      "key": "c_row12_other"
+    },
+    {
+      "key": "c_row12_totals"
+    },
+    {
+      "key": "d_cash_needs_federal_q1"
+    },
+    {
+      "key": "d_cash_needs_federal_q2"
+    },
+    {
+      "key": "d_cash_needs_federal_q3"
+    },
+    {
+      "key": "d_cash_needs_federal_q4"
+    },
+    {
+      "key": "d_cash_needs_federal_total"
+    },
+    {
+      "key": "d_cash_needs_non_federal_q1"
+    },
+    {
+      "key": "d_cash_needs_non_federal_q2"
+    },
+    {
+      "key": "d_cash_needs_non_federal_q3"
+    },
+    {
+      "key": "d_cash_needs_non_federal_q4"
+    },
+    {
+      "key": "d_cash_needs_non_federal_total"
+    },
+    {
+      "key": "d_cash_needs_total_q1"
+    },
+    {
+      "key": "d_cash_needs_total_q2"
+    },
+    {
+      "key": "d_cash_needs_total_q3"
+    },
+    {
+      "key": "d_cash_needs_total_q4"
+    },
+    {
+      "key": "d_cash_needs_total_total"
+    },
+    {
+      "key": "e_row16_program"
+    },
+    {
+      "key": "e_row16_y1"
+    },
+    {
+      "key": "e_row16_y2"
+    },
+    {
+      "key": "e_row16_y3"
+    },
+    {
+      "key": "e_row16_y4"
+    },
+    {
+      "key": "e_row16_total"
+    },
+    {
+      "key": "e_row17_program"
+    },
+    {
+      "key": "e_row17_y1"
+    },
+    {
+      "key": "e_row17_y2"
+    },
+    {
+      "key": "e_row17_y3"
+    },
+    {
+      "key": "e_row17_y4"
+    },
+    {
+      "key": "e_row17_total"
+    },
+    {
+      "key": "e_row18_program"
+    },
+    {
+      "key": "e_row18_y1"
+    },
+    {
+      "key": "e_row18_y2"
+    },
+    {
+      "key": "e_row18_y3"
+    },
+    {
+      "key": "e_row18_y4"
+    },
+    {
+      "key": "e_row18_total"
+    },
+    {
+      "key": "e_row19_program"
+    },
+    {
+      "key": "e_row19_y1"
+    },
+    {
+      "key": "e_row19_y2"
+    },
+    {
+      "key": "e_row19_y3"
+    },
+    {
+      "key": "e_row19_y4"
+    },
+    {
+      "key": "e_row19_total"
+    },
+    {
+      "key": "e_row20_program"
+    },
+    {
+      "key": "e_row20_y1"
+    },
+    {
+      "key": "e_row20_y2"
+    },
+    {
+      "key": "e_row20_y3"
+    },
+    {
+      "key": "e_row20_y4"
+    },
+    {
+      "key": "e_row20_total"
+    },
+    {
+      "key": "f_other_direct_charges"
+    },
+    {
+      "key": "f_other_indirect_charges"
+    },
+    {
+      "key": "f_other_remarks"
+    }
   ]
 }

--- a/ai-agent/tests/test_form_fill_424A.py
+++ b/ai-agent/tests/test_form_fill_424A.py
@@ -1,0 +1,76 @@
+import main
+from fastapi.testclient import TestClient
+
+client = TestClient(main.app)
+
+def test_form_424A_calculations():
+    payload = {
+        "a_row1_program": "Prog1",
+        "a_row1_assistance_listing": "12.345",
+        "a_row1_unobligated_federal": 100,
+        "a_row1_unobligated_non_federal": 50,
+        "a_row1_new_federal": 200,
+        "a_row1_new_non_federal": 100,
+        "b_personnel_col1": 1000,
+        "b_personnel_col2": 2000,
+        "b_equipment_col1": 500,
+        "b_indirect_col1": 100,
+        "b_program_income_col1": 10,
+        "c_row8_program": "P1",
+        "c_row8_applicant": 10,
+        "c_row8_state": 20,
+        "c_row8_other": 30,
+        "c_row9_program": "P2",
+        "c_row9_applicant": 5,
+        "c_row9_state": 5,
+        "d_cash_needs_federal_q1": 100,
+        "d_cash_needs_federal_q2": 50,
+        "d_cash_needs_non_federal_q1": 20,
+        "e_row16_program": "EA",
+        "e_row16_y1": 100,
+        "e_row17_program": "EB",
+        "e_row17_y1": 50,
+        "f_other_direct_charges": 100,
+        "f_other_indirect_charges": 10,
+        "f_other_remarks": "ok",
+    }
+    resp = client.post(
+        "/form-fill",
+        json={"form_name": "form_424A", "user_payload": payload, "analyzer_fields": {}},
+    )
+    assert resp.status_code == 200
+    filled = resp.json()["filled_form"]
+    fields = filled["fields"]
+    assert filled["missing_keys"] == []
+    assert filled["calc_mismatches"] == []
+    assert fields["a_row1_total"] == 450.0
+    assert fields["a_row5_unobligated_federal"] == 100.0
+    assert fields["b_personnel_total"] == 3000.0
+    assert fields["b_total_direct_col1"] == 1500.0
+    assert fields["b_indirect_total"] == 100.0
+    assert fields["b_totals_col1"] == 1600.0
+    assert fields["c_row8_totals"] == 60.0
+    assert fields["c_row12_applicant"] == 15.0
+    assert fields["d_cash_needs_federal_total"] == 150.0
+    assert fields["d_cash_needs_total_q1"] == 120.0
+    assert fields["e_row16_total"] == 100.0
+    assert fields["e_row20_y1"] == 150.0
+
+
+def test_form_424A_mismatch_detected():
+    payload = {
+        "a_row1_program": "Prog1",
+        "a_row1_assistance_listing": "12.3",
+        "a_row1_unobligated_federal": 100,
+        "b_personnel_col1": 100,
+        "b_personnel_total": 50,
+    }
+    resp = client.post(
+        "/form-fill",
+        json={"form_name": "form_424A", "user_payload": payload, "analyzer_fields": {}},
+    )
+    assert resp.status_code == 200
+    filled = resp.json()["filled_form"]
+    assert filled["calc_mismatches"]
+    paths = {m["path"] for m in filled["calc_mismatches"]}
+    assert "b_personnel_total" in paths


### PR DESCRIPTION
## Summary
- add expansive SF-424A template with canonical field keys
- implement SF-424A normalization, auto-calculation, and validation
- cover SF-424A logic with unit tests

## Testing
- `PYTHONPATH=ai-agent pytest ai-agent/tests/test_form_fill_424A.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68af47b905a4832794d9c06f2afe8d9a