### PR TITLE
Enable document uploads directly from checklist

### DIFF
--- a/frontend/tests/document-checklist.test.tsx
+++ b/frontend/tests/document-checklist.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import DocumentChecklist from "@/components/DocumentChecklist";
 import { api } from "@/lib/apiClient";
 
@@ -8,6 +8,11 @@ jest.mock("@/lib/apiClient", () => ({
     post: jest.fn(),
   },
 }));
+
+beforeEach(() => {
+  (api.get as jest.Mock).mockReset();
+  (api.post as jest.Mock).mockReset();
+});
 
 test("renders and dedupes documents", async () => {
   (api.get as jest.Mock).mockResolvedValue({
@@ -45,4 +50,49 @@ test("renders and dedupes documents", async () => {
   expect(await screen.findByText("IRS_941X")).toBeInTheDocument();
   expect(screen.getAllByText("IRS_941X")).toHaveLength(1);
   expect(screen.getByText("Required by: GrantA, GrantB")).toBeInTheDocument();
+});
+
+test("uploads document and refreshes status", async () => {
+  (api.get as jest.Mock)
+    .mockResolvedValueOnce({
+      data: [
+        {
+          doc_type: "W9",
+          source: "common",
+          grants: [],
+          status: "not_uploaded",
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      data: [
+        {
+          doc_type: "W9",
+          source: "common",
+          grants: [],
+          status: "uploaded",
+        },
+      ],
+    });
+
+  (api.post as jest.Mock).mockResolvedValue({});
+
+  render(<DocumentChecklist caseId="case123" />);
+
+  const input = (await screen.findByText("W9"))
+    .closest("li")!
+    .querySelector("input[type=file]") as HTMLInputElement;
+
+  const file = new File(["dummy"], "w9.pdf", { type: "application/pdf" });
+  await act(async () => {
+    fireEvent.change(input, { target: { files: [file] } });
+  });
+
+  expect(api.post).toHaveBeenCalledWith("/files/upload", expect.any(FormData));
+  const form = (api.post as jest.Mock).mock.calls[0][1] as FormData;
+  expect(form.get("caseId")).toBe("case123");
+  expect(form.get("key")).toBe("W9");
+
+  expect(await screen.findByText("uploaded")).toBeInTheDocument();
+  expect((api.get as jest.Mock)).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
## Summary
- allow uploading missing or mismatched documents from DocumentChecklist
- post uploaded files to `/files/upload` and refresh checklist statuses
- add tests for document upload flow and status refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b21d48d7c88327ae34e45cd1a9dbaa