### PR TITLE
feat: add EIN letter document type

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -34,6 +34,7 @@ EXTRACTORS = {
     "IRS_941X": ("irs_941x", "extract"),
     "Business_License": ("business_license", "extract"),
     "Articles_Of_Incorporation": ("articles_of_incorporation", "extract"),
+    "EIN_Letter": ("ein_letter", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/ein_letter.py
+++ b/ai-analyzer/src/extractors/ein_letter.py
@@ -1,0 +1,115 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+EIN_RE = re.compile(r"\b(\d{2}-\d{7})\b")
+DATE_CANDIDATES = [
+    r"\b(\d{1,2}-\d{1,2}-\d{4})\b",
+    r"\b([A-Za-z]{3,9}\s+\d{1,2},\s+\d{4})\b",
+]
+NOTICE_RE = re.compile(r"\bCP\s*575\s*([A-Z])?", re.IGNORECASE)
+
+
+def detect(text: str) -> bool:
+    needles = [
+        "CP 575",
+        "Employer Identification Number",
+        "Internal Revenue Service",
+        "Department of the Treasury",
+    ]
+    tl = text.lower()
+    return any(n.lower() in tl for n in needles)
+
+
+def parse_issue_date(text: str) -> Optional[str]:
+    for pat in DATE_CANDIDATES:
+        m = re.search(pat, text)
+        if m:
+            raw = m.group(1)
+            for fmt in ("%m-%d-%Y", "%B %d, %Y", "%b %d, %Y"):
+                try:
+                    return datetime.strptime(raw, fmt).date().isoformat()
+                except Exception:
+                    continue
+    return None
+
+
+def parse_business_name(text: str) -> Optional[str]:
+    for line in text.splitlines():
+        line_s = line.strip()
+        if (
+            len(line_s) > 2
+            and line_s.isupper()
+            and not any(
+                tok in line_s
+                for tok in [
+                    "INTERNAL REVENUE SERVICE",
+                    "DEPARTMENT",
+                    "UNITED STATES",
+                ]
+            )
+        ):
+            if not re.search(r"\d{3,}", line_s):
+                return line_s
+    return None
+
+
+def parse_address_block(text: str) -> Optional[str]:
+    lines = [l.rstrip() for l in text.splitlines()]
+    for i, l in enumerate(lines):
+        if re.search(r"\b[A-Z]{2}\s+\d{5}(-\d{4})?\b", l):
+            start = max(0, i - 2)
+            block = "\n".join(lines[start : i + 1])
+            return block
+    return None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    ein = None
+    m = EIN_RE.search(text)
+    if m:
+        ein = m.group(1)
+
+    issue_date = parse_issue_date(text)
+    business_name = parse_business_name(text)
+    address = parse_address_block(text)
+
+    notice = None
+    nm = NOTICE_RE.search(text)
+    if nm:
+        tail = nm.group(1) or ""
+        notice = ("CP 575 " + tail).strip()
+
+    fields: Dict[str, Any] = {}
+    if ein:
+        fields["ein"] = ein
+    if business_name:
+        fields["business_name"] = business_name
+    if address:
+        fields["address"] = address
+    if issue_date:
+        fields["issue_date"] = issue_date
+    if notice:
+        fields["notice_code"] = notice
+
+    conf = 0.6 + (0.1 if ein else 0) + (0.1 if issue_date else 0)
+
+    return {
+        "doc_type": "EIN_Letter",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]
+

--- a/ai-analyzer/tests/test_ein_letter.py
+++ b/ai-analyzer/tests/test_ein_letter.py
@@ -1,0 +1,48 @@
+from src.detectors import identify
+from src.extractors.ein_letter import detect, extract
+
+CLEAN_CP575 = """Department of the Treasury
+Internal Revenue Service
+Date: October 19, 2016
+ACME WIDGETS LLC
+123 MAIN ST
+ANYTOWN CA 12345
+This is your Employer Identification Number: 12-3456789
+Notice CP 575 G
+"""
+
+NOISY_CP575 = """CP 575 A
+Your Employer Identification Number is 98-7654321.
+Issued 10-20-2016
+"""
+
+NEGATIVE = "This letter has nothing to do with taxes."
+
+
+def test_detect_cp575():
+    assert detect(CLEAN_CP575) is True
+    det = identify(CLEAN_CP575)
+    assert det["type_key"] == "EIN_Letter"
+    out = extract(CLEAN_CP575, "uploads/sample.pdf")
+    assert out["doc_type"] == "EIN_Letter"
+    fields = out["fields"]
+    assert fields["ein"] == "12-3456789"
+    assert fields["issue_date"] == "2016-10-19"
+    assert fields["notice_code"] == "CP 575 G"
+    assert fields["business_name"] == "ACME WIDGETS LLC"
+    assert "ANYTOWN CA 12345" in fields["address"]
+
+
+def test_extract_noisy_variant():
+    assert detect(NOISY_CP575) is True
+    out = extract(NOISY_CP575, "uploads/noisy.pdf")
+    fields = out["fields"]
+    assert fields["ein"] == "98-7654321"
+    assert fields["issue_date"] == "2016-10-20"
+
+
+def test_negative_sample():
+    assert detect(NEGATIVE) is False
+    det = identify(NEGATIVE)
+    assert det == {}
+

--- a/server/tests/checklist.ein_letter.test.js
+++ b/server/tests/checklist.ein_letter.test.js
@@ -1,0 +1,119 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('EIN Letter checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        grantA: { required_docs: ['EIN_Letter'], common_docs: [] },
+        grantB: { required_docs: ['EIN_Letter'], common_docs: [] },
+      });
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes EIN letter and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility: both grants shortlisted
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'EIN_Letter'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload EIN letter -> analyzer then eligibility
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'EIN_Letter',
+          fields: { ein: '12-3456789' },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'grantA', score: 1 },
+            { key: 'grantB', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('dummy'), 'cp575.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'EIN_Letter'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Re-run eligibility with only one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ key: 'grantB', score: 1 }] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'EIN_Letter'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Checklist endpoint reflects uploaded EIN letter
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'EIN_Letter'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});
+

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -27,6 +27,7 @@
         },
         { "doc_type": "Tax_Payment_Receipt", "min_count": 1 },
         { "doc_type": "Articles_Of_Incorporation", "min_count": 1 },
+        { "doc_type": "EIN_Letter", "min_count": 1 },
         { "doc_type": "IRS_941X", "min_count": 0, "max_count": 10, "label": "Form 941-X (if corrections/claims)" },
         {
           "key": "filed_returns_original_and_amended",

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -67,6 +67,29 @@
         "state_of_incorporation": "string",
         "registered_agent": "string"
       }
+    },
+    "EIN_Letter": {
+      "detector": {
+        "keywords": [
+          "CP 575",
+          "EIN Confirmation Letter",
+          "Employer Identification Number",
+          "Internal Revenue Service",
+          "Department of the Treasury",
+          "This is your Employer Identification Number"
+        ]
+      },
+      "extractor": "ein_letter",
+      "fields": {
+        "ein": "string",
+        "business_name": "string",
+        "address": "string",
+        "issue_date": "date",
+        "notice_code": "string"
+      },
+      "examples": [
+        "IRS Notice CP-575 EIN assignment letter"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- recognize EIN_Letter in analyzer with new detector and extractor
- require EIN_Letter for grants needing EIN proof
- add EIN Letter checklist integration test

## Testing
- `pytest ai-analyzer/tests/test_ein_letter.py -q`
- `npm test` *(fails: fetch failed / eligibility engine unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b48ed027e08327bc065fc4b4b2caeb