### PR TITLE
feat: add pre-upload wizard for common documents

### DIFF
--- a/frontend/src/components/DocumentChecklist.tsx
+++ b/frontend/src/components/DocumentChecklist.tsx
@@ -1,6 +1,8 @@
+"use client";
 import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/apiClient";
 import Tooltip from "@/components/Tooltip";
+import PreUploadWizard from "@/components/PreUploadWizard";
 
 export interface ChecklistItem {
   doc_type: string;
@@ -100,6 +102,15 @@ export default function DocumentChecklist({
 }: {
   caseId: string;
 }) {
+  const storageKey = `preupload_done_${caseId}`;
+  const [wizardDone, setWizardDone] = useState(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(storageKey) === "1";
+    } catch {
+      return false;
+    }
+  });
   const [items, setItems] = useState<ChecklistItem[]>([]);
   const [uploading, setUploading] = useState<Record<string, boolean>>({});
 
@@ -157,6 +168,19 @@ export default function DocumentChecklist({
   const grant = items
     .filter((i) => i.source === "grant")
     .sort((a, b) => a.doc_type.localeCompare(b.doc_type));
+
+  if (!wizardDone) {
+    return (
+      <PreUploadWizard
+        onContinue={() => {
+          setWizardDone(true);
+          try {
+            window.localStorage.setItem(storageKey, "1");
+          } catch {}
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/PreUploadWizard.tsx
+++ b/frontend/src/components/PreUploadWizard.tsx
@@ -1,0 +1,78 @@
+"use client";
+import React from "react";
+
+export interface CommonDoc {
+  doc_type: string;
+  title: string;
+  description: string;
+  example_url?: string;
+}
+
+const COMMON_DOCS: CommonDoc[] = [
+  {
+    doc_type: "W9",
+    title: "IRS W-9",
+    description: "Provides your taxpayer identification number.",
+    example_url: "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
+  },
+  {
+    doc_type: "EIN_Letter",
+    title: "EIN Letter (CP-575)",
+    description: "Confirms your business's Employer Identification Number.",
+  },
+  {
+    doc_type: "Basic_Financials",
+    title: "Basic Financials (P&L / Balance Sheet)",
+    description: "Demonstrates the financial health of your business.",
+  },
+  {
+    doc_type: "Basic_Tax_Return",
+    title: "Basic Tax Return (1120 / Schedule C)",
+    description: "Verifies reported income and taxes.",
+  },
+  {
+    doc_type: "Bank_Statements",
+    title: "Bank Statements (3–6 months)",
+    description: "Shows cash flow for the business.",
+  },
+];
+
+export default function PreUploadWizard({
+  onContinue,
+}: {
+  onContinue: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-700">
+        Please prepare these common documents before uploading. They are required
+        for all grants.
+      </p>
+      <ul className="space-y-2">
+        {COMMON_DOCS.map((doc) => (
+          <li key={doc.doc_type} className="border rounded p-3">
+            <div className="font-medium">{doc.title}</div>
+            <p className="text-sm text-gray-600">{doc.description}</p>
+            {doc.example_url && (
+              <a
+                href={doc.example_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 text-sm underline"
+              >
+                Example
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={onContinue}
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Continue
+      </button>
+    </div>
+  );
+}
+

--- a/frontend/tests/document-checklist.test.tsx
+++ b/frontend/tests/document-checklist.test.tsx
@@ -12,9 +12,11 @@ jest.mock("@/lib/apiClient", () => ({
 beforeEach(() => {
   (api.get as jest.Mock).mockReset();
   (api.post as jest.Mock).mockReset();
+  localStorage.clear();
 });
 
 test("renders and dedupes documents", async () => {
+  localStorage.setItem("preupload_done_123", "1");
   (api.get as jest.Mock).mockResolvedValue({
     data: [
       {
@@ -53,6 +55,7 @@ test("renders and dedupes documents", async () => {
 });
 
 test("uploads document and refreshes status", async () => {
+  localStorage.setItem("preupload_done_case123", "1");
   (api.get as jest.Mock)
     .mockResolvedValueOnce({
       data: [

--- a/frontend/tests/preupload-wizard.test.tsx
+++ b/frontend/tests/preupload-wizard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import PreUploadWizard from "@/components/PreUploadWizard";
+
+it("renders common docs and continues", () => {
+  const onContinue = jest.fn();
+  render(<PreUploadWizard onContinue={onContinue} />);
+
+  expect(screen.getByText("IRS W-9")).toBeInTheDocument();
+  expect(screen.getByText("EIN Letter (CP-575)")).toBeInTheDocument();
+  expect(
+    screen.getByText("Basic Financials (P&L / Balance Sheet)")
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Basic Tax Return (1120 / Schedule C)")
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Bank Statements (3–6 months)")
+  ).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(/continue/i));
+  expect(onContinue).toHaveBeenCalled();
+});

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -1,10 +1,18 @@
 {
   "version": 1,
   "common_documents": [
+    { "doc_type": "Tax_Payment_Receipt", "label": "Tax payment receipt / confirmation" },
+    { "doc_type": "W9", "label": "IRS W-9" },
+    { "doc_type": "EIN_Letter", "label": "EIN Letter (CP-575)" },
     {
-      "doc_type": "Tax_Payment_Receipt",
-      "label": "Tax payment receipt / confirmation"
-    }
+      "doc_type": "Basic_Financials",
+      "label": "Basic Financials (P&L / Balance Sheet)"
+    },
+    {
+      "doc_type": "Basic_Tax_Return",
+      "label": "Basic Tax Return (1120 / Schedule C)"
+    },
+    { "doc_type": "Bank_Statements", "label": "Bank Statements (3–6 months)" }
   ],
   "grants": {
     "business_tax_refund": {


### PR DESCRIPTION
## Summary
- add PreUploadWizard to guide users on common documents
- gate DocumentChecklist behind PreUploadWizard with per-case persistence
- list standard documents in grants library

## Testing
- `npm test` (frontend)
- `npm test` (server) *(fails: Port 5000 not reachable)*


------
https://chatgpt.com/codex/tasks/task_b_68b220c1880083279343af67cecc1eb1