### PR TITLE
feat: add required documents checklist API

### DIFF
--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -16,6 +16,7 @@ const documentSchema = new mongoose.Schema(
 );
 
 const caseSchema = new mongoose.Schema({
+  caseId: { type: String, unique: true, sparse: true },
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   status: { type: String, default: 'open' },
   answers: { type: mongoose.Schema.Types.Mixed, default: {} },

--- a/server/tests/checklistBuilder.test.js
+++ b/server/tests/checklistBuilder.test.js
@@ -1,0 +1,45 @@
+const { buildChecklist } = require('../utils/checklistBuilder');
+
+describe('buildChecklist', () => {
+  const grantsLibrary = {
+    erc: {
+      required_docs: ['IRS_941X'],
+      common_docs: ['W9'],
+    },
+    business_tax_refund: {
+      required_docs: ['IRS_941X', 'Tax_Payment_Receipt'],
+      common_docs: ['W9', 'FEIN'],
+    },
+  };
+
+  test('returns empty array when no grants', async () => {
+    const { required } = await buildChecklist({
+      shortlistedGrants: [],
+      grantsLibrary,
+    });
+    expect(required).toEqual([]);
+  });
+
+  test('deduplicates docs and hydrates status', async () => {
+    const caseDocs = [{ doc_type: 'IRS_941X', status: 'uploaded' }];
+    const { required } = await buildChecklist({
+      shortlistedGrants: ['erc', 'business_tax_refund'],
+      grantsLibrary,
+      caseDocuments: caseDocs,
+    });
+
+    const order = required.map((d) => d.doc_type);
+    expect(order).toEqual(['FEIN', 'W9', 'IRS_941X', 'Tax_Payment_Receipt']);
+
+    const irs = required.find((d) => d.doc_type === 'IRS_941X');
+    expect(irs.source).toBe('grant');
+    expect(irs.grants.sort()).toEqual(['business_tax_refund', 'erc']);
+    expect(irs.status).toBe('uploaded');
+
+    const w9 = required.find((d) => d.doc_type === 'W9');
+    expect(w9.source).toBe('common');
+    expect(w9.grants).toEqual([]);
+    expect(w9.status).toBe('not_uploaded');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add checklist builder to merge common and grant-specific docs
- expose GET /api/case/required-documents to deliver deduplicated checklist
- cover checklist building and API behavior with new tests

## Testing
- `npm test tests/checklistBuilder.test.js tests/case.required-documents.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b218598b848327b92174fae6d45ca3