### PR TITLE
Add questionnaire answer mappers for form templates

### DIFF
--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -14,7 +14,42 @@ const { saveDraft } = require('../utils/drafts');
 const { renderPdf } = require('../utils/pdfRenderer');
 const { validateForm8974Calcs } = require('../utils/form8974');
 const { validateForm6765Calcs } = require('../utils/form6765');
-const { normalizeAnswers } = require('../utils/normalizeAnswers');
+const {
+  normalizeAnswers,
+  toMMDDYYYY,
+  toNumber,
+  currency,
+} = require('../utils/normalizeAnswers');
+const {
+  mapSF424,
+  mapSF424A,
+  mapRD400_1,
+  mapRD400_4,
+  mapRD400_8,
+  map8974,
+  map6765,
+} = require('../utils/formMappers');
+
+function mapForForm(formId, answers, { testMode = false } = {}) {
+  switch (formId) {
+    case 'form_sf424':
+      return { ...answers, ...mapSF424(answers, { testMode }) };
+    case 'form_sf424a':
+      return { ...answers, ...mapSF424A(answers) };
+    case 'form_rd400_1':
+      return { ...answers, ...mapRD400_1(answers) };
+    case 'form_rd400_4':
+      return { ...answers, ...mapRD400_4(answers) };
+    case 'form_rd400_8':
+      return { ...answers, ...mapRD400_8(answers) };
+    case 'form_8974':
+      return { ...answers, ...map8974(answers) };
+    case 'form_6765':
+      return { ...answers, ...map6765(answers) };
+    default:
+      return answers;
+  }
+}
 
 const router = express.Router();
 
@@ -128,10 +163,16 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
           .status(502)
           .json({ message: `AI agent form-fill error ${agentResp.status}`, details: text });
       }
