### PR TITLE
feat: add smart questionnaire flow

### DIFF
--- a/frontend/src/app/dashboard/_steps/QuestionnaireStep.tsx
+++ b/frontend/src/app/dashboard/_steps/QuestionnaireStep.tsx
@@ -1,64 +1,181 @@
 'use client';
+
 import { useState } from 'react';
 import { postQuestionnaire } from '@/lib/apiClient';
 import type { CaseSnapshot } from '@/lib/types';
 
-const STATES = ['AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY'];
-const ENTITY_TYPES = ['LLC','C-Corp','S-Corp','Sole Proprietor','Nonprofit'];
-const GENDERS = ['Male','Female','Other'];
-const ETHNICITIES = ['Hispanic','African-American','Asian','Native American','White','Other'];
-const YES_NO = [
-  { value: 'yes', label: 'Yes' },
-  { value: 'no', label: 'No' }
+const STATES = [
+  'AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT',
+  'NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY'
 ];
-const YES_NO_UNSURE = [
-  { value: 'yes', label: 'Yes' },
-  { value: 'no', label: 'No' },
-  { value: 'unsure', label: 'Unsure' }
+const ENTITY_TYPES = [
+  'LLC',
+  'Corporation',
+  'Partnership',
+  'Nonprofit',
+  'Sole Proprietor',
+  'Other'
 ];
 
-export default function QuestionnaireStep({ caseId, onComplete, onBack }: { caseId: string; onComplete: (snap: CaseSnapshot) => void; onBack: () => void; }) {
-  const [form, setForm] = useState<Record<string, string>>({
-    business_name: '',
+interface Owner {
+  name: string;
+  role: string;
+  percent: string;
+  email: string;
+  phone: string;
+}
+
+interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  county: string;
+  congressionalDistrict: string;
+}
+
+interface Contact {
+  name: string;
+  title: string;
+  phone: string;
+  email: string;
+}
+
+const emptyAddress: Address = {
+  street: '',
+  city: '',
+  state: '',
+  zip: '',
+  county: '',
+  congressionalDistrict: '',
+};
+
+const emptyContact: Contact = { name: '', title: '', phone: '', email: '' };
+
+export default function QuestionnaireStep({
+  caseId,
+  onComplete,
+  onBack,
+}: {
+  caseId: string;
+  onComplete: (snap: CaseSnapshot) => void;
+  onBack: () => void;
+}) {
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    legalBusinessName: '',
+    dba: '',
+    entityType: '',
+    incorporationDate: '',
+    incorporationState: '',
+    physicalAddress: { ...emptyAddress },
+    mailingAddress: { ...emptyAddress },
+    primaryContact: { ...emptyContact },
+    authorizedRep: { ...emptyContact },
+    numEmployees: '',
+    projectTitle: '',
+    fundingRequest: '',
+    projectStart: '',
+    projectEnd: '',
+    hasEin: 'yes',
     ein: '',
-    year_established: '',
-    entity_type: '',
-    ownership_percentage: '',
-    owner_veteran: '',
-    owner_spouse_veteran: '',
-    owner_gender: '',
-    owner_ethnicity: '',
-    w2_employee_count: '',
-    w2_part_time_count: '',
-    payroll_total: '',
-    received_ppp: '',
-    annual_revenue: '',
-    revenue_decline: '',
-    revenue_drop_percent: '',
-    gov_shutdown: '',
-    address: '',
-    state: '',
-    rural_area: '',
-    opportunity_zone: '',
+    ssn: '',
+    complianceCertify: false,
+    eeoOfficer: { ...emptyContact },
   });
+  const [owners, setOwners] = useState<Owner[]>([
+    { name: '', role: '', percent: '', email: '', phone: '' },
+  ]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
   ) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value, type, checked } = e.target as HTMLInputElement;
+    setForm((f) => ({ ...f, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleAddressChange = (
+    which: 'physicalAddress' | 'mailingAddress',
+    field: keyof Address,
+    value: string,
+  ) => {
+    setForm((f) => ({
+      ...f,
+      [which]: { ...f[which], [field]: value },
+    }));
+  };
+
+  const handleContactChange = (
+    which: 'primaryContact' | 'authorizedRep' | 'eeoOfficer',
+    field: keyof Contact,
+    value: string,
+  ) => {
+    setForm((f) => ({
+      ...f,
+      [which]: { ...f[which], [field]: value },
+    }));
+  };
+
+  const handleOwnerChange = (idx: number, field: keyof Owner, value: string) => {
+    setOwners((prev) =>
+      prev.map((o, i) => (i === idx ? { ...o, [field]: value } : o)),
+    );
+  };
+
+  const addOwner = () => {
+    setOwners((o) => [...o, { name: '', role: '', percent: '', email: '', phone: '' }]);
+  };
+
+  const removeOwner = (idx: number) => {
+    setOwners((o) => o.filter((_, i) => i !== idx));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError(undefined);
+
+    if (!form.firstName || !form.lastName || !form.legalBusinessName || !form.entityType) {
+      setError('First name, last name, legal business name and entity type are required');
+      setLoading(false);
+      return;
+    }
+    if (form.hasEin === 'yes' && !/^\d{9}$/.test(form.ein)) {
+      setError('Valid EIN required');
+      setLoading(false);
+      return;
+    }
+    if (form.hasEin === 'no' && !/^\d{9}$/.test(form.ssn)) {
+      setError('Valid SSN required');
+      setLoading(false);
+      return;
+    }
+    if (!form.complianceCertify) {
+      setError('Compliance certification required');
+      setLoading(false);
+      return;
+    }
+    if (!owners.length || owners.some((o) => !o.name)) {
+      setError('At least one owner with name is required');
+      setLoading(false);
+      return;
+    }
+
     try {
-      const { revenue_decline, ...payload } = form;
-      if (revenue_decline !== 'yes') {
-        payload.revenue_drop_percent = '';
-      }
+      const payload = {
+        ...form,
+        numEmployees: form.numEmployees ? Number(form.numEmployees) : undefined,
+        fundingRequest: form.fundingRequest ? Number(form.fundingRequest) : undefined,
+        owners: owners.map((o) => ({
+          ...o,
+          percent: o.percent ? Number(o.percent) : undefined,
+        })),
+        ein: form.hasEin === 'yes' ? form.ein : undefined,
+        ssn: form.hasEin === 'no' ? form.ssn : undefined,
+      };
       const snap = await postQuestionnaire({ caseId, answers: payload });
       onComplete(snap);
     } catch (err: any) {
@@ -68,146 +185,408 @@ export default function QuestionnaireStep({ caseId, onComplete, onBack }: { case
     }
   };
 
-  const renderOptions = (opts: string[]) => opts.map(o => <option key={o} value={o}>{o}</option>);
+  const renderAddress = (which: 'physicalAddress' | 'mailingAddress', label: string) => (
+    <div className="border p-2 space-y-2">
+      <h4 className="font-semibold">{label}</h4>
+      <div>
+        <label htmlFor={`${which}-street`} className="block text-sm">Street</label>
+        <input
+          id={`${which}-street`}
+          value={form[which].street}
+          onChange={(e) => handleAddressChange(which, 'street', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor={`${which}-city`} className="block text-sm">City</label>
+        <input
+          id={`${which}-city`}
+          value={form[which].city}
+          onChange={(e) => handleAddressChange(which, 'city', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label htmlFor={`${which}-state`} className="block text-sm">State</label>
+          <select
+            id={`${which}-state`}
+            value={form[which].state}
+            onChange={(e) => handleAddressChange(which, 'state', e.target.value)}
+            className="border p-1 w-full"
+          >
+            <option value="" />
+            {STATES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={`${which}-zip`} className="block text-sm">ZIP</label>
+          <input
+            id={`${which}-zip`}
+            value={form[which].zip}
+            onChange={(e) => handleAddressChange(which, 'zip', e.target.value)}
+            className="border p-1 w-full"
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor={`${which}-county`} className="block text-sm">County</label>
+        <input
+          id={`${which}-county`}
+          value={form[which].county}
+          onChange={(e) => handleAddressChange(which, 'county', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor={`${which}-cd`} className="block text-sm">Congressional District</label>
+        <input
+          id={`${which}-cd`}
+          value={form[which].congressionalDistrict}
+          onChange={(e) => handleAddressChange(which, 'congressionalDistrict', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+    </div>
+  );
+
+  const renderContact = (which: 'primaryContact' | 'authorizedRep' | 'eeoOfficer', label: string) => (
+    <div className="border p-2 space-y-2">
+      <h4 className="font-semibold">{label}</h4>
+      <div>
+        <label htmlFor={`${which}-name`} className="block text-sm">Name</label>
+        <input
+          id={`${which}-name`}
+          value={form[which].name}
+          onChange={(e) => handleContactChange(which, 'name', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor={`${which}-title`} className="block text-sm">Title</label>
+        <input
+          id={`${which}-title`}
+          value={form[which].title}
+          onChange={(e) => handleContactChange(which, 'title', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor={`${which}-phone`} className="block text-sm">Phone</label>
+        <input
+          id={`${which}-phone`}
+          value={form[which].phone}
+          onChange={(e) => handleContactChange(which, 'phone', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor={`${which}-email`} className="block text-sm">Email</label>
+        <input
+          id={`${which}-email`}
+          type="email"
+          value={form[which].email}
+          onChange={(e) => handleContactChange(which, 'email', e.target.value)}
+          className="border p-1 w-full"
+        />
+      </div>
+    </div>
+  );
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <h2 className="text-2xl font-bold">Questionnaire</h2>
       {error && <div className="bg-red-100 text-red-800 p-2 rounded">{error}</div>}
 
-      <h3 className="text-xl font-semibold">Business Information</h3>
-      <div>
-        <label htmlFor="business_name" className="block text-sm">Business Name</label>
-        <input id="business_name" name="business_name" value={form.business_name} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="ein" className="block text-sm">EIN</label>
-        <input id="ein" name="ein" value={form.ein} onChange={handleChange} pattern="^\d{2}-?\d{7}$" className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="year_established" className="block text-sm">Year Established</label>
-        <input type="number" id="year_established" name="year_established" value={form.year_established} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="entity_type" className="block text-sm">Entity Type</label>
-        <select id="entity_type" name="entity_type" value={form.entity_type} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {ENTITY_TYPES.map(t => <option key={t} value={t.replace(/\s+/g,'_').toLowerCase()}>{t}</option>)}
-        </select>
-      </div>
-
-      <h3 className="text-xl font-semibold">Ownership</h3>
-      <div>
-        <label htmlFor="ownership_percentage" className="block text-sm">Ownership Percentage</label>
-        <input type="number" id="ownership_percentage" name="ownership_percentage" value={form.ownership_percentage} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="owner_veteran" className="block text-sm">Veteran Owner?</label>
-        <select id="owner_veteran" name="owner_veteran" value={form.owner_veteran} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
-      <div>
-        <label htmlFor="owner_spouse_veteran" className="block text-sm">Spouse of Veteran?</label>
-        <select id="owner_spouse_veteran" name="owner_spouse_veteran" value={form.owner_spouse_veteran} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
-      <div>
-        <label htmlFor="owner_gender" className="block text-sm">Gender</label>
-        <select id="owner_gender" name="owner_gender" value={form.owner_gender} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {renderOptions(GENDERS)}
-        </select>
-      </div>
-      <div>
-        <label htmlFor="owner_ethnicity" className="block text-sm">Ethnicity</label>
-        <select id="owner_ethnicity" name="owner_ethnicity" value={form.owner_ethnicity} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {renderOptions(ETHNICITIES)}
-        </select>
-      </div>
-
-      <h3 className="text-xl font-semibold">Employees & Payroll</h3>
-      <div>
-        <label htmlFor="w2_employee_count" className="block text-sm">Full-time Employees (W-2)</label>
-        <input type="number" id="w2_employee_count" name="w2_employee_count" value={form.w2_employee_count} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="w2_part_time_count" className="block text-sm">Part-time Employees (W-2)</label>
-        <input type="number" id="w2_part_time_count" name="w2_part_time_count" value={form.w2_part_time_count} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="payroll_total" className="block text-sm">Total Annual Payroll (USD)</label>
-        <input type="number" id="payroll_total" name="payroll_total" value={form.payroll_total} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="received_ppp" className="block text-sm">Received PPP Loan Before?</label>
-        <select id="received_ppp" name="received_ppp" value={form.received_ppp} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
-
-      <h3 className="text-xl font-semibold">Revenue & Financial Status</h3>
-      <div>
-        <label htmlFor="annual_revenue" className="block text-sm">Annual Revenue (USD)</label>
-        <input type="number" id="annual_revenue" name="annual_revenue" value={form.annual_revenue} onChange={handleChange} className="border p-1 w-full" />
-      </div>
-      <div>
-        <label htmlFor="revenue_decline" className="block text-sm">Revenue Decline vs. Previous Year?</label>
-        <select id="revenue_decline" name="revenue_decline" value={form.revenue_decline} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
-      {form.revenue_decline === 'yes' && (
+      <h3 className="text-xl font-semibold">Business Identity</h3>
+      <div className="grid grid-cols-2 gap-2">
         <div>
-          <label htmlFor="revenue_drop_percent" className="block text-sm">Decline Percentage</label>
-          <input type="number" id="revenue_drop_percent" name="revenue_drop_percent" value={form.revenue_drop_percent} onChange={handleChange} className="border p-1 w-full" />
+          <label htmlFor="firstName" className="block text-sm">First Name</label>
+          <input id="firstName" name="firstName" value={form.firstName} onChange={handleChange} className="border p-1 w-full" />
+        </div>
+        <div>
+          <label htmlFor="lastName" className="block text-sm">Last Name</label>
+          <input id="lastName" name="lastName" value={form.lastName} onChange={handleChange} className="border p-1 w-full" />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="legalBusinessName" className="block text-sm">Legal Business Name</label>
+        <input
+          id="legalBusinessName"
+          name="legalBusinessName"
+          value={form.legalBusinessName}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor="dba" className="block text-sm">DBA</label>
+        <input id="dba" name="dba" value={form.dba} onChange={handleChange} className="border p-1 w-full" />
+      </div>
+      <div>
+        <label htmlFor="entityType" className="block text-sm">Entity Type</label>
+        <select
+          id="entityType"
+          name="entityType"
+          value={form.entityType}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        >
+          <option value="" />
+          {ENTITY_TYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label htmlFor="incorporationDate" className="block text-sm">Date of Incorporation</label>
+          <input
+            type="date"
+            id="incorporationDate"
+            name="incorporationDate"
+            value={form.incorporationDate}
+            onChange={handleChange}
+            className="border p-1 w-full"
+          />
+        </div>
+        <div>
+          <label htmlFor="incorporationState" className="block text-sm">State of Incorporation</label>
+          <select
+            id="incorporationState"
+            name="incorporationState"
+            value={form.incorporationState}
+            onChange={handleChange}
+            className="border p-1 w-full"
+          >
+            <option value="" />
+            {STATES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {renderAddress('physicalAddress', 'Physical Address')}
+      {renderAddress('mailingAddress', 'Mailing Address')}
+
+      {renderContact('primaryContact', 'Primary Contact')}
+      {renderContact('authorizedRep', 'Authorized Representative')}
+
+      <div>
+        <label htmlFor="numEmployees" className="block text-sm">Number of Employees</label>
+        <input
+          type="number"
+          id="numEmployees"
+          name="numEmployees"
+          value={form.numEmployees}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor="projectTitle" className="block text-sm">Project Title/Short Description</label>
+        <textarea
+          id="projectTitle"
+          name="projectTitle"
+          value={form.projectTitle}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div>
+        <label htmlFor="fundingRequest" className="block text-sm">Funding Request Amount (USD)</label>
+        <input
+          type="number"
+          id="fundingRequest"
+          name="fundingRequest"
+          value={form.fundingRequest}
+          onChange={handleChange}
+          className="border p-1 w-full"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label htmlFor="projectStart" className="block text-sm">Project Start Date</label>
+          <input
+            type="date"
+            id="projectStart"
+            name="projectStart"
+            value={form.projectStart}
+            onChange={handleChange}
+            className="border p-1 w-full"
+          />
+        </div>
+        <div>
+          <label htmlFor="projectEnd" className="block text-sm">Project End Date</label>
+          <input
+            type="date"
+            id="projectEnd"
+            name="projectEnd"
+            value={form.projectEnd}
+            onChange={handleChange}
+            className="border p-1 w-full"
+          />
+        </div>
+      </div>
+
+      <h3 className="text-xl font-semibold">Tax Information</h3>
+      <div>
+        <span className="block text-sm">Do you have an EIN?</span>
+        <label className="mr-4">
+          <input
+            type="radio"
+            name="hasEin"
+            value="yes"
+            checked={form.hasEin === 'yes'}
+            onChange={handleChange}
+          />{' '}
+          Yes
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="hasEin"
+            value="no"
+            checked={form.hasEin === 'no'}
+            onChange={handleChange}
+          />{' '}
+          No
+        </label>
+      </div>
+      {form.hasEin === 'yes' ? (
+        <div>
+          <label htmlFor="ein" className="block text-sm">EIN</label>
+          <input
+            id="ein"
+            name="ein"
+            value={form.ein}
+            onChange={handleChange}
+            pattern="^\d{9}$"
+            className="border p-1 w-full"
+          />
+        </div>
+      ) : (
+        <div>
+          <label htmlFor="ssn" className="block text-sm">SSN</label>
+          <input
+            id="ssn"
+            name="ssn"
+            type="password"
+            value={form.ssn}
+            onChange={handleChange}
+            pattern="^\d{9}$"
+            className="border p-1 w-full"
+          />
         </div>
       )}
-      <div>
-        <label htmlFor="gov_shutdown" className="block text-sm">Temporary Shutdown due to Government Order?</label>
-        <select id="gov_shutdown" name="gov_shutdown" value={form.gov_shutdown} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
 
-      <h3 className="text-xl font-semibold">Location & Community</h3>
+      <h3 className="text-xl font-semibold">Owners / Officers</h3>
+      {owners.map((o, idx) => (
+        <div key={idx} className="border p-2 mb-2 space-y-2">
+          <div className="flex justify-between items-center">
+            <h4 className="font-semibold">Owner #{idx + 1}</h4>
+            {owners.length > 1 && (
+              <button type="button" onClick={() => removeOwner(idx)} className="text-red-600 text-sm">
+                Remove
+              </button>
+            )}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-sm" htmlFor={`owner-name-${idx}`}>Full Name</label>
+              <input
+                id={`owner-name-${idx}`}
+                value={o.name}
+                onChange={(e) => handleOwnerChange(idx, 'name', e.target.value)}
+                className="border p-1 w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor={`owner-role-${idx}`}>Title/Role</label>
+              <input
+                id={`owner-role-${idx}`}
+                value={o.role}
+                onChange={(e) => handleOwnerChange(idx, 'role', e.target.value)}
+                className="border p-1 w-full"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div>
+              <label className="block text-sm" htmlFor={`owner-percent-${idx}`}>% Ownership</label>
+              <input
+                type="number"
+                id={`owner-percent-${idx}`}
+                value={o.percent}
+                onChange={(e) => handleOwnerChange(idx, 'percent', e.target.value)}
+                className="border p-1 w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor={`owner-email-${idx}`}>Email</label>
+              <input
+                id={`owner-email-${idx}`}
+                type="email"
+                value={o.email}
+                onChange={(e) => handleOwnerChange(idx, 'email', e.target.value)}
+                className="border p-1 w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm" htmlFor={`owner-phone-${idx}`}>Phone</label>
+              <input
+                id={`owner-phone-${idx}`}
+                value={o.phone}
+                onChange={(e) => handleOwnerChange(idx, 'phone', e.target.value)}
+                className="border p-1 w-full"
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addOwner}
+        className="px-2 py-1 bg-gray-200 rounded"
+      >
+        Add Owner/Officer
+      </button>
+
+      <h3 className="text-xl font-semibold">Compliance</h3>
       <div>
-        <label htmlFor="address" className="block text-sm">Business Address</label>
-        <input id="address" name="address" value={form.address} onChange={handleChange} className="border p-1 w-full" />
+        <label className="inline-flex items-center">
+          <input
+            type="checkbox"
+            name="complianceCertify"
+            checked={form.complianceCertify}
+            onChange={handleChange}
+            className="mr-2"
+          />
+          I certify this business complies with Equal Opportunity and Nondiscrimination requirements.
+        </label>
       </div>
-      <div>
-        <label htmlFor="state" className="block text-sm">State</label>
-        <select id="state" name="state" value={form.state} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {renderOptions(STATES)}
-        </select>
-      </div>
-      <div>
-        <label htmlFor="rural_area" className="block text-sm">Rural Area?</label>
-        <select id="rural_area" name="rural_area" value={form.rural_area} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO_UNSURE.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
-      <div>
-        <label htmlFor="opportunity_zone" className="block text-sm">In Opportunity Zone?</label>
-        <select id="opportunity_zone" name="opportunity_zone" value={form.opportunity_zone} onChange={handleChange} className="border p-1 w-full">
-          <option value="" />
-          {YES_NO_UNSURE.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-        </select>
-      </div>
+      {form.complianceCertify && renderContact('eeoOfficer', 'EEO Officer (optional)')}
 
       <div className="flex justify-between">
-        <button type="button" onClick={onBack} className="px-3 py-2 rounded bg-gray-200">Back</button>
-        <button type="submit" disabled={loading} className="px-3 py-2 rounded bg-blue-600 text-white disabled:opacity-50">{loading ? 'Saving...' : 'Next'}</button>
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-3 py-2 rounded bg-gray-200"
+        >
+          Back
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-3 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+        >
+          {loading ? 'Saving...' : 'Next'}
+        </button>
       </div>
     </form>
   );
 }
+

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -34,6 +34,14 @@ describe('Dashboard wizard', () => {
 
     expect(await screen.findByRole('heading', { name: 'Questionnaire' })).toBeInTheDocument();
 
+    fireEvent.change(screen.getByLabelText('First Name'), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText('Last Name'), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText('Legal Business Name'), { target: { value: 'Biz LLC' } });
+    fireEvent.change(screen.getByLabelText('Entity Type'), { target: { value: 'LLC' } });
+    fireEvent.change(screen.getByLabelText('EIN'), { target: { value: '123456789' } });
+    fireEvent.change(screen.getByLabelText('Full Name'), { target: { value: 'Owner One' } });
+    fireEvent.click(screen.getByLabelText(/I certify this business/));
+
     fireEvent.click(screen.getByText('Next'));
     await waitFor(() => expect(api.postQuestionnaire).toHaveBeenCalled());
 


### PR DESCRIPTION
## Summary
- replace questionnaire step with smart form collecting business identity, contacts, tax info and ownership
- add conditional EIN/SSN logic with dynamic owner/officer list and compliance section
- update dashboard test to exercise new required fields

## Testing
- `npm test --prefix frontend`
- `npm test --prefix server` *(fails: jest not found)*
- `npm install --prefix server` *(fails: 403 forbidden for @bcoe/v8-coverage)*

------
https://chatgpt.com/codex/tasks/task_b_68af57e68a7883278b9af295618da995