### PR TITLE
feat: relax questionnaire requirements for test mode

### DIFF
--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -41,34 +41,10 @@ export function normalizeQuestionnaire(input: any = {}) {
     }
   });
 
-  const required = [
-    'businessName',
-    'phone',
-    'email',
-    'address',
-    'city',
-    'state',
-    'zip',
-    'locationZone',
-    'businessType',
-    'incorporationDate',
-    'annualRevenue',
-    'netProfit',
-    'numberOfEmployees',
-    'ownershipPercentage',
-    'businessIncome',
-    'businessExpenses',
-    'taxPaid',
-    'taxYear',
-    'previousRefundsClaimed',
-    'previousGrants',
-  ];
-
-  const missing = required.filter((f) => data[f] === undefined || data[f] === '' || data[f] === null || Number.isNaN(data[f]));
-
+  const missing: string[] = [];
   if (data.businessType === 'Sole') {
     if (!data.ssn) missing.push('ssn');
-  } else {
+  } else if (data.businessType) {
     if (!data.ein) missing.push('ein');
   }
 

--- a/frontend/tests/dashboard.test.tsx
+++ b/frontend/tests/dashboard.test.tsx
@@ -34,14 +34,6 @@ describe('Dashboard wizard', () => {
 
     expect(await screen.findByRole('heading', { name: 'Questionnaire' })).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('First Name'), { target: { value: 'John' } });
-    fireEvent.change(screen.getByLabelText('Last Name'), { target: { value: 'Doe' } });
-    fireEvent.change(screen.getByLabelText('Legal Business Name'), { target: { value: 'Biz LLC' } });
-    fireEvent.change(screen.getByLabelText('Entity Type'), { target: { value: 'LLC' } });
-    fireEvent.change(screen.getByLabelText('EIN'), { target: { value: '123456789' } });
-    fireEvent.change(screen.getByLabelText('Full Name'), { target: { value: 'Owner One' } });
-    fireEvent.click(screen.getByLabelText(/I certify this business/));
-
     fireEvent.click(screen.getByText('Next'));
     await waitFor(() => expect(api.postQuestionnaire).toHaveBeenCalled());
 

--- a/server/tests/questionnaire.test.js
+++ b/server/tests/questionnaire.test.js
@@ -10,6 +10,16 @@ describe('questionnaire endpoints', () => {
     resetStore();
   });
 
+  test('POST accepts empty answers', async () => {
+    const caseId = await createCase('dev-user');
+    const res = await request(app)
+      .post('/api/questionnaire')
+      .send({ caseId, answers: {} });
+    expect(res.status).toBe(200);
+    const c = await getCase('dev-user', caseId);
+    expect(c.questionnaire.data).toEqual({});
+  });
+
   test('POST saves questionnaire and overrides existing analyzer fields', async () => {
     const caseId = await createCase('dev-user');
     await updateCase(caseId, { analyzer: { fields: { existing: 'keep', empty: '' } } });


### PR DESCRIPTION
## Summary
- collect owner name once and reuse via `authorizedRepSameAsOwner`
- allow empty questionnaire submission and remove required client-side checks
- loosen questionnaire normalization to hint only on EIN/SSN
- add tests for empty questionnaire submissions

## Testing
- `npm test` (frontend)
- `npm test` (server) *(fails: jest: not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_b_68af686fc5b4832786c800f2920ac932