### PR TITLE
feat: track default required documents for cases

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -145,6 +145,9 @@ function transformCase(data: any): CaseSnapshot {
   return {
     caseId: data.caseId,
     requiredForms: Array.isArray(data.requiredForms) ? data.requiredForms : undefined,
+    requiredDocuments: Array.isArray(data.requiredDocuments)
+      ? data.requiredDocuments
+      : undefined,
     status: data.status,
     documents: data.documents || [],
     analyzerFields: data.analyzerFields || data.analyzer?.fields || {},

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,6 +46,7 @@ export interface IncompleteForm {
 export interface CaseSnapshot {
   caseId: string | null;
   requiredForms?: string[];
+  requiredDocuments?: string[];
   status?: CaseStatus;
   documents?: CaseDoc[];
   analyzerFields?: Record<string, unknown>;

--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -1,10 +1,12 @@
 const mongoose = require('mongoose');
+const { ALWAYS_REQUIRED } = require('../utils/requiredDocuments');
 
 const caseSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   status: { type: String, default: 'open' },
   answers: { type: mongoose.Schema.Types.Mixed, default: {} },
   documents: { type: [mongoose.Schema.Types.Mixed], default: [] },
+  requiredDocuments: { type: [String], default: ALWAYS_REQUIRED },
   eligibility: { type: mongoose.Schema.Types.Mixed, default: null },
   normalized: { type: mongoose.Schema.Types.Mixed, default: {} },
   generatedForms: {

--- a/server/models/PipelineCase.js
+++ b/server/models/PipelineCase.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { ALWAYS_REQUIRED } = require('../utils/requiredDocuments');
 
 const documentSchema = new mongoose.Schema(
   {
@@ -45,6 +46,7 @@ const pipelineSchema = new mongoose.Schema(
       lastUpdated: Date,
     },
     documents: { type: [documentSchema], default: [] },
+    requiredDocuments: { type: [String], default: ALWAYS_REQUIRED },
     generatedForms: { type: [generatedFormSchema], default: [] },
     normalized: { type: mongoose.Schema.Types.Mixed, default: {} },
   },

--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { createCase, getCase } = require('../utils/pipelineStore');
+const { createCase, getCase, updateCase } = require('../utils/pipelineStore');
 const { getRequiredDocuments } = require('../utils/requiredDocuments');
 
 const router = express.Router();
@@ -34,6 +34,7 @@ async function caseStatusHandler(req, res) {
     generatedForms: c.generatedForms,
     incompleteForms: c.incompleteForms,
     documents: c.documents,
+    requiredDocuments: c.requiredDocuments,
     normalized: c.normalized,
   });
 }
@@ -62,6 +63,7 @@ router.post('/case/init', async (req, res) => {
     generatedForms: c.generatedForms,
     incompleteForms: c.incompleteForms,
     documents: c.documents,
+    requiredDocuments: c.requiredDocuments,
     normalized: c.normalized,
   });
 });
@@ -72,7 +74,11 @@ router.get('/case/required-documents', async (req, res) => {
   if (!caseId) return res.status(400).json({ error: 'caseId required' });
   const c = await getCase(userId, caseId);
   if (!c) return res.status(404).json({ error: 'Case not found' });
-  const requiredDocs = getRequiredDocuments(c);
+  let requiredDocs = c.requiredDocuments;
+  if (!requiredDocs || !requiredDocs.length) {
+    requiredDocs = getRequiredDocuments(c);
+    await updateCase(caseId, { requiredDocuments: requiredDocs });
+  }
   res.json({ required: requiredDocs });
 });
 

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -71,6 +71,7 @@ router.get('/eligibility-report', async (req, res) => {
     status: c.status,
     generatedForms: c.generatedForms,
     incompleteForms: c.incompleteForms,
+    requiredDocuments: c.requiredDocuments,
   });
 });
 
@@ -335,6 +336,7 @@ router.post('/eligibility-report', async (req, res) => {
     status: c.status,
     generatedForms: c.generatedForms,
     incompleteForms: c.incompleteForms,
+    requiredDocuments: c.requiredDocuments,
   });
 });
 

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -119,6 +119,7 @@ router.post('/files/upload', (req, res) => {
       documents,
       analyzer: { fields: mergedFields, lastUpdated: now },
       analyzerFields: mergedFields,
+      requiredDocuments: c.requiredDocuments,
     });
   });
 });

--- a/server/tests/case.required-documents.test.js
+++ b/server/tests/case.required-documents.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
 process.env.SKIP_DB = 'true';
 const app = require('../index');
-const { createCase, updateCase, resetStore } = require('../utils/pipelineStore');
+const { createCase, resetStore } = require('../utils/pipelineStore');
 
 describe('GET /api/case/required-documents', () => {
   beforeEach(() => {
@@ -10,15 +10,19 @@ describe('GET /api/case/required-documents', () => {
 
   test('returns required documents for case', async () => {
     const caseId = await createCase('dev-user');
-    await updateCase(caseId, {
-      questionnaire: { data: { employees: 5, ownerVeteran: true } },
-    });
+    await request(app)
+      .post('/api/questionnaire')
+      .send({ caseId, answers: { employees: 5, ownerVeteran: true } });
     const res = await request(app).get(
       `/api/case/required-documents?caseId=${caseId}`
     );
     expect(res.status).toBe(200);
     const docs = res.body.required;
     expect(docs).toContain('Tax Returns (last 2–3 years)');
+    expect(docs).toContain(
+      'Ownership / Officer List (≥20% shareholders / officers)'
+    );
+    expect(docs).toContain('Financial Statements (P&L + Balance Sheet)');
     expect(docs).toContain('Quarterly revenue statements (2020–2021)');
     expect(docs).toContain('DD214 (Proof of Veteran Status)');
   });

--- a/server/utils/pipelineStore.js
+++ b/server/utils/pipelineStore.js
@@ -1,4 +1,5 @@
 const PipelineCase = require('../models/PipelineCase');
+const { ALWAYS_REQUIRED } = require('./requiredDocuments');
 
 const useMemory = process.env.SKIP_DB === 'true';
 const memoryStore = new Map();
@@ -15,6 +16,7 @@ async function createCase(userId, caseId) {
       questionnaire: { data: {}, lastUpdated: null },
       eligibility: { results: [], requiredForms: [], lastUpdated: null },
       documents: [],
+      requiredDocuments: [...ALWAYS_REQUIRED],
       generatedForms: [],
       incompleteForms: [],
       normalized: {},

--- a/server/utils/requiredDocuments.js
+++ b/server/utils/requiredDocuments.js
@@ -3,7 +3,9 @@ const ALWAYS_REQUIRED = [
   "Payroll Records (Form 941 / W-2)",
   "Bank Statements (last 3–6 months)",
   "Business License / Incorporation Docs",
-  "Owner ID (Driver’s License / Passport)"
+  "Owner ID (Driver’s License / Passport)",
+  "Ownership / Officer List (≥20% shareholders / officers)",
+  "Financial Statements (P&L + Balance Sheet)",
 ];
 
 function hasEligibility(caseObj, name) {


### PR DESCRIPTION
## Summary
- expand default required documents list to include ownership roster and financial statements
- persist required documents on case records and surface via API
- expose required document data to frontend types and clients

## Testing
- `npm test` *(frontend)*
- `npm install` *(server, fails: 403 Forbidden fetching dependencies)*


------
https://chatgpt.com/codex/tasks/task_b_68af53b3fb308327a538f32762f995a0