### PR TITLE
Map and log form payload before agent

### DIFF
--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -99,8 +99,8 @@ router.post('/files/upload', (req, res) => {
     });
     if (updatedKeys.length) {
       const logFn = logger.debug ? logger.debug.bind(logger) : logger.info.bind(logger);
-      logFn('merge: analyzer overrides existing fields', {
-        overriddenKeys: updatedKeys,
+      logFn('safeMerge updatedKeys', {
+        updatedKeys,
         requestId: req.headers['x-request-id'],
       });
     }

--- a/server/routes/questionnaire.js
+++ b/server/routes/questionnaire.js
@@ -79,8 +79,8 @@ router.post(['/questionnaire', '/case/questionnaire'], async (req, res) => {
   const { merged, updatedKeys } = safeMerge(existingFields, normalizedPayload, {
     source: 'questionnaire',
   });
-  logger.info('merge: questionnaire overrides existing fields', {
-    overriddenKeys: updatedKeys,
+  logger.info('safeMerge updatedKeys', {
+    updatedKeys,
     requestId: req.headers['x-request-id'],
   });
   const normalizedMerged = normalizeAnswers(merged);


### PR DESCRIPTION
## Summary
- map questionnaire answers to snake_case before calling form-fill agent
- log payload preview keys to verify mapping
- streamline safeMerge logs to show updatedKeys

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@bcoe%2fv8-coverage)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af8c9dec488327b13b163d35311116