### PR TITLE
Log service URLs on server start

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,8 @@
 
 require('dotenv').config();
 console.log("ELIGIBILITY_ENGINE_URL =", process.env.ELIGIBILITY_ENGINE_URL);
+console.log("AI_ANALYZER_URL =", process.env.AI_ANALYZER_URL);
+console.log("AI_AGENT_URL =", process.env.AI_AGENT_URL);
 
 const env = require('./config/env');
 const express = require('express');


### PR DESCRIPTION
## Summary
- log configured Eligibility Engine, AI Analyzer, and AI Agent URLs when the server boots

## Testing
- `ELIGIBILITY_ENGINE_URL=http://localhost:8002 AI_ANALYZER_URL=http://localhost:8001 AI_AGENT_URL=http://localhost:8003 SKIP_DB=true node index.js`
- `npm test` *(fails: 5 failed, 12 passed, 17 total)*

------
https://chatgpt.com/codex/tasks/task_b_68b483176a8c832798624f34dc73879f