### PR TITLE
Allow empty questionnaire submissions in test mode

### DIFF
--- a/frontend/src/app/dashboard/_steps/QuestionnaireStep.tsx
+++ b/frontend/src/app/dashboard/_steps/QuestionnaireStep.tsx
@@ -265,7 +265,6 @@ export default function QuestionnaireStep({
         <label htmlFor="eeoOfficer-email" className="block text-sm">Email</label>
         <input
           id="eeoOfficer-email"
-          type="email"
           value={form.eeoOfficer.email}
           onChange={(e) => handleEeoOfficerChange('email', e.target.value)}
           className="border p-1 w-full"
@@ -275,7 +274,7 @@ export default function QuestionnaireStep({
   );
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
       <h2 className="text-2xl font-bold">Questionnaire</h2>
 
       <h3 className="text-xl font-semibold">Business Identity</h3>
@@ -507,7 +506,6 @@ export default function QuestionnaireStep({
             name="ein"
             value={form.ein}
             onChange={handleChange}
-            pattern="^\d{9}$"
             className="border p-1 w-full"
           />
         </div>
@@ -520,7 +518,6 @@ export default function QuestionnaireStep({
             type="password"
             value={form.ssn}
             onChange={handleChange}
-            pattern="^\d{9}$"
             className="border p-1 w-full"
           />
         </div>
@@ -572,7 +569,6 @@ export default function QuestionnaireStep({
               <label className="block text-sm" htmlFor={`owner-email-${idx}`}>Email</label>
               <input
                 id={`owner-email-${idx}`}
-                type="email"
                 value={o.email}
                 onChange={(e) => handleOwnerChange(idx, 'email', e.target.value)}
                 className="border p-1 w-full"

--- a/server/routes/questionnaire.js
+++ b/server/routes/questionnaire.js
@@ -37,10 +37,9 @@ router.get(['/questionnaire', '/case/questionnaire'], async (req, res) => {
 router.post(['/questionnaire', '/case/questionnaire'], async (req, res) => {
   const userId = 'dev-user';
   let { caseId, answers, data } = req.body || {};
-  const payload = answers || data;
-  if (!payload || typeof payload !== 'object') {
-    return res.status(400).json({ message: 'data required' });
-  }
+  let payload = {};
+  if (answers && typeof answers === 'object') payload = answers;
+  else if (data && typeof data === 'object') payload = data;
   let c;
   if (caseId) {
     c = await getCase(userId, caseId);


### PR DESCRIPTION
## Summary
- Allow submitting questionnaire forms without native HTML validation.
- Backend questionnaire route defaults to empty answers instead of requiring payload.

## Testing
- `npm test --prefix frontend`
- `npm test --prefix server` *(fails: jest not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_b_68af6b2377cc83279e6f3cbbf8204d70