### PR TITLE
feat: support W-9 form documents

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -35,6 +35,7 @@ EXTRACTORS = {
     "Business_License": ("business_license", "extract"),
     "Articles_Of_Incorporation": ("articles_of_incorporation", "extract"),
     "EIN_Letter": ("ein_letter", "extract"),
+    "W9_Form": ("w9_form", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -1,0 +1,107 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+EIN_RE = re.compile(r"\b\d{2}-\d{7}\b")
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+DATE_PATS = [
+    r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b",
+    r"\b[A-Za-z]{3,9}\s+\d{1,2},\s+\d{4}\b",
+]
+
+
+def detect(text: str) -> bool:
+    tl = text.lower()
+    needles = [
+        "form w-9",
+        "request for taxpayer identification number and certification",
+        "taxpayer identification number",
+        "tin",
+    ]
+    return any(n in tl for n in needles)
+
+
+def _parse_date(text: str) -> Optional[str]:
+    for pat in DATE_PATS:
+        m = re.search(pat, text)
+        if m:
+            raw = m.group(0)
+            for fmt in (
+                "%m/%d/%Y",
+                "%m-%d-%Y",
+                "%m/%d/%y",
+                "%B %d, %Y",
+                "%b %d, %Y",
+            ):
+                try:
+                    return datetime.strptime(raw, fmt).date().isoformat()
+                except Exception:
+                    pass
+    return None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    ein = EIN_RE.search(text)
+    ssn = SSN_RE.search(text)
+    tin = ein.group(0) if ein else (ssn.group(0) if ssn else None)
+
+    legal_name = None
+    m_name = re.search(r"(?:Name|Legal Name)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
+    if m_name:
+        legal_name = m_name.group(1).strip()
+
+    business_name = None
+    m_biz = re.search(r"(?:Business\s+name|DBA)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
+    if m_biz:
+        business_name = m_biz.group(1).strip()
+
+    entity_type = None
+    et = re.search(
+        r"\b(LLC|Corporation|C[ -]?Corp|S[ -]?Corp|Sole Propriet(?:or|orship)|Partnership|Nonprofit)\b",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if et:
+        entity_type = et.group(0)
+
+    address = None
+    for line in text.splitlines():
+        if re.search(r"\b[A-Z]{2}\s+\d{5}(-\d{4})?\b", line):
+            address = line.strip()
+            break
+
+    signature_date = _parse_date(text)
+
+    fields: Dict[str, Any] = {}
+    if legal_name:
+        fields["legal_name"] = legal_name
+    if business_name:
+        fields["business_name"] = business_name
+    if entity_type:
+        fields["entity_type"] = entity_type
+    if tin:
+        fields["tin"] = tin
+    if address:
+        fields["address"] = address
+    if signature_date:
+        fields["signature_date"] = signature_date
+
+    conf = 0.6 + (0.1 if tin else 0) + (0.1 if legal_name else 0)
+
+    return {
+        "doc_type": "W9_Form",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -1,0 +1,33 @@
+from src.detectors import identify
+from src.detectors import identify
+from src.extractors.w9_form import detect, extract
+
+SAMPLE = """Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+Name: John Doe
+Business name: JD Widgets LLC
+TIN: 12-3456789
+Address: 123 Main St Anytown CA 90210
+Signature: John Doe   01/15/2024
+"""
+
+NEGATIVE = "This is just a random letter with no tax info."
+
+
+def test_detect_and_extract():
+    assert detect(SAMPLE) is True
+    det = identify(SAMPLE)
+    assert det["type_key"] == "W9_Form"
+    out = extract(SAMPLE, "uploads/w9.pdf")
+    assert out["doc_type"] == "W9_Form"
+    fields = out["fields"]
+    assert fields["tin"] == "12-3456789"
+    assert fields["legal_name"].startswith("John Doe")
+    assert fields["entity_type"].upper() == "LLC"
+    assert fields["signature_date"] == "2024-01-15"
+
+
+def test_negative_sample():
+    assert detect(NEGATIVE) is False
+    det = identify(NEGATIVE)
+    assert det == {}

--- a/frontend/src/components/PreUploadWizard.tsx
+++ b/frontend/src/components/PreUploadWizard.tsx
@@ -10,9 +10,10 @@ export interface CommonDoc {
 
 const COMMON_DOCS: CommonDoc[] = [
   {
-    doc_type: "W9",
-    title: "IRS W-9",
-    description: "Provides your taxpayer identification number.",
+    doc_type: "W9_Form",
+    title: "IRS Form W-9 (Request for TIN)",
+    description:
+      "Signed IRS W-9 showing your TIN (SSN/EIN), legal name, entity type, and address.",
     example_url: "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
   },
   {

--- a/frontend/tests/document-checklist.test.tsx
+++ b/frontend/tests/document-checklist.test.tsx
@@ -20,11 +20,11 @@ test("renders and dedupes documents", async () => {
   (api.get as jest.Mock).mockResolvedValue({
     data: [
       {
-        doc_type: "W9",
+        doc_type: "W9_Form",
         source: "common",
         grants: [],
         status: "not_uploaded",
-        description: "W9 form",
+        description: "IRS Form W-9 (Request for TIN)",
         example_url: "http://example.com/w9",
       },
       {
@@ -48,7 +48,7 @@ test("renders and dedupes documents", async () => {
 
   render(<DocumentChecklist caseId="123" />);
 
-  expect(await screen.findByText("W9")).toBeInTheDocument();
+  expect(await screen.findByText("W9_Form")).toBeInTheDocument();
   expect(await screen.findByText("IRS_941X")).toBeInTheDocument();
   expect(screen.getAllByText("IRS_941X")).toHaveLength(1);
   expect(screen.getByText("Required by: GrantA, GrantB")).toBeInTheDocument();
@@ -60,7 +60,7 @@ test("uploads document and refreshes status", async () => {
     .mockResolvedValueOnce({
       data: [
         {
-          doc_type: "W9",
+          doc_type: "W9_Form",
           source: "common",
           grants: [],
           status: "not_uploaded",
@@ -70,7 +70,7 @@ test("uploads document and refreshes status", async () => {
     .mockResolvedValueOnce({
       data: [
         {
-          doc_type: "W9",
+          doc_type: "W9_Form",
           source: "common",
           grants: [],
           status: "uploaded",
@@ -86,7 +86,7 @@ test("uploads document and refreshes status", async () => {
 
   render(<DocumentChecklist caseId="case123" />);
 
-  const input = (await screen.findByText("W9"))
+  const input = (await screen.findByText("W9_Form"))
     .closest("li")!
     .querySelector("input[type=file]") as HTMLInputElement;
 
@@ -98,7 +98,7 @@ test("uploads document and refreshes status", async () => {
   expect(uploadFile).toHaveBeenCalledWith(expect.any(FormData));
   const form = (uploadFile as jest.Mock).mock.calls[0][0] as FormData;
   expect(form.get("caseId")).toBe("case123");
-  expect(form.get("key")).toBe("W9");
+  expect(form.get("key")).toBe("W9_Form");
 
   expect(await screen.findByText("uploaded")).toBeInTheDocument();
   expect((api.get as jest.Mock)).toHaveBeenCalledTimes(2);
@@ -109,17 +109,17 @@ test('refreshes when eligibility changes', async () => {
   (api.get as jest.Mock)
     .mockResolvedValueOnce({
       data: [
-        { doc_type: 'W9', source: 'common', grants: [], status: 'not_uploaded' },
+        { doc_type: 'W9_Form', source: 'common', grants: [], status: 'not_uploaded' },
       ],
     })
     .mockResolvedValueOnce({
       data: [
-        { doc_type: 'W9', source: 'common', grants: [], status: 'uploaded' },
+        { doc_type: 'W9_Form', source: 'common', grants: [], status: 'uploaded' },
       ],
     });
 
   render(<DocumentChecklist caseId="abc" />);
-  expect(await screen.findByText('W9')).toBeInTheDocument();
+  expect(await screen.findByText('W9_Form')).toBeInTheDocument();
 
   act(() => {
     window.dispatchEvent(

--- a/server/tests/checklist.w9.test.js
+++ b/server/tests/checklist.w9.test.js
@@ -1,0 +1,120 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+let getCase;
+
+describe('W9 checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    getCase = store.getCase;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        grantA: { required_docs: ['W9_Form'], common_docs: [] },
+        grantB: { required_docs: ['W9_Form'], common_docs: [] },
+      });
+    const CaseModel = require('../models/Case');
+    jest.spyOn(CaseModel, 'findOne').mockImplementation(({ caseId }) => ({
+      lean: async () => ({ ...(await getCase('dev-user', caseId)) }),
+    }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes W9 form and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'W9_Form'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'W9_Form',
+          fields: { tin: '12-3456789' },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'grantA', score: 1 },
+            { key: 'grantB', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('dummy'), 'w9.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'W9_Form'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ key: 'grantB', score: 1 }] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'W9_Form'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'W9_Form'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});

--- a/server/tests/checklistBuilder.test.js
+++ b/server/tests/checklistBuilder.test.js
@@ -4,11 +4,11 @@ describe('buildChecklist', () => {
   const grantsLibrary = {
     erc: {
       required_docs: ['IRS_941X'],
-      common_docs: ['W9'],
+      common_docs: ['W9_Form'],
     },
     business_tax_refund: {
       required_docs: ['IRS_941X', 'Tax_Payment_Receipt'],
-      common_docs: ['W9', 'FEIN'],
+      common_docs: ['W9_Form', 'FEIN'],
     },
   };
 
@@ -29,14 +29,14 @@ describe('buildChecklist', () => {
     });
 
     const order = required.map((d) => d.doc_type);
-    expect(order).toEqual(['FEIN', 'W9', 'IRS_941X', 'Tax_Payment_Receipt']);
+    expect(order).toEqual(['FEIN', 'W9_Form', 'IRS_941X', 'Tax_Payment_Receipt']);
 
     const irs = required.find((d) => d.doc_type === 'IRS_941X');
     expect(irs.source).toBe('grant');
     expect(irs.grants.sort()).toEqual(['business_tax_refund', 'erc']);
     expect(irs.status).toBe('uploaded');
 
-    const w9 = required.find((d) => d.doc_type === 'W9');
+    const w9 = required.find((d) => d.doc_type === 'W9_Form');
     expect(w9.source).toBe('common');
     expect(w9.grants).toEqual([]);
     expect(w9.status).toBe('not_uploaded');

--- a/server/utils/checklistBuilder.js
+++ b/server/utils/checklistBuilder.js
@@ -15,12 +15,12 @@ async function buildChecklist({
 }) {
   const lower = (s) => (s || '').toLowerCase();
 
-  const commonDocs = new Set();
+  const commonDocs = new Map(); // lower -> original
   const grantDocsMap = new Map(); // docTypeLower -> { doc_type, grants: Set() }
 
   for (const g of shortlistedGrants || []) {
     const cfg = grantsLibrary[g] || {};
-    for (const d of cfg.common_docs || []) commonDocs.add(lower(d));
+    for (const d of cfg.common_docs || []) commonDocs.set(lower(d), d);
     for (const d of cfg.required_docs || []) {
       const k = lower(d);
       if (!grantDocsMap.has(k)) {
@@ -34,8 +34,8 @@ async function buildChecklist({
   // Merge & dedupe
   const merged = new Map(); // key -> item
   // a) common first
-  for (const dLower of commonDocs) {
-    const docType = grantDocsMap.get(dLower)?.doc_type || dLower.toUpperCase();
+  for (const [dLower, original] of commonDocs) {
+    const docType = grantDocsMap.get(dLower)?.doc_type || original;
     merged.set(dLower, {
       doc_type: docType,
       source: 'common',

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -2,7 +2,7 @@
   "version": 1,
   "common_documents": [
     { "doc_type": "Tax_Payment_Receipt", "label": "Tax payment receipt / confirmation" },
-    { "doc_type": "W9", "label": "IRS W-9" },
+    { "doc_type": "W9_Form", "label": "IRS W-9" },
     { "doc_type": "EIN_Letter", "label": "EIN Letter (CP-575)" },
     {
       "doc_type": "Basic_Financials",
@@ -68,6 +68,7 @@
         "Business_License",
         "Articles_Of_Incorporation",
         "EIN_Letter",
+        "W9_Form",
         "Financials_Basic",
         "Tax_Returns",
         "Business_Plan",
@@ -81,6 +82,7 @@
         "Business_License",
         "Articles_Of_Incorporation",
         "EIN_Letter",
+        "W9_Form",
         "Financials_Basic",
         "Tax_Returns",
         "Business_Plan",
@@ -94,6 +96,7 @@
         "Business_License",
         "Articles_Of_Incorporation",
         "EIN_Letter",
+        "W9_Form",
         "Financials_Basic",
         "Tax_Returns",
         "Business_Plan",

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -90,6 +90,29 @@
       "examples": [
         "IRS Notice CP-575 EIN assignment letter"
       ]
+    },
+    "W9_Form": {
+      "extractor": "w9_form",
+      "detector": {
+        "keywords": [
+          "Form W-9",
+          "Request for Taxpayer Identification Number and Certification",
+          "W-9 (Rev.",
+          "Taxpayer Identification Number",
+          "TIN",
+          "Employer Identification Number",
+          "Social Security Number"
+        ]
+      },
+      "fields": {
+        "legal_name": "string",
+        "business_name": "string",
+        "entity_type": "string",
+        "tin": "string",
+        "address": "string",
+        "signature_date": "date"
+      },
+      "examples": ["IRS Form W-9"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add IRS W-9 to document catalog and grants
- implement W-9 detector/extractor in analyzer
- surface W9 requirements in checklist and tests

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py -q`
- `npx jest tests/checklistBuilder.test.js tests/checklist.w9.test.js --runInBand`
- `npm test` *(fails: eligibility engine unreachable / DB operations)*

------
https://chatgpt.com/codex/tasks/task_b_68b493c82258832796ba072fd3fdbd8f