### PR TITLE
Add Business License document type and extractor

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -32,6 +32,7 @@ EXTRACTORS = {
     "Form_1120X": ("irs_1120x", "extract"),
     "Tax_Payment_Receipt": ("tax_payment_receipt", "extract"),
     "IRS_941X": ("irs_941x", "extract"),
+    "Business_License": ("business_license", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/business_license.py
+++ b/ai-analyzer/src/extractors/business_license.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+import re
+from pydantic import BaseModel
+
+
+def detect_business_license(text: str) -> bool:
+    keywords = [
+        "Application for General Business License",
+        "Business License",
+        "Applicant Information",
+        "Business Information",
+    ]
+    t = text.lower()
+    return any(k.lower() in t for k in keywords)
+
+
+class BusinessLicenseFields(BaseModel):
+    applicant_name: str | None = None
+    date_of_birth: str | None = None
+    home_address: str | None = None
+    business_name: str | None = None
+    business_address: str | None = None
+    type_of_business: str | None = None
+
+
+def _normalize_date(val: str) -> str:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"):
+        try:
+            return datetime.strptime(val, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val
+
+
+APPLICANT_NAME_RE = re.compile(r"Applicant Name\s*[:\-]?\s*(.+)", re.I)
+DOB_RE = re.compile(r"Date of Birth\s*[:\-]?\s*([0-9/\-]+)", re.I)
+HOME_ADDRESS_RE = re.compile(r"Home Address\s*[:\-]?\s*(.+)", re.I)
+BUSINESS_NAME_RE = re.compile(r"Business Name\s*[:\-]?\s*(.+)", re.I)
+BUSINESS_ADDRESS_RE = re.compile(r"Business Address\s*[:\-]?\s*(.+)", re.I)
+TYPE_OF_BUSINESS_RE = re.compile(r"Type of Business\s*[:\-]?\s*(.+)", re.I)
+
+
+def extract(text: str) -> dict:
+    f = BusinessLicenseFields()
+    if m := APPLICANT_NAME_RE.search(text):
+        f.applicant_name = m.group(1).strip()
+    if m := DOB_RE.search(text):
+        f.date_of_birth = _normalize_date(m.group(1).strip())
+    if m := HOME_ADDRESS_RE.search(text):
+        f.home_address = m.group(1).strip()
+    if m := BUSINESS_NAME_RE.search(text):
+        f.business_name = m.group(1).strip()
+    if m := BUSINESS_ADDRESS_RE.search(text):
+        f.business_address = m.group(1).strip()
+    if m := TYPE_OF_BUSINESS_RE.search(text):
+        f.type_of_business = m.group(1).strip()
+    return {"fields": f.model_dump(), "confidence": 0.6}

--- a/ai-analyzer/tests/test_business_license.py
+++ b/ai-analyzer/tests/test_business_license.py
@@ -1,0 +1,26 @@
+from src.detectors import identify
+from src.extractors.business_license import detect_business_license, extract
+
+SAMPLE = """
+Application for General Business License
+Applicant Name: Jane Doe
+Date of Birth: 01/01/1990
+Home Address: 123 Home St
+Business Name: Doe Ventures
+Business Address: 456 Biz Ave
+Type of Business: Consulting
+"""
+
+def test_detect_business_license():
+    assert detect_business_license(SAMPLE)
+    det = identify(SAMPLE)
+    assert det["type_key"] == "Business_License"
+    assert det["confidence"] >= 0.5
+
+def test_extract_fields():
+    result = extract(SAMPLE)
+    fields = result["fields"]
+    assert fields["applicant_name"] == "Jane Doe"
+    assert fields["business_name"] == "Doe Ventures"
+    assert fields["type_of_business"] == "Consulting"
+    assert fields["date_of_birth"] == "1990-01-01"

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -59,6 +59,45 @@
         { "key": "ppp_docs", "label": "PPP forgiveness & allocations", "accept_mime": ["application/pdf"] , "examples": ["SBA forgiveness letter"] }
         , { "doc_type": "IRS_941X", "min_count": 1, "max_count": 10, "label": "Form 941-X for applicable quarters" }
       ]
+    },
+    "california_small_biz": {
+      "title": "California Small Business Grant",
+      "required_docs": [
+        "Business_License",
+        "Articles_Of_Incorporation",
+        "EIN_Letter",
+        "Financials_Basic",
+        "Tax_Returns",
+        "Business_Plan",
+        "Grant_Use_Statement"
+      ],
+      "common_docs": ["Owner_ID", "Bank_Statements"]
+    },
+    "urban_small_biz": {
+      "title": "Urban Small Business Grant",
+      "required_docs": [
+        "Business_License",
+        "Articles_Of_Incorporation",
+        "EIN_Letter",
+        "Financials_Basic",
+        "Tax_Returns",
+        "Business_Plan",
+        "Grant_Use_Statement"
+      ],
+      "common_docs": ["Owner_ID", "Bank_Statements"]
+    },
+    "general_support": {
+      "title": "General Support Grant",
+      "required_docs": [
+        "Business_License",
+        "Articles_Of_Incorporation",
+        "EIN_Letter",
+        "Financials_Basic",
+        "Tax_Returns",
+        "Business_Plan",
+        "Grant_Use_Statement"
+      ],
+      "common_docs": ["Owner_ID", "Bank_Statements"]
     }
   }
 }

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -29,6 +29,25 @@
     "IRS_941X": {
       "$ref": "IRS_941X.json",
       "display_name": "IRS Form 941-X"
+    },
+    "Business_License": {
+      "detector": {
+        "keywords": [
+          "Application for General Business License",
+          "Business License",
+          "Applicant Information",
+          "Business Information"
+        ]
+      },
+      "extractor": "business_license",
+      "fields": {
+        "applicant_name": "string",
+        "date_of_birth": "date",
+        "home_address": "string",
+        "business_name": "string",
+        "business_address": "string",
+        "type_of_business": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Business_License type to document catalog
- require Business_License for small business grant configurations
- implement Business License detector/extractor and unit tests

## Testing
- `pytest ai-analyzer/tests/test_business_license.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4879b6f4c8327842bea02a24c901b