### PR TITLE
Add Articles of Incorporation document type and extractor

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -33,6 +33,7 @@ EXTRACTORS = {
     "Tax_Payment_Receipt": ("tax_payment_receipt", "extract"),
     "IRS_941X": ("irs_941x", "extract"),
     "Business_License": ("business_license", "extract"),
+    "Articles_Of_Incorporation": ("articles_of_incorporation", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/articles_of_incorporation.py
+++ b/ai-analyzer/src/extractors/articles_of_incorporation.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+import re
+from pydantic import BaseModel
+
+KEYWORDS = [
+    "Articles of Incorporation",
+    "Articles of Organization",
+    "Certificate of Incorporation",
+    "Certificate of Formation",
+    "Secretary of State",
+]
+
+
+def detect_articles_of_incorporation(text: str) -> bool:
+    t = text.lower()
+    return any(k.lower() in t for k in KEYWORDS)
+
+
+class ArticlesOfIncorporationFields(BaseModel):
+    business_name: str | None = None
+    entity_type: str | None = None
+    date_of_incorporation: str | None = None
+    state_of_incorporation: str | None = None
+    registered_agent: str | None = None
+
+
+def _normalize_date(val: str) -> str:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"):
+        try:
+            return datetime.strptime(val, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val
+
+
+BUSINESS_NAME_RE = re.compile(r"(?:Company|Business)?\s*Name\s*[:\-]\s*(.+)", re.I)
+ENTITY_TYPE_RE = re.compile(r"Entity\s*Type\s*[:\-]\s*(.+)", re.I)
+DATE_RE = re.compile(r"(?:Date\s*of\s*Incorporation|Effective\s*Date|Date)\s*[:\-]\s*([0-9/\-]+)", re.I)
+STATE_RE = re.compile(r"State\s*of\s*Incorporation\s*[:\-]\s*(.+)", re.I)
+REGISTERED_AGENT_RE = re.compile(r"Registered\s*Agent\s*[:\-]\s*(.+)", re.I)
+
+
+def extract(text: str) -> dict:
+    f = ArticlesOfIncorporationFields()
+    if m := BUSINESS_NAME_RE.search(text):
+        f.business_name = m.group(1).strip()
+    if m := ENTITY_TYPE_RE.search(text):
+        f.entity_type = m.group(1).strip()
+    if m := DATE_RE.search(text):
+        f.date_of_incorporation = _normalize_date(m.group(1).strip())
+    if m := STATE_RE.search(text):
+        f.state_of_incorporation = m.group(1).strip()
+    if m := REGISTERED_AGENT_RE.search(text):
+        f.registered_agent = m.group(1).strip()
+    return {"fields": f.model_dump(), "confidence": 0.6}

--- a/ai-analyzer/tests/test_articles_of_incorporation.py
+++ b/ai-analyzer/tests/test_articles_of_incorporation.py
@@ -1,0 +1,43 @@
+from src.detectors import identify
+from src.extractors.articles_of_incorporation import (
+    detect_articles_of_incorporation,
+    extract,
+)
+
+SAMPLE_INC = """
+Articles of Incorporation
+Company Name: Example Corp
+Entity Type: Corporation
+Date of Incorporation: 05/01/2020
+State of Incorporation: California
+Registered Agent: John Agent
+"""
+
+SAMPLE_CERT = """
+Certificate of Formation
+Name: Sample LLC
+State of Incorporation: Texas
+Registered Agent: Jane Agent
+"""
+
+
+def test_detect_articles_of_incorporation():
+    assert detect_articles_of_incorporation(SAMPLE_INC)
+    det = identify(SAMPLE_INC)
+    assert det["type_key"] == "Articles_Of_Incorporation"
+    assert det["confidence"] >= 0.5
+
+
+def test_detect_certificate_of_formation():
+    assert detect_articles_of_incorporation(SAMPLE_CERT)
+    det = identify(SAMPLE_CERT)
+    assert det["type_key"] == "Articles_Of_Incorporation"
+
+
+def test_extract_fields():
+    result = extract(SAMPLE_INC)
+    fields = result["fields"]
+    assert fields["business_name"] == "Example Corp"
+    assert fields["date_of_incorporation"] == "2020-05-01"
+    assert fields["registered_agent"] == "John Agent"
+    assert fields["state_of_incorporation"] == "California"

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -26,6 +26,7 @@
           "notes": "Show payments for the claimed period"
         },
         { "doc_type": "Tax_Payment_Receipt", "min_count": 1 },
+        { "doc_type": "Articles_Of_Incorporation", "min_count": 1 },
         { "doc_type": "IRS_941X", "min_count": 0, "max_count": 10, "label": "Form 941-X (if corrections/claims)" },
         {
           "key": "filed_returns_original_and_amended",

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -48,6 +48,25 @@
         "business_address": "string",
         "type_of_business": "string"
       }
+    },
+    "Articles_Of_Incorporation": {
+      "detector": {
+        "keywords": [
+          "Articles of Incorporation",
+          "Articles of Organization",
+          "Certificate of Incorporation",
+          "Certificate of Formation",
+          "Secretary of State"
+        ]
+      },
+      "extractor": "articles_of_incorporation",
+      "fields": {
+        "business_name": "string",
+        "entity_type": "string",
+        "date_of_incorporation": "date",
+        "state_of_incorporation": "string",
+        "registered_agent": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- support Articles_Of_Incorporation in document type catalog
- require Articles_Of_Incorporation for applicable grants and add extractor
- test detection and field extraction for Articles_Of_Incorporation

## Testing
- `cd ai-analyzer && pytest tests/test_articles_of_incorporation.py`
- `cd ai-analyzer && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b48a2eafd8832796de2cb84c3060c6