### PR TITLE
Integrate analyzer normalization and eligibility refresh

### DIFF
--- a/server/tests/files.eligibilityRefresh.test.js
+++ b/server/tests/files.eligibilityRefresh.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest');
+process.env.SKIP_DB = 'true';
+let app;
+
+beforeEach(() => {
+  global.pipelineFetch = jest
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        doc_type: 'IRS_941X',
+        fields: { ein: '12-3456789', year: '2021' },
+        doc_confidence: 0.9,
+      }),
+      headers: { get: () => 'application/json' },
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ program: 'sample', status: 'eligible', certainty: 0.8 }],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+  app = require('../index');
+});
+
+afterEach(() => {
+  delete global.pipelineFetch;
+  jest.resetModules();
+});
+
+test('upload triggers analyzer and eligibility refresh', async () => {
+  const res = await request(app)
+    .post('/api/files/upload')
+    .attach('file', Buffer.from('dummy'), '941x.pdf');
+  expect(res.status).toBe(200);
+  const doc = res.body.documents[0];
+  expect(doc.analyzer_fields.employer_identification_number).toBe('12-3456789');
+  expect(res.body.eligibility.results).toHaveLength(1);
+  expect(global.pipelineFetch).toHaveBeenCalledTimes(2);
+  const secondCall = global.pipelineFetch.mock.calls[1];
+  const payload = JSON.parse(secondCall[1].body);
+  expect(payload.employer_identification_number).toBe('12-3456789');
+});

--- a/server/utils/fieldNormalizer.js
+++ b/server/utils/fieldNormalizer.js
@@ -1,0 +1,24 @@
+const fieldMap = require('../../eligibility-engine/contracts/field_map.json');
+
+const aliasMap = (() => {
+  const map = {};
+  for (const [canonical, info] of Object.entries(fieldMap)) {
+    const target = info.target || canonical;
+    map[canonical] = target;
+    (info.aliases || []).forEach((alias) => {
+      map[alias] = target;
+    });
+  }
+  return map;
+})();
+
+function normalizeFields(fields = {}) {
+  const out = {};
+  for (const [key, value] of Object.entries(fields)) {
+    const mapped = aliasMap[key] || key;
+    out[mapped] = value;
+  }
+  return out;
+}
+
+module.exports = { normalizeFields };


### PR DESCRIPTION
## Summary
- Normalize analyzer field keys using `field_map.json`
- Merge analyzer fields into case documents and re-run eligibility engine after upload
- Add eligibility refresh test covering analyzer integration

## Testing
- `npm test` *(fails: Operation `cases.findOne()` buffering timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68b21ecdc4808327a5c06ce16920435a