### PR TITLE
fix: align eligibility engine endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The backend exposes a unified flow that processes grant applications end‑to‑
 
 1. **POST `/api/files/upload`** – Upload a document. The server forwards the file to the AI Analyzer (`AI_ANALYZER_URL/analyze`) to extract and normalize fields.
 2. **POST `/api/questionnaire`** – Persist user supplied answers and merge them with analyzer fields.
-3. **POST `/api/eligibility-report`** – Run the Eligibility Engine (`ELIGIBILITY_ENGINE_URL/check`) to compute program eligibility and required forms.
+3. **POST `/api/eligibility-report`** – Run the Eligibility Engine (`ELIGIBILITY_ENGINE_URL`) to compute program eligibility and required forms.
 4. **Digital signature & submission** – Hooks exist after form filling for optional signing and external submission.
 5. **GET `/api/status/:caseId`** – Fetch case status, analyzer fields, eligibility results and generated documents for the applicant dashboard.
 

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -127,8 +127,14 @@ router.post('/eligibility-report', async (req, res) => {
   }
   base = normalizeAnswers(base);
 
-  const engineBase = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
-  const engineUrl = `${engineBase.replace(/\/$/, '')}/check`;
+  const engineBase =
+    process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
+  const engineUrl = engineBase.replace(/\/$/, '');
+  logger.info('eligibility_engine_request', {
+    url: engineUrl,
+    payload: base,
+    requestId: req.id,
+  });
   let resp;
   try {
     resp = await fetchFn(engineUrl, {

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -122,11 +122,20 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
     const normalized = normalizeAnswers({ ...extracted, ...basePayload });
     await updateCase(caseId, { status: 'analyzed', normalized, analyzer: extracted });
 
-    const engineBase = process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
-    const engineUrl = `${engineBase.replace(/\/$/, '')}/check`;
+    const engineBase =
+      process.env.ELIGIBILITY_ENGINE_URL || 'http://localhost:4001';
+    const engineUrl = engineBase.replace(/\/$/, '');
+    logger.info('eligibility_engine_request', {
+      url: engineUrl,
+      payload: normalized,
+      requestId: req.id,
+    });
     const eligResp = await fetchFn(engineUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...getServiceHeaders('ELIGIBILITY_ENGINE', req) },
+      headers: {
+        'Content-Type': 'application/json',
+        ...getServiceHeaders('ELIGIBILITY_ENGINE', req),
+      },
       body: JSON.stringify(normalized),
     });
     if (!eligResp.ok) {

--- a/server/tests/README.md
+++ b/server/tests/README.md
@@ -1,0 +1,5 @@
+# Server Test Notes
+
+Integration tests hit the live services. The Eligibility Engine listens on the root path (`/`).
+Older instructions referenced a `/check` route, but the engine now responds directly on `/`.
+Ensure `ELIGIBILITY_ENGINE_URL` points to the base URL and the server POSTs to that root rather than appending `/check`.

--- a/server/utils/caseStore.js
+++ b/server/utils/caseStore.js
@@ -111,8 +111,14 @@ async function computeDocuments(answers = {}) {
 
   try {
     const config = loadGrantConfig();
-    const baseUrl = process.env.ELIGIBILITY_ENGINE_URL || 'https://localhost:4001';
-    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/check`, {
+    const baseUrl =
+      process.env.ELIGIBILITY_ENGINE_URL || 'https://localhost:4001';
+    const engineUrl = baseUrl.replace(/\/$/, '');
+    logger.info('eligibility_engine_request', {
+      url: engineUrl,
+      payload: answers,
+    });
+    const response = await fetch(engineUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(answers),


### PR DESCRIPTION
## Summary
- post eligibility requests to engine root endpoint instead of `/check`
- log payloads sent to the eligibility engine
- document expected eligibility engine endpoint for tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@bcoe%2fv8-coverage)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b069c90630832795fc5d1ed3fcf121