### PR TITLE
Log ELIGIBILITY_ENGINE_URL on startup

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,8 @@
 // server/index.js
 
+require('dotenv').config();
+console.log("ELIGIBILITY_ENGINE_URL =", process.env.ELIGIBILITY_ENGINE_URL);
+
 const env = require('./config/env');
 const express = require('express');
 const cors = require('cors');


### PR DESCRIPTION
## Summary
- log ELIGIBILITY_ENGINE_URL from environment when server boots

## Testing
- `npm test` *(fails: Port 8002 not reachable)*
- `SKIP_DB=true node index.js`

------
https://chatgpt.com/codex/tasks/task_b_68b4801230c48327a6b0616a8e43d35b