-      const agentData = await agentResp.json();
-      const tmpl = await getLatestTemplate(formName);
-      const version = tmpl ? tmpl.version : 1;
-      const formData = agentData.filled_form || agentData;
+        const agentData = await agentResp.json();
+        const tmpl = await getLatestTemplate(formName);
+        const version = tmpl ? tmpl.version : 1;
+        const mappedAnswers = mapForForm(formName, normalized, {
+          testMode: process.env.PROCESS_TEST_MODE === 'true',
+        });
+        const formData = {
+          ...mappedAnswers,
+          ...(agentData.filled_form || agentData),
+        };
       const required = pdfTemplates[formName]?.required || [];
       const missingRequired = required.filter(
         (k) =>

--- a/server/tests/formMappers.test.js
+++ b/server/tests/formMappers.test.js
@@ -1,0 +1,117 @@
+const {
+  mapSF424,
+  mapSF424A,
+  mapRD400_1,
+  mapRD400_4,
+  mapRD400_8,
+  map8974,
+  map6765,
+} = require('../utils/formMappers');
+const { toMMDDYYYY } = require('../utils/normalizeAnswers');
+
+describe('form mappers', () => {
+  test('mapSF424 maps core fields and authorized rep from owner when same', () => {
+    const out = mapSF424(
+      {
+        legalBusinessName: 'ACME Corp',
+        ein: '12-3456789',
+        projectTitle: 'Project X',
+        projectStart: '2024-01-01',
+        projectEnd: '2024-02-01',
+        fundingRequest: '$1,234',
+        authorizedRepSameAsOwner: true,
+        ownerFirstName: 'Jane',
+        ownerLastName: 'Doe',
+        ownerTitle: 'CEO',
+        physicalAddress: { street: '1 Main', city: 'Town', state: 'CA', zip: '12345' },
+      },
+      { testMode: true }
+    );
+    expect(out).toMatchObject({
+      applicant_legal_name: 'ACME Corp',
+      applicant_name: 'ACME Corp',
+      ein: '12-3456789',
+      descriptive_title: 'Project X',
+      project_start_date: toMMDDYYYY('2024-01-01'),
+      project_end_date: toMMDDYYYY('2024-02-01'),
+      funding_total: 1234,
+      authorized_rep_name: 'Jane Doe',
+      authorized_rep_title: 'CEO',
+      address_city: 'Town',
+    });
+    expect(out.authorized_rep_date_signed).toBeDefined();
+  });
+
+  test('mapSF424A currency fields', () => {
+    const out = mapSF424A({ budgetPersonnel: '100', budgetFringe: '$200' });
+    expect(out).toMatchObject({
+      object_class_personnel: 100,
+      object_class_fringe: 200,
+    });
+  });
+
+  test('mapRD400_1 basic fields', () => {
+    const out = mapRD400_1({
+      legalBusinessName: 'Biz',
+      ein: '99',
+      physicalAddress: { street: 's', city: 'c', state: 'st', zip: 'z' },
+      eeoOfficer: { name: 'A', email: 'a@b.com', phone: '1' },
+      complianceCertify: 'yes',
+    });
+    expect(out).toMatchObject({
+      applicant_legal_name: 'Biz',
+      eeo_officer_email: 'a@b.com',
+      certify_equal_opportunity: true,
+    });
+  });
+
+  test('mapRD400_8 number conversions', () => {
+    const out = mapRD400_8({
+      legalBusinessName: 'Biz',
+      reportingStart: '2024-01-01',
+      reportingEnd: '2024-02-01',
+      workforceMale: '1',
+      workforceFemale: '2',
+    });
+    expect(out).toMatchObject({
+      org_name: 'Biz',
+      workforce_male: 1,
+      workforce_female: 2,
+    });
+  });
+
+  test('map8974 numeric fields', () => {
+    const out = map8974({
+      ein: '1',
+      taxYear: '2023',
+      taxQuarter: 1,
+      socialSecurityWages: '10',
+      medicareWages: '20',
+      federalTaxDeposits: '30',
+      rAndDWagesAllocated: '40',
+    });
+    expect(out).toMatchObject({
+      tax_year: '2023',
+      ss_wages: 10,
+      federal_tax_deposits: 30,
+    });
+  });
+
+  test('map6765 maps array receipts', () => {
+    const out = map6765({
+      ein: '1',
+      taxYear: '2023',
+      qreWages: '10',
+      grossReceiptsPrev4Years: ['1', '2', '3', '4'],
+      fixedBasePercentage: '0.5',
+      electPayrollOffset: 'true',
+    });
+    expect(out).toMatchObject({
+      qre_wages: 10,
+      gross_receipts_y1: 1,
+      gross_receipts_y4: 4,
+      fixed_base_pct: 0.5,
+      elect_payroll_offset: true,
+    });
+  });
+});

--- a/server/tests/integration.sf424.test.js
+++ b/server/tests/integration.sf424.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const nock = require('nock');
+
+process.env.SKIP_DB = 'true';
+process.env.ELIGIBILITY_ENGINE_URL = 'http://engine.test';
+process.env.AI_AGENT_URL = 'http://agent.test';
+process.env.PROCESS_TEST_MODE = 'true';
+
+jest.mock('../utils/pdfRenderer', () => ({
+  renderPdf: jest.fn(() => Buffer.from('%PDF-1.4\n%%EOF')),
+}));
+
+const app = require('../index');
+const { renderPdf } = require('../utils/pdfRenderer');
+
+describe('eligibility report integration', () => {
+  afterEach(() => {
+    nock.cleanAll();
+    renderPdf.mockClear();
+  });
+
+  test('SF-424 mapping applied before rendering', async () => {
+    nock('http://engine.test')
+      .post('/check')
+      .reply(200, { results: [{ requiredForms: ['SF-424'] }] });
+    nock('http://agent.test').post('/form-fill').reply(200, {});
+
+    const payload = {
+      legalBusinessName: 'ACME',
+      ein: '11',
+      projectTitle: 'Proj',
+      projectStart: '2024-01-01',
+      projectEnd: '2024-02-01',
+      fundingRequest: '1000',
+      authorizedRepSameAsOwner: true,
+      ownerFirstName: 'Jane',
+      ownerLastName: 'Doe',
+      ownerTitle: 'CEO',
+      physicalAddress: { street: '1 Main', city: 'Town', state: 'CA', zip: '12345' },
+    };
+
+    await request(app)
+      .post('/api/eligibility-report')
+      .send({ payload })
+      .expect(200);
+
+    expect(renderPdf).toHaveBeenCalled();
+    const arg = renderPdf.mock.calls[0][0];
+    expect(arg.filledForm.applicant_legal_name).toBe('ACME');
+    expect(arg.filledForm.authorized_rep_name).toBe('Jane Doe');
+  });
+});

--- a/server/utils/formMappers.js
+++ b/server/utils/formMappers.js
@@ -1,0 +1,131 @@
+const { toMMDDYYYY, toNumber, bool, fullName, currency } = require('./normalizeAnswers');
+
+function mapSF424(a, { testMode = false } = {}) {
+  const applicant_legal_name = a.legalBusinessName || a.applicant_name;
+  const authorized_rep_name = a.authorizedRepSameAsOwner
+    ? fullName(a.ownerFirstName, a.ownerLastName)
+    : fullName(a.authorizedRepFirstName, a.authorizedRepLastName);
+  const authorized_rep_title = a.authorizedRepSameAsOwner
+    ? a.ownerTitle
+    : a.authorizedRepTitle;
+
+  return {
+    applicant_legal_name,
+    applicant_name: applicant_legal_name,
+    ein: a.ein,
+    descriptive_title: a.projectTitle,
+    project_start_date: toMMDDYYYY(a.projectStart),
+    project_end_date: toMMDDYYYY(a.projectEnd),
+    funding_total: currency(a.fundingRequest),
+    authorized_rep_name,
+    authorized_rep_title,
+    authorized_rep_date_signed: testMode
+      ? toMMDDYYYY(new Date())
+      : undefined,
+    address_line1: a.physicalAddress?.street,
+    address_city: a.physicalAddress?.city,
+    address_state: a.physicalAddress?.state,
+    address_zip: a.physicalAddress?.zip,
+  };
+}
+
+function mapSF424A(a) {
+  return {
+    object_class_personnel: currency(a.budgetPersonnel),
+    object_class_fringe: currency(a.budgetFringe),
+    object_class_travel: currency(a.budgetTravel),
+    object_class_equipment: currency(a.budgetEquipment),
+    object_class_supplies: currency(a.budgetSupplies),
+    object_class_contractual: currency(a.budgetContractual),
+    object_class_construction: currency(a.budgetConstruction),
+    object_class_other: currency(a.budgetOther),
+    object_class_indirect: currency(a.budgetIndirect),
+    non_federal_share: currency(a.nonFederalShare),
+    program_income: currency(a.programIncome),
+    cash_needs_q1: currency(a.cashNeedsQ1),
+    cash_needs_q2: currency(a.cashNeedsQ2),
+    cash_needs_q3: currency(a.cashNeedsQ3),
+    cash_needs_q4: currency(a.cashNeedsQ4),
+  };
+}
+
+function mapRD400Common(a) {
+  return {
+    applicant_legal_name: a.legalBusinessName,
+    ein: a.ein,
+    addr_line1: a.physicalAddress?.street,
+    addr_city: a.physicalAddress?.city,
+    addr_state: a.physicalAddress?.state,
+    addr_zip: a.physicalAddress?.zip,
+    eeo_officer_name: a.eeoOfficer?.name,
+    eeo_officer_email: a.eeoOfficer?.email,
+    eeo_officer_phone: a.eeoOfficer?.phone,
+    certify_equal_opportunity: bool(a.complianceCertify),
+  };
+}
+function mapRD400_1(a) {
+  return mapRD400Common(a);
+}
+function mapRD400_4(a) {
+  return mapRD400Common(a);
+}
+
+function mapRD400_8(a) {
+  return {
+    org_name: a.legalBusinessName,
+    reporting_period_start: toMMDDYYYY(a.reportingStart),
+    reporting_period_end: toMMDDYYYY(a.reportingEnd),
+    workforce_male: toNumber(a.workforceMale),
+    workforce_female: toNumber(a.workforceFemale),
+    workforce_nonbinary: toNumber(a.workforceNonbinary),
+    workforce_hispanic: toNumber(a.workforceHispanic),
+    workforce_black: toNumber(a.workforceBlack),
+    workforce_asian: toNumber(a.workforceAsian),
+    workforce_white: toNumber(a.workforceWhite),
+    board_male: toNumber(a.boardMale),
+    board_female: toNumber(a.boardFemale),
+    board_nonbinary: toNumber(a.boardNonbinary),
+  };
+}
+
+function map8974(a) {
+  return {
+    ein: a.ein,
+    tax_year: a.taxYear,
+    tax_quarter: a.taxQuarter,
+    ss_wages: currency(a.socialSecurityWages),
+    medicare_wages: currency(a.medicareWages),
+    federal_tax_deposits: currency(a.federalTaxDeposits),
+    rd_wages_allocated: currency(a.rAndDWagesAllocated),
+  };
+}
+
+function map6765(a) {
+  return {
+    ein: a.ein,
+    tax_year: a.taxYear,
+    qre_wages: currency(a.qreWages),
+    qre_supplies: currency(a.qreSupplies),
+    qre_contract_research: currency(a.qreContractResearch),
+    qre_basic_research: currency(a.qreBasicResearch),
+    computer_rental_costs: currency(a.computerRentalCosts),
+    gross_receipts_y1: currency(a.grossReceiptsPrev4Years?.[0]),
+    gross_receipts_y2: currency(a.grossReceiptsPrev4Years?.[1]),
+    gross_receipts_y3: currency(a.grossReceiptsPrev4Years?.[2]),
+    gross_receipts_y4: currency(a.grossReceiptsPrev4Years?.[3]),
+    fixed_base_pct: toNumber(a.fixedBasePercentage),
+    base_amount: currency(a.baseAmount),
+    elect_payroll_offset: bool(a.electPayrollOffset),
+    carryforward_amount: currency(a.carryforwardAmount),
+  };
+}
+
+module.exports = {
+  mapSF424,
+  mapSF424A,
+  mapRD400_1,
+  mapRD400_4,
+  mapRD400_8,
+  map8974,
+  map6765,
+};

--- a/server/utils/normalizeAnswers.js
+++ b/server/utils/normalizeAnswers.js
@@ -1,8 +1,37 @@
+const toMMDDYYYY = (d) =>
+  d
+    ? new Date(d).toLocaleDateString('en-US', { timeZone: 'UTC' })
+    : undefined;
+
+const toNumber = (v) =>
+  v === '' || v == null ? undefined : Number(String(v).replace(/[^0-9.-]/g, ''));
+
+const bool = (v) => v === true || v === 'true' || v === 'yes' || v === 'on';
+
+function fullName(first, last) {
+  return [first, last].filter(Boolean).join(' ').trim() || undefined;
+}
+
+function currency(v) {
+  return toNumber(v);
+} // alias for clarity
+
 function normalizeAnswers(answers = {}) {
   const out = { ...answers };
-  if (!out.applicant_name && out.legal_business_name) {
-    out.applicant_name = out.legal_business_name;
+  if (
+    !out.applicant_name &&
+    (out.legal_business_name || out.legalBusinessName)
+  ) {
+    out.applicant_name = out.legal_business_name || out.legalBusinessName;
   }
   return out;
 }
-module.exports = { normalizeAnswers };
+
+module.exports = {
+  toMMDDYYYY,
+  toNumber,
+  bool,
+  fullName,
+  currency,
+  normalizeAnswers,
+};


### PR DESCRIPTION
## Summary
- add normalization utilities for dates, numbers, and names
- map questionnaire fields to specific form template keys
- integrate mapping layer into eligibility and pipeline routes with tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af87def5848327b7a59b38ed723aea