### PR TITLE
feat(docs): add IRS Form 941-X document type, analyzer extractor, server validation, and frontend checklist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ To extend the library:
    `shared/document_library/` (e.g. `grants_v2.json`).
 3. Update services to reference the new version if needed.
 
+Example: to support IRS Form 941-X uploads, add a `shared/document_types/IRS_941X.json`
+with detector keywords and required fields (`employer_identification_number`,
+`quarter`, `calendar_year`), register it in `catalog.json`, and list the
+document under relevant grants in `grants_v1.json`.
+
 ### Veteran Owned Business Grant
 
 This program awards a flat $10,000 to five veteran-owned small businesses each year.

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -17,6 +17,7 @@ from ai_analyzer.upload_utils import validate_upload
 from src.detectors import identify
 from src.extractors.irs_1120x import extract as extract_1120x
 from src.extractors.tax_payment_receipt import extract as extract_tax_payment_receipt
+from src.extractors.irs_941x import extract as extract_941x
 try:  # pragma: no cover - optional OpenAI dependency
     from openai import OpenAI  # type: ignore
     openai_client = (
@@ -374,6 +375,8 @@ async def analyze_text_flow(
         response["fields"] = extract_1120x(text)
     elif det.get("type_key") == "Tax_Payment_Receipt":
         response["fields"] = extract_tax_payment_receipt(text)
+    elif det.get("type_key") == "IRS_941X":
+        response["fields"] = extract_941x(text)
     extra = {"source": source}
     if filename:
         extra["upload_filename"] = filename

--- a/ai-analyzer/src/extractors/irs_941x.py
+++ b/ai-analyzer/src/extractors/irs_941x.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+import re
+
+class IRS941XFields(BaseModel):
+    ein: str | None = None
+    year: str | None = None
+    quarter: str | None = None
+    date_discovered: str | None = None
+
+EIN_RE = re.compile(r"\b(employer identification number|EIN)\b[^0-9]*([0-9\-]{9,})", re.I)
+YEAR_RE = re.compile(r"calendar year[^0-9]*([12][0-9]{3})", re.I)
+Q_RE = re.compile(r"\b(1|2|3|4)\s*:\s*(January|April|July|October)", re.I)
+DISC_RE = re.compile(r"date you discovered errors[^0-9]*(\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4})", re.I)
+
+def extract(text: str) -> dict:
+    f = IRS941XFields()
+    if m := EIN_RE.search(text):
+        f.ein = m.group(2).replace("-", "")
+    if m := YEAR_RE.search(text):
+        f.year = m.group(1)
+    if m := Q_RE.search(text):
+        f.quarter = m.group(1)
+    if m := DISC_RE.search(text):
+        f.date_discovered = m.group(1)
+    return {"fields": f.model_dump(), "confidence": 0.7}

--- a/ai-analyzer/tests/test_detect_941x.py
+++ b/ai-analyzer/tests/test_detect_941x.py
@@ -1,0 +1,18 @@
+from src.detectors import detect
+
+SAMPLE = """
+Adjusted Employer's QUARTERLY Federal Tax Return or Claim for Refund
+Form 941-X  OMB No. 1545-0029
+Employer identification number (EIN) 12-3456789
+Enter the calendar year of the quarter you're correcting 2021
+Check the ONE quarter you're correcting 1: January, February, March
+Enter the date you discovered errors 05/01/2022
+"""
+
+def test_detect_941x():
+    res = detect(SAMPLE)
+    assert res["type"]["key"] == "IRS_941X"
+    f = res["extracted"]["fields"]
+    assert f["ein"] == "123456789"
+    assert f["year"] == "2021"
+    assert f["quarter"] == "1"

--- a/frontend/src/components/RequiredDocs.tsx
+++ b/frontend/src/components/RequiredDocs.tsx
@@ -9,55 +9,69 @@ type Item = {
   uploads?: Upload[];
 };
 
+const LABELS: Record<string, string> = {
+  IRS_941X: "IRS Form 941-X (Adjusted Quarterly Return)",
+};
+
 export default function RequiredDocs({ items }: { items: Item[] }) {
   return (
     <div className="space-y-3">
-      {items.map((i) => (
-        <div key={i.key} className="rounded-xl border p-4">
-          <div className="font-medium">
-            {i.label}{" "}
-            {i.optional && (
-              <span className="text-sm text-gray-500">(optional)</span>
+      {items.map((i) => {
+        const label = LABELS[i.key] || i.label;
+        return (
+          <div key={i.key} className="rounded-xl border p-4">
+            <div className="font-medium">
+              {label}{" "}
+              {i.optional && (
+                <span className="text-sm text-gray-500">(optional)</span>
+              )}
+            </div>
+            {i.uploads && i.uploads.length ? (
+              <ul className="text-sm mt-1 space-y-1">
+                {i.uploads.slice(0, 3).map((u, idx) => {
+                  const f = u.fields || {};
+                  let parts: string[] = [];
+                  if (i.key === "Tax_Payment_Receipt") {
+                    parts = ["Payment Confirmation"];
+                    if (typeof f.payment_amount === "number") {
+                      parts.push(
+                        new Intl.NumberFormat("en-US", {
+                          style: "currency",
+                          currency: "USD",
+                        }).format(f.payment_amount)
+                      );
+                    }
+                    if (f.payment_date) parts.push(f.payment_date);
+                    if (f.confirmation_number) parts.push(`#${f.confirmation_number}`);
+                  } else if (i.key === "IRS_941X") {
+                    parts = ["Form 941-X"];
+                    if (f.ein) parts.push(`EIN ${f.ein}`);
+                    if (f.year) parts.push(f.year);
+                    if (f.quarter) parts.push(`Q${f.quarter}`);
+                  }
+                  return <li key={idx}>{parts.join(" • ")}</li>;
+                })}
+              </ul>
+            ) : (
+              <>
+                {i.accept_mime && (
+                  <div className="text-sm">
+                    Accepted: {i.accept_mime.join(", ")}
+                  </div>
+                )}
+                {i.examples?.length ? (
+                  <div className="text-sm">
+                    Examples: {i.examples.join(" • ")}
+                  </div>
+                ) : null}
+                {i.notes ? (
+                  <div className="text-sm text-gray-500">{i.notes}</div>
+                ) : null}
+              </>
             )}
           </div>
-          {i.uploads && i.uploads.length ? (
-            <ul className="text-sm mt-1 space-y-1">
-              {i.uploads.slice(0, 3).map((u, idx) => {
-                const f = u.fields || {};
-                const parts = ["Payment Confirmation"];
-                if (typeof f.payment_amount === "number") {
-                  parts.push(
-                    new Intl.NumberFormat("en-US", {
-                      style: "currency",
-                      currency: "USD",
-                    }).format(f.payment_amount)
-                  );
-                }
-                if (f.payment_date) parts.push(f.payment_date);
-                if (f.confirmation_number)
-                  parts.push(`#${f.confirmation_number}`);
-                return <li key={idx}>{parts.join(" • ")}</li>;
-              })}
-            </ul>
-          ) : (
-            <>
-              {i.accept_mime && (
-                <div className="text-sm">
-                  Accepted: {i.accept_mime.join(", ")}
-                </div>
-              )}
-              {i.examples?.length ? (
-                <div className="text-sm">
-                  Examples: {i.examples.join(" • ")}
-                </div>
-              ) : null}
-              {i.notes ? (
-                <div className="text-sm text-gray-500">{i.notes}</div>
-              ) : null}
-            </>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/frontend/tests/__snapshots__/required-docs.test.tsx.snap
+++ b/frontend/tests/__snapshots__/required-docs.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders Tax_Payment_Receipt preview 1`] = `
+exports[`renders doc previews 1`] = `
 <DocumentFragment>
   <div
     class="space-y-3"
@@ -11,13 +11,29 @@ exports[`renders Tax_Payment_Receipt preview 1`] = `
       <div
         class="font-medium"
       >
-        Tax Payment Receipt / Payment Confirmation 
+        Tax Payment Receipt / Payment Confirmation
       </div>
       <ul
         class="text-sm mt-1 space-y-1"
       >
         <li>
           Payment Confirmation • $1,234.56 • 2023-04-15 • #ABC12345
+        </li>
+      </ul>
+    </div>
+    <div
+      class="rounded-xl border p-4"
+    >
+      <div
+        class="font-medium"
+      >
+        IRS Form 941-X (Adjusted Quarterly Return)
+      </div>
+      <ul
+        class="text-sm mt-1 space-y-1"
+      >
+        <li>
+          Form 941-X • EIN 123456789 • 2021 • Q1
         </li>
       </ul>
     </div>

--- a/frontend/tests/required-docs.test.tsx
+++ b/frontend/tests/required-docs.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import RequiredDocs from "../src/components/RequiredDocs";
 
-test("renders Tax_Payment_Receipt preview", () => {
+test("renders doc previews", () => {
   const items = [
     {
       key: "Tax_Payment_Receipt",
@@ -14,6 +14,13 @@ test("renders Tax_Payment_Receipt preview", () => {
             payment_date: "2023-04-15",
           },
         },
+      ],
+    },
+    {
+      key: "IRS_941X",
+      label: "IRS Form 941-X (Adjusted Quarterly Return)",
+      uploads: [
+        { fields: { ein: "123456789", year: "2021", quarter: "1" } },
       ],
     },
   ];

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -131,9 +131,12 @@ router.post('/files/upload', (req, res) => {
       if (!spec) {
         return res.status(400).json({ error: 'Unknown doc_type' });
       }
-      const requiredFields = Object.entries(spec.extract.fields)
-        .filter(([_, cfg]) => cfg.required)
-        .map(([k]) => k);
+      let requiredFields = [];
+      if (spec.extract && spec.extract.fields) {
+        requiredFields = Object.entries(spec.extract.fields)
+          .filter(([_, cfg]) => cfg.required)
+          .map(([k]) => k);
+      }
       for (const f of requiredFields) {
         if (!(f in docFields)) {
           return res.status(400).json({ error: `missing field ${f}` });

--- a/server/utils/documentLibrary.js
+++ b/server/utils/documentLibrary.js
@@ -11,6 +11,10 @@ const DOC_CATALOG = path.join(DOC_TYPES_DIR, "catalog.json");
 let cache = null;
 let docTypeCache = null;
 
+const DOC_TYPES = {
+  IRS_941X: { title: "IRS Form 941-X", accept: [".pdf"], minBytes: 10_000 },
+};
+
 function loadLibrary() {
   if (!cache) {
     cache = JSON.parse(fs.readFileSync(LIB_PATH, "utf8"));
@@ -61,4 +65,4 @@ function getRequiredDocs(grantKey, caseDocs = []) {
   });
 }
 
-module.exports = { loadLibrary, getRequiredDocs, loadDocTypes, getDocType };
+module.exports = { loadLibrary, getRequiredDocs, loadDocTypes, getDocType, DOC_TYPES };

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -12,6 +12,7 @@
           "notes": "Show payments for the claimed period"
         },
         { "doc_type": "Tax_Payment_Receipt", "min_count": 1 },
+        { "doc_type": "IRS_941X", "min_count": 0, "max_count": 10, "label": "Form 941-X (if corrections/claims)" },
         {
           "key": "filed_returns_original_and_amended",
           "label": "Original & amended tax returns",
@@ -42,6 +43,7 @@
         { "key": "revenue_decline_proof", "label": "Revenue decline statements", "accept_mime": ["application/pdf"], "examples": ["P&L 2019-2021"] },
         { "key": "shutdown_orders", "label": "Government shutdown orders (if relevant)", "accept_mime": ["application/pdf", "image/png", "image/jpeg"] , "optional": true, "examples": ["city/state order PDF"] },
         { "key": "ppp_docs", "label": "PPP forgiveness & allocations", "accept_mime": ["application/pdf"] , "examples": ["SBA forgiveness letter"] }
+        , { "doc_type": "IRS_941X", "min_count": 1, "max_count": 10, "label": "Form 941-X for applicable quarters" }
       ]
     }
   }

--- a/shared/document_types/IRS_941X.json
+++ b/shared/document_types/IRS_941X.json
@@ -1,0 +1,551 @@
+{
+  "detector": {
+    "keywords": ["Form 941-X", "Adjusted Employer's QUARTERLY Federal Tax Return", "OMB No. 1545-0029"],
+    "regex": ["Form\\s*941[- ]X", "Adjusted Employer.?s\\s+QUARTERLY\\s+Federal\\s+Tax\\s+Return", "OMB\\s*No\\.\\s*1545-0029"]
+  },
+  "required_fields": ["header_information.employer_identification_number", "return_correction_info.quarter", "return_correction_info.calendar_year"],
+  "version": 1,
+  "form": {
+    "name": "Form 941-X",
+    "title": "Adjusted Employer's QUARTERLY Federal Tax Return or Claim for Refund",
+    "revision": "Rev. April 2025",
+    "department": "Department of the Treasury",
+    "agency": "Internal Revenue Service",
+    "omb_number": "1545-0029"
+  },
+  "header_information": {
+    "employer_identification_number": {
+      "label": "Employer identification number (EIN)",
+      "value": ""
+    },
+    "company_info": {
+      "name": {
+        "label": "Name (not your trade name)",
+        "value": ""
+      },
+      "trade_name": {
+        "label": "Trade name (if any)",
+        "value": ""
+      },
+      "address": {
+        "number_street": {
+          "label": "Number Street Suite or room number",
+          "value": ""
+        },
+        "city_state_zip": {
+          "city": "",
+          "state": "",
+          "zip_code": ""
+        },
+        "foreign": {
+          "country_name": "",
+          "province_county": "",
+          "postal_code": ""
+        }
+      }
+    }
+  },
+  "return_correction_info": {
+    "return_type": {
+      "label": "Check the type of return you're correcting",
+      "form_941": false,
+      "form_941_ss": false
+    },
+    "quarter": {
+      "label": "Check the ONE quarter you're correcting",
+      "q1": {
+        "label": "1: January, February, March",
+        "selected": false
+      },
+      "q2": {
+        "label": "2: April, May, June",
+        "selected": false
+      },
+      "q3": {
+        "label": "3: July, August, September",
+        "selected": false
+      },
+      "q4": {
+        "label": "4: October, November, December",
+        "selected": false
+      }
+    },
+    "calendar_year": {
+      "label": "Enter the calendar year of the quarter you're correcting (YYYY)",
+      "value": ""
+    },
+    "date_discovered": {
+      "label": "Enter the date you discovered errors (MM/DD/YYYY)",
+      "value": ""
+    }
+  },
+  "part_1_process_selection": {
+    "title": "Select ONLY one process",
+    "option_1": {
+      "label": "Adjusted employment tax return",
+      "description": "Check this box if you underreported tax amounts. Also check this box if you overreported tax amounts and you would like to use the adjustment process to correct the errors. You must check this box if you're correcting both underreported and overreported tax amounts on this form. The amount shown on line 27, if less than zero, may only be applied as a credit to your Form 941 or Form 944 for the tax period in which you're filing this form.",
+      "selected": false
+    },
+    "option_2": {
+      "label": "Claim",
+      "description": "Check this box if you overreported tax amounts only and you would like to use the claim process to ask for a refund or abatement of the amount shown on line 27. Don't check this box if you're correcting ANY underreported tax amounts on this form.",
+      "selected": false
+    }
+  },
+  "part_2_certifications": {
+    "line_3": {
+      "label": "I certify that I've filed or will file Forms W-2, Wage and Tax Statement, or Forms W-2c, Corrected Wage and Tax Statement, as required.",
+      "certified": false
+    },
+    "line_4": {
+      "condition": "If you checked line 1 because you're adjusting overreported federal income tax, social security tax, Medicare tax, or Additional Medicare Tax, check all that apply. You must check at least one box.",
+      "certifications": {
+        "4a": {
+          "label": "I repaid or reimbursed each affected employee for the overcollected federal income tax or Additional Medicare Tax for the current year and the overcollected social security tax and Medicare tax for current and prior years. For adjustments of employee social security tax and Medicare tax overcollected in prior years, I have a written statement from each affected employee stating that they haven't claimed (or the claim was rejected) and won't claim a refund or credit for the overcollection.",
+          "checked": false
+        },
+        "4b": {
+          "label": "The adjustments of social security tax and Medicare tax are for the employer's share only. I couldn't find the affected employees or each affected employee didn't give me a written statement that they haven't claimed (or the claim was rejected) and won't claim a refund or credit for the overcollection.",
+          "checked": false
+        },
+        "4c": {
+          "label": "The adjustment is for federal income tax, social security tax, Medicare tax, or Additional Medicare Tax that I didn't withhold from employee wages.",
+          "checked": false
+        }
+      }
+    },
+    "line_5": {
+      "condition": "If you checked line 2 because you're claiming a refund or abatement of overreported federal income tax, social security tax, Medicare tax, or Additional Medicare Tax, check all that apply. You must check at least one box.",
+      "certifications": {
+        "5a": {
+          "label": "I repaid or reimbursed each affected employee for the overcollected social security tax and Medicare tax. For claims of employee social security tax and Medicare tax overcollected in prior years, I have a written statement from each affected employee stating that they haven't claimed (or the claim was rejected) and won't claim a refund or credit for the overcollection.",
+          "checked": false
+        },
+        "5b": {
+          "label": "I have a written consent from each affected employee stating that I may file this claim for the employee's share of social security tax and Medicare tax. For refunds of employee social security tax and Medicare tax overcollected in prior years, I also have a written statement from each affected employee stating that they haven't claimed (or the claim was rejected) and won't claim a refund or credit for the overcollection.",
+          "checked": false
+        },
+        "5c": {
+          "label": "The claim for social security tax and Medicare tax is for the employer's share only. I couldn't find the affected employees, or each affected employee didn't give me a written consent to file a claim for the employee's share of social security tax and Medicare tax, or each affected employee didn't give me a written statement that they haven't claimed (or the claim was rejected) and won't claim a refund or credit for the overcollection.",
+          "checked": false
+        },
+        "5d": {
+          "label": "The claim is for federal income tax, social security tax, Medicare tax, or Additional Medicare Tax that I didn't withhold from employee wages.",
+          "checked": false
+        }
+      }
+    }
+  },
+  "part_3_corrections": {
+    "title": "Enter the corrections for this quarter. If any line doesn't apply, leave it blank.",
+    "columns": {
+      "column_1": "Total corrected amount (for ALL employees)",
+      "column_2": "Amount originally reported or as previously corrected (for ALL employees)",
+      "column_3": "Difference (If this amount is a negative number, use a minus sign.)",
+      "column_4": "Tax correction"
+    },
+    "lines": {
+      "line_6": {
+        "label": "Wages, tips, and other compensation (Form 941, line 2)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "note": "Use the amount in Column 1 when you prepare your Forms W-2 or Forms W-2c."
+      },
+      "line_7": {
+        "label": "Federal income tax withheld from wages, tips, and other compensation (Form 941, line 3)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_8": {
+        "label": "Taxable social security wages (Form 941 or 941-SS, line 5a, Column 1)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.124* = ",
+        "note": "If you're correcting your employer share only, use 0.062. See instructions."
+      },
+      "line_9": {
+        "label": "Qualified sick leave wages* (Form 941 or 941-SS, line 5a(i), Column 1)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.062 = ",
+        "note": "Use line 9 only for qualified sick leave wages paid after March 31, 2020, for leave taken before April 1, 2021."
+      },
+      "line_10": {
+        "label": "Qualified family leave wages* (Form 941 or 941-SS, line 5a(ii), Column 1)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.062 = ",
+        "note": "Use line 10 only for qualified family leave wages paid after March 31, 2020, for leave taken before April 1, 2021."
+      },
+      "line_11": {
+        "label": "Taxable social security tips (Form 941 or 941-SS, line 5b, Column 1)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.124* = ",
+        "note": "If you're correcting your employer share only, use 0.062. See instructions."
+      },
+      "line_12": {
+        "label": "Taxable Medicare wages & tips (Form 941 or 941-SS, line 5c, Column 1)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.029* = ",
+        "note": "If you're correcting your employer share only, use 0.0145. See instructions."
+      },
+      "line_13": {
+        "label": "Taxable wages & tips subject to Additional Medicare Tax withholding (Form 941 or 941-SS, line 5d)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": "",
+        "calculation": "× 0.009* = ",
+        "note": "Certain wages and tips reported in Column 3 shouldn't be multiplied by 0.009. See instructions."
+      },
+      "line_14": {
+        "label": "Section 3121(q) Notice and Demand—Tax due on unreported tips (Form 941 or 941-SS, line 5f)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_15": {
+        "label": "Tax adjustments (Form 941 or 941-SS, lines 7 through 9)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_16": {
+        "label": "Qualified small business payroll tax credit for increasing research activities (See instructions; you must attach Form 8974.)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_17": {
+        "label": "Nonrefundable portion of credit for qualified sick and family leave wages for leave taken before April 1, 2021 (Form 941 or 941-SS, line 11b)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_18a": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_18b": {
+        "label": "Nonrefundable portion of credit for qualified sick and family leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 11d)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_18c": {
+        "label": "Nonrefundable portion of COBRA premium assistance credit (Form 941 or 941-SS, line 11e)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_18d": {
+        "label": "Number of individuals provided COBRA premium assistance (Form 941 or 941-SS, line 11f)",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_19": {
+        "label": "Special addition to wages for federal income tax",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_20": {
+        "label": "Special addition to wages for social security taxes",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_21": {
+        "label": "Special addition to wages for Medicare taxes",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_22": {
+        "label": "Special addition to wages for Additional Medicare Tax",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_23": {
+        "label": "Combine the amounts on lines 7 through 22 of Column 4",
+        "value": ""
+      },
+      "line_24": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_25": {
+        "label": "Refundable portion of credit for qualified sick and family leave wages for leave taken before April 1, 2021 (Form 941 or 941-SS, line 13c)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_26a": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_26b": {
+        "label": "Refundable portion of credit for qualified sick and family leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 13e)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_26c": {
+        "label": "Refundable portion of COBRA premium assistance credit (Form 941 or 941-SS, line 13f)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": "",
+        "column_4": ""
+      },
+      "line_27": {
+        "label": "Total. Combine the amounts on lines 23 through 26c of Column 4",
+        "value": "",
+        "instructions": {
+          "less_than_zero": {
+            "line_1_checked": "If you checked line 1, this is the amount you want applied as a credit to your Form 941 for the tax period in which you're filing this form. (If you're currently filing a Form 944, Employer's ANNUAL Federal Tax Return, see the instructions.)",
+            "line_2_checked": "If you checked line 2, this is the amount you want refunded or abated."
+          },
+          "more_than_zero": "If line 27 is more than zero, this is the amount you owe. Pay this amount by the time you file this return. For information on how to pay, see Amount you owe in the instructions."
+        }
+      },
+      "line_28": {
+        "label": "Qualified health plan expenses allocable to qualified sick leave wages for leave taken before April 1, 2021 (Form 941 or 941-SS, line 19)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_29": {
+        "label": "Qualified health plan expenses allocable to qualified family leave wages for leave taken before April 1, 2021 (Form 941 or 941-SS, line 20)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_30": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_31a": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_31b": {
+        "label": "Reserved for future use"
+      },
+      "line_32": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_33a": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_33b": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_34": {
+        "label": "Reserved for future use",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "lines_35_40_caution": "Lines 35–40 apply only to quarters beginning after March 31, 2021.",
+      "line_35": {
+        "label": "Qualified sick leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 23)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_36": {
+        "label": "Qualified health plan expenses allocable to qualified sick leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 24)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_37": {
+        "label": "Amounts under certain collectively bargained agreements allocable to qualified sick leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 25)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_38": {
+        "label": "Qualified family leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 26)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_39": {
+        "label": "Qualified health plan expenses allocable to qualified family leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 27)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      },
+      "line_40": {
+        "label": "Amounts under certain collectively bargained agreements allocable to qualified family leave wages for leave taken after March 31, 2021, and before October 1, 2021 (Form 941 or 941-SS, line 28)",
+        "column_1": "",
+        "column_2": "",
+        "column_3": ""
+      }
+    }
+  },
+  "part_4_explanations": {
+    "title": "Explain your corrections for this quarter",
+    "line_41": {
+      "label": "Check here if any corrections you entered on a line include both underreported and overreported amounts. Explain both your underreported and overreported amounts on line 43.",
+      "checked": false
+    },
+    "line_42": {
+      "label": "Check here if any corrections involve reclassified workers. Explain on line 43.",
+      "checked": false
+    },
+    "line_43": {
+      "label": "You must give us a detailed explanation of how you determined your corrections. See the instructions.",
+      "explanation": ""
+    }
+  },
+  "part_5_signature": {
+    "title": "Sign here. You must complete all five pages of this form and sign it.",
+    "declaration": "Under penalties of perjury, I declare that I have filed an original Form 941 or Form 941-SS and that I have examined this adjusted return or claim, including accompanying schedules and statements, and to the best of my knowledge and belief, it is true, correct, and complete. Declaration of preparer (other than taxpayer) is based on all information of which preparer has any knowledge.",
+    "signature": {
+      "signature": "",
+      "date": "",
+      "name": "",
+      "title": "",
+      "phone": ""
+    },
+    "paid_preparer": {
+      "self_employed": false,
+      "preparer_name": "",
+      "ptin": "",
+      "preparer_signature": "",
+      "date": "",
+      "firm_name": "",
+      "ein": "",
+      "address": "",
+      "phone": "",
+      "city": "",
+      "state": "",
+      "zip_code": ""
+    }
+  },
+  "process_guidance": {
+    "title": "Which process should you use?",
+    "scenarios": {
+      "underreported_only": {
+        "description": "Underreported tax amounts ONLY",
+        "process": "Use the adjustment process to correct underreported tax amounts.",
+        "instructions": [
+          "Check the box on line 1.",
+          "Pay the amount you owe from line 27 by the time you file Form 941-X."
+        ]
+      },
+      "overreported_only": {
+        "description": "Overreported tax amounts ONLY",
+        "process": "The process you use depends on when you file Form 941-X.",
+        "more_than_90_days": {
+          "condition": "If you're filing Form 941-X MORE THAN 90 days before the period of limitations on credit or refund for Form 941 or Form 941-SS expires",
+          "options": [
+            {
+              "name": "adjustment_process",
+              "description": "Choose the adjustment process if you want the amount shown on line 27 credited to your Form 941 or Form 944 for the period in which you file Form 941-X. Check the box on line 1."
+            },
+            {
+              "name": "claim_process",
+              "description": "Choose the claim process if you want the amount shown on line 27 refunded to you or abated. Check the box on line 2."
+            }
+          ]
+        },
+        "within_90_days": {
+          "condition": "If you're filing Form 941-X WITHIN 90 days of the expiration of the period of limitations on credit or refund for Form 941 or Form 941-SS",
+          "requirement": "You must use the claim process to correct the overreported tax amounts. Check the box on line 2."
+        }
+      },
+      "both_under_and_over": {
+        "description": "BOTH underreported and overreported tax amounts",
+        "process": "The process you use depends on when you file Form 941-X.",
+        "more_than_90_days": {
+          "condition": "If you're filing Form 941-X MORE THAN 90 days before the period of limitations on credit or refund for Form 941 or Form 941-SS expires",
+          "options": [
+            {
+              "name": "adjustment_process_only",
+              "description": "Choose the adjustment process if combining your underreported tax amounts and overreported tax amounts results in a balance due or creates a credit that you want applied to Form 941 or Form 944.",
+              "steps": [
+                "File one Form 941-X, and",
+                "Check the box on line 1 and follow the instructions on line 27."
+              ]
+            },
+            {
+              "name": "both_processes",
+              "description": "Choose both the adjustment process and the claim process if you want the overreported tax amount refunded to you or abated.",
+              "steps": [
+                "File two separate forms.",
+                "For the adjustment process, file one Form 941-X to correct the underreported tax amounts. Check the box on line 1. Pay the amount you owe from line 27 by the time you file Form 941-X.",
+                "For the claim process, file a second Form 941-X to correct the overreported tax amounts. Check the box on line 2."
+              ]
+            }
+          ]
+        },
+        "within_90_days": {
+          "condition": "If you're filing Form 941-X WITHIN 90 days of the expiration of the period of limitations on credit or refund for Form 941 or Form 941-SS",
+          "requirement": "You must use both the adjustment process and the claim process.",
+          "steps": [
+            "File two separate forms.",
+            "For the adjustment process, file one Form 941-X to correct the underreported tax amounts. Check the box on line 1. Pay the amount you owe from line 27 by the time you file Form 941-X.",
+            "For the claim process, file a second Form 941-X to correct the overreported tax amounts. Check the box on line 2."
+          ]
+        }
+      }
+    },
+    "employment_tax_credit_note": "Unless otherwise specified in the separate instructions, an underreported employment tax credit should be treated like an overreported tax amount. An overreported employment tax credit should be treated like an underreported tax amount. For more information, including which process to select on lines 1 and 2, see Correcting an employment tax credit in the separate instructions."
+  },
+  "form_metadata": {
+    "website": "www.irs.gov/Form941X",
+    "catalog_number": "17025J",
+    "pages": 6,
+    "completion_requirement": "You must complete all five pages of this form and sign it"
+  }
+}

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -25,6 +25,10 @@
     },
     "Tax_Payment_Receipt": {
       "$ref": "Tax_Payment_Receipt.json"
+    },
+    "IRS_941X": {
+      "$ref": "IRS_941X.json",
+      "display_name": "IRS Form 941-X"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add IRS Form 941-X document type and catalog entry with detector keywords and required fields
- implement 941-X extractor and detection pipeline in analyzer
- allow server and frontend to accept/display 941-X uploads for relevant grants

## Testing
- `cd ai-analyzer && pytest -q`
- `cd server && npm test` *(fails: eligibility-report returned 502: Eligibility engine unreachable)*
- `cd frontend && pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68b1fbb082888327b8eb09d1ac7c2131