### PR TITLE
feat(documents): add Tax_Payment_Receipt detection and checklist support

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -16,6 +16,7 @@ from ai_analyzer.config import settings  # type: ignore
 from ai_analyzer.upload_utils import validate_upload
 from src.detectors import identify
 from src.extractors.irs_1120x import extract as extract_1120x
+from src.extractors.tax_payment_receipt import extract as extract_tax_payment_receipt
 try:  # pragma: no cover - optional OpenAI dependency
     from openai import OpenAI  # type: ignore
     openai_client = (
@@ -367,10 +368,12 @@ async def analyze_text_flow(
         "source": source,
     }
     det = identify(text)
-    response["document_type"] = det.get("type_key")
-    response["document_confidence"] = det.get("confidence", 0)
+    response["doc_type"] = det.get("type_key")
+    response["doc_confidence"] = det.get("confidence", 0)
     if det.get("type_key") == "Form_1120X":
-        response["extracted_fields"] = extract_1120x(text)
+        response["fields"] = extract_1120x(text)
+    elif det.get("type_key") == "Tax_Payment_Receipt":
+        response["fields"] = extract_tax_payment_receipt(text)
     extra = {"source": source}
     if filename:
         extra["upload_filename"] = filename

--- a/ai-analyzer/src/extractors/tax_payment_receipt.py
+++ b/ai-analyzer/src/extractors/tax_payment_receipt.py
@@ -1,0 +1,54 @@
+import re
+from datetime import datetime
+from typing import Dict
+
+
+def _parse_currency(val: str) -> float:
+    return float(val.replace(",", ""))
+
+
+def _parse_date(val: str) -> str:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(val, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val
+
+
+def _classify(text: str) -> str:
+    t = text.lower()
+    if "irs" in t or "internal revenue service" in t:
+        return "federal"
+    if "department of revenue" in t:
+        return "state"
+    if "city of" in t:
+        return "city"
+    return "other"
+
+
+def extract(text: str) -> Dict[str, object]:
+    out: Dict[str, object] = {}
+    m = re.search(
+        r"Payment\s+Confirmation\s+(?:Number|No\.)[^A-Z0-9]{0,10}([A-Z0-9\-]{6,})",
+        text,
+        flags=re.I,
+    )
+    if m:
+        out["confirmation_number"] = m.group(1)
+    m = re.search(
+        r"(?:Amount\s*of\s*Payment|Payment\s*amount)\s*\$?([0-9,]+(?:\.[0-9]{2})?)",
+        text,
+        flags=re.I,
+    )
+    if m:
+        out["payment_amount"] = _parse_currency(m.group(1))
+    m = re.search(
+        r"(?:Payment|Submitted)[^\n]{0,40}?((?:\d{4}[-/]\d{1,2}[-/]\d{1,2})|(?:\d{1,2}[-/]\d{1,2}[-/]\d{4}))",
+        text,
+        flags=re.I,
+    )
+    if m:
+        out["payment_date"] = _parse_date(m.group(1))
+    out["payment_type"] = _classify(text)
+    return out

--- a/ai-analyzer/tests/test_tax_payment_receipt.py
+++ b/ai-analyzer/tests/test_tax_payment_receipt.py
@@ -1,0 +1,22 @@
+from src.detectors import identify
+from src.extractors.tax_payment_receipt import extract
+
+SAMPLE = """
+IRS Payment Confirmation
+Payment Confirmation Number: ABC12345
+Amount of Payment $1,234.56
+Payment Date Submitted 2023-04-15
+"""
+
+def test_detect_tax_payment_receipt():
+    det = identify(SAMPLE)
+    assert det["type_key"] == "Tax_Payment_Receipt"
+    assert det["confidence"] >= 0.5
+
+
+def test_extract_fields():
+    fields = extract(SAMPLE)
+    assert fields["confirmation_number"] == "ABC12345"
+    assert fields["payment_amount"] == 1234.56
+    assert fields["payment_date"] == "2023-04-15"
+    assert fields["payment_type"] == "federal"

--- a/frontend/src/components/RequiredDocs.tsx
+++ b/frontend/src/components/RequiredDocs.tsx
@@ -1,14 +1,61 @@
-type Item = { key:string; label:string; optional?:boolean; accept_mime:string[]; notes?:string; examples:string[] };
+type Upload = { fields?: any };
+type Item = {
+  key: string;
+  label: string;
+  optional?: boolean;
+  accept_mime?: string[];
+  notes?: string;
+  examples?: string[];
+  uploads?: Upload[];
+};
 
 export default function RequiredDocs({ items }: { items: Item[] }) {
   return (
     <div className="space-y-3">
-      {items.map(i => (
+      {items.map((i) => (
         <div key={i.key} className="rounded-xl border p-4">
-          <div className="font-medium">{i.label} {i.optional && <span className="text-sm text-gray-500">(optional)</span>}</div>
-          <div className="text-sm">Accepted: {i.accept_mime.join(", ")}</div>
-          {i.examples?.length ? <div className="text-sm">Examples: {i.examples.join(" • ")}</div> : null}
-          {i.notes ? <div className="text-sm text-gray-500">{i.notes}</div> : null}
+          <div className="font-medium">
+            {i.label}{" "}
+            {i.optional && (
+              <span className="text-sm text-gray-500">(optional)</span>
+            )}
+          </div>
+          {i.uploads && i.uploads.length ? (
+            <ul className="text-sm mt-1 space-y-1">
+              {i.uploads.slice(0, 3).map((u, idx) => {
+                const f = u.fields || {};
+                const parts = ["Payment Confirmation"];
+                if (typeof f.payment_amount === "number") {
+                  parts.push(
+                    new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: "USD",
+                    }).format(f.payment_amount)
+                  );
+                }
+                if (f.payment_date) parts.push(f.payment_date);
+                if (f.confirmation_number)
+                  parts.push(`#${f.confirmation_number}`);
+                return <li key={idx}>{parts.join(" • ")}</li>;
+              })}
+            </ul>
+          ) : (
+            <>
+              {i.accept_mime && (
+                <div className="text-sm">
+                  Accepted: {i.accept_mime.join(", ")}
+                </div>
+              )}
+              {i.examples?.length ? (
+                <div className="text-sm">
+                  Examples: {i.examples.join(" • ")}
+                </div>
+              ) : null}
+              {i.notes ? (
+                <div className="text-sm text-gray-500">{i.notes}</div>
+              ) : null}
+            </>
+          )}
         </div>
       ))}
     </div>

--- a/frontend/tests/__snapshots__/required-docs.test.tsx.snap
+++ b/frontend/tests/__snapshots__/required-docs.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders Tax_Payment_Receipt preview 1`] = `
+<DocumentFragment>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="rounded-xl border p-4"
+    >
+      <div
+        class="font-medium"
+      >
+        Tax Payment Receipt / Payment Confirmation 
+      </div>
+      <ul
+        class="text-sm mt-1 space-y-1"
+      >
+        <li>
+          Payment Confirmation • $1,234.56 • 2023-04-15 • #ABC12345
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/tests/required-docs.test.tsx
+++ b/frontend/tests/required-docs.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import RequiredDocs from "../src/components/RequiredDocs";
+
+test("renders Tax_Payment_Receipt preview", () => {
+  const items = [
+    {
+      key: "Tax_Payment_Receipt",
+      label: "Tax Payment Receipt / Payment Confirmation",
+      uploads: [
+        {
+          fields: {
+            confirmation_number: "ABC12345",
+            payment_amount: 1234.56,
+            payment_date: "2023-04-15",
+          },
+        },
+      ],
+    },
+  ];
+  const { container } = render(<RequiredDocs items={items} />);
+  expect(container).toMatchSnapshot();
+});

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -1,11 +1,35 @@
 const express = require("express");
 const router = express.Router();
 const { getRequiredDocs } = require("../utils/documentLibrary");
+const { getCase, updateCase } = require("../utils/pipelineStore");
 
-router.get("/api/grants/:key/required-documents", (req, res) => {
-  const items = getRequiredDocs(req.params.key);
+router.get("/api/grants/:key/required-documents", async (req, res) => {
+  let caseDocs = [];
+  if (req.query.caseId) {
+    const c = await getCase("dev-user", req.query.caseId);
+    if (!c) return res.status(404).json({ error: "Case not found" });
+    caseDocs = c.documents || [];
+  }
+  const items = getRequiredDocs(req.params.key, caseDocs);
   if (!items) return res.status(404).json({ error: "Unknown grant key" });
   res.json({ grant: req.params.key, required_documents: items });
+});
+
+router.post("/api/cases/:caseId/documents", async (req, res) => {
+  const userId = "dev-user";
+  const { caseId } = req.params;
+  const c = await getCase(userId, caseId);
+  if (!c) return res.status(404).json({ error: "Case not found" });
+  const doc = {
+    docType: req.body.docType,
+    fields: req.body.fields || {},
+    fileUrl: req.body.fileUrl,
+    uploadedAt: req.body.uploadedAt || new Date().toISOString(),
+    requestId: req.body.requestId,
+  };
+  const documents = [...(c.documents || []), doc];
+  await updateCase(caseId, { documents });
+  res.json({ ok: true });
 });
 
 module.exports = router;

--- a/server/tests/documents.test.js
+++ b/server/tests/documents.test.js
@@ -1,6 +1,7 @@
 const request = require("supertest");
 process.env.SKIP_DB = "true";
 const app = require("../index");
+const { createCase } = require("../utils/pipelineStore");
 
 test("returns required docs for business_tax_refund", async () => {
   const res = await request(app).get(
@@ -9,4 +10,29 @@ test("returns required docs for business_tax_refund", async () => {
   expect(res.status).toBe(200);
   expect(res.body.required_documents.length).toBeGreaterThan(1);
   expect(res.body.required_documents[0]).toHaveProperty("key");
+});
+
+test("marks Tax_Payment_Receipt as fulfilled", async () => {
+  const caseId = await createCase("dev-user");
+  await request(app)
+    .post(`/api/cases/${caseId}/documents`)
+    .send({
+      docType: "Tax_Payment_Receipt",
+      fields: {
+        confirmation_number: "ABC12345",
+        payment_amount: 100,
+        payment_date: "2023-04-15",
+        payment_type: "federal",
+      },
+      fileUrl: "receipt.pdf",
+    });
+  const res = await request(app).get(
+    `/api/grants/business_tax_refund/required-documents?caseId=${caseId}`
+  );
+  expect(res.status).toBe(200);
+  const item = res.body.required_documents.find(
+    (d) => d.doc_type === "Tax_Payment_Receipt"
+  );
+  expect(item.fulfilled).toBe(true);
+  expect(item.uploads.length).toBe(1);
 });

--- a/server/tests/files.validateUploads.test.js
+++ b/server/tests/files.validateUploads.test.js
@@ -29,3 +29,30 @@ test("accepts expected evidence_key", async () => {
   expect(res.status).toBe(200);
   expect(res.body.documents[0].evidence_key).toBe("tax_payment_proofs");
 });
+
+test("processes Tax_Payment_Receipt payload", async () => {
+  global.pipelineFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      doc_type: "Tax_Payment_Receipt",
+      fields: {
+        confirmation_number: "ABC12345",
+        payment_amount: "123.45",
+        payment_date: "2023-04-15",
+        payment_type: "federal",
+      },
+      doc_confidence: 0.9,
+    }),
+    headers: { get: () => "application/json" },
+  });
+
+  const res = await request(app)
+    .post("/api/files/upload")
+    .field("grant_key", "business_tax_refund")
+    .attach("file", Buffer.from("dummy"), "receipt.pdf");
+  expect(res.status).toBe(200);
+  const doc = res.body.documents[0];
+  expect(doc.docType).toBe("Tax_Payment_Receipt");
+  expect(doc.fields.payment_amount).toBe(123.45);
+  expect(doc.fields.payment_date).toBe("2023-04-15");
+});

--- a/server/utils/documentLibrary.js
+++ b/server/utils/documentLibrary.js
@@ -1,9 +1,16 @@
 const fs = require("fs");
 const path = require("path");
 
-const LIB_PATH = path.resolve(__dirname, "../../shared/document_library/grants_v1.json");
+const LIB_PATH = path.resolve(
+  __dirname,
+  "../../shared/document_library/grants_v1.json"
+);
+const DOC_TYPES_DIR = path.resolve(__dirname, "../../shared/document_types");
+const DOC_CATALOG = path.join(DOC_TYPES_DIR, "catalog.json");
 
 let cache = null;
+let docTypeCache = null;
+
 function loadLibrary() {
   if (!cache) {
     cache = JSON.parse(fs.readFileSync(LIB_PATH, "utf8"));
@@ -11,11 +18,47 @@ function loadLibrary() {
   return cache;
 }
 
-function getRequiredDocs(grantKey) {
+function loadDocTypes() {
+  if (!docTypeCache) {
+    const raw = JSON.parse(fs.readFileSync(DOC_CATALOG, "utf8")).types;
+    docTypeCache = {};
+    for (const [key, spec] of Object.entries(raw)) {
+      if (spec && spec.$ref) {
+        const p = path.join(DOC_TYPES_DIR, spec.$ref);
+        docTypeCache[key] = JSON.parse(fs.readFileSync(p, "utf8"));
+      } else {
+        docTypeCache[key] = spec;
+      }
+    }
+  }
+  return docTypeCache;
+}
+
+function getDocType(key) {
+  return loadDocTypes()[key];
+}
+
+function getRequiredDocs(grantKey, caseDocs = []) {
   const lib = loadLibrary();
   const g = lib.grants[grantKey];
   if (!g) return null;
-  return g.required_documents;
+  const types = loadDocTypes();
+  return g.required_documents.map((d) => {
+    if (d.doc_type) {
+      const spec = types[d.doc_type] || {};
+      const uploads = caseDocs.filter((c) => c.docType === d.doc_type);
+      const min = d.min_count || 1;
+      return {
+        key: d.doc_type,
+        doc_type: d.doc_type,
+        label: spec.display_name || d.doc_type,
+        min_count: min,
+        uploads,
+        fulfilled: uploads.length >= min,
+      };
+    }
+    return d;
+  });
 }
 
-module.exports = { loadLibrary, getRequiredDocs };
+module.exports = { loadLibrary, getRequiredDocs, loadDocTypes, getDocType };

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -11,6 +11,7 @@
           "examples": ["IRS payment confirmation PDF", "bank receipt"],
           "notes": "Show payments for the claimed period"
         },
+        { "doc_type": "Tax_Payment_Receipt", "min_count": 1 },
         {
           "key": "filed_returns_original_and_amended",
           "label": "Original & amended tax returns",

--- a/shared/document_types/Tax_Payment_Receipt.json
+++ b/shared/document_types/Tax_Payment_Receipt.json
@@ -1,0 +1,36 @@
+{
+  "type": "Tax_Payment_Receipt",
+  "display_name": "Tax Payment Receipt / Payment Confirmation",
+  "category": "tax_payment",
+  "version": 1,
+  "identify": {
+    "keywords_any": [
+      "Payment Confirmation",
+      "Payment confirmation number",
+      "IRS",
+      "Department of Revenue",
+      "Tax Payment",
+      "Payment amount"
+    ],
+    "regex_any": [
+      "Payment\\s*Confirmation\\s*(No\\.|Number)?\\s*[:#]?\\s*[A-Z0-9\\-]{6,}",
+      "Amount\\s*of\\s*Payment\\s*\\$?[0-9,]+(\\.[0-9]{2})?",
+      "\\b(20\\d{2}|19\\d{2})[-/](0?[1-9]|1[0-2])[-/](0?[1-9]|[12][0-9]|3[01])\\b"
+    ]
+  },
+  "extract": {
+    "fields": {
+      "confirmation_number": {"type": "string", "required": true},
+      "payment_amount": {"type": "currency", "required": true, "currency": "USD"},
+      "payment_date": {"type": "date", "required": true},
+      "payment_type": {
+        "type": "enum",
+        "required": false,
+        "values": ["federal", "state", "city", "other"]
+      }
+    }
+  },
+  "examples": [
+    "https://www.scribd.com/document/412190301/Payment-Confirmation"
+  ]
+}

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -22,6 +22,9 @@
         "overpayment": "currency",
         "tax_due": "currency"
       }
+    },
+    "Tax_Payment_Receipt": {
+      "$ref": "Tax_Payment_Receipt.json"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Tax_Payment_Receipt document type and catalog wiring
- extract tax payment receipt fields in analyzer and expose through API
- validate, store and display tax payment receipts on server and frontend

## Testing
- `cd ai-analyzer && pytest -q`
- `cd server && npm test` *(fails: fetch failed / eligibility engine unreachable)*
- `cd frontend && pnpm test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68b1f2a6832483278f97fca80ea3d22a