### PR TITLE
Add financial statement document support

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -22,6 +22,8 @@ def _load_doc_types() -> dict:
                 "keywords_any": det.get("keywords", []),
                 "regex_any": det.get("regex", []),
             }
+        if "identify" not in out[key]:
+            out[key]["identify"] = {"keywords_any": [], "regex_any": []}
     return out
 
 
@@ -36,6 +38,8 @@ EXTRACTORS = {
     "Articles_Of_Incorporation": ("articles_of_incorporation", "extract"),
     "EIN_Letter": ("ein_letter", "extract"),
     "W9_Form": ("w9_form", "extract"),
+    "Profit_And_Loss_Statement": ("p_and_l_statement", "extract"),
+    "Balance_Sheet": ("balance_sheet", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/balance_sheet.py
+++ b/ai-analyzer/src/extractors/balance_sheet.py
@@ -1,0 +1,75 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+MONEY = r"[-+]?\$?\s?\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?"
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return ("balance sheet" in t) or ("statement of financial position" in t)
+
+
+def _parse_date(text: str) -> Optional[str]:
+    m = re.search(
+        r"(?:as of|as at)\s+([A-Za-z]{3,9}\s+\d{1,2},\s+\d{4}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|\d{4}-\d{2}-\d{2})",
+        text,
+        re.IGNORECASE,
+    )
+    if m:
+        raw = m.group(1)
+        for fmt in ("%B %d, %Y", "%b %d, %Y", "%m/%d/%Y", "%m-%d-%Y", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(raw, fmt).date().isoformat()
+            except Exception:
+                pass
+    return None
+
+
+def _find_amount(label: str, text: str) -> Optional[str]:
+    pat = re.compile(rf"(?:{label}).*?({MONEY})", re.IGNORECASE)
+    m = pat.search(text)
+    return m.group(1).replace("$", "").replace(",", "").strip() if m else None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    fields: Dict[str, Any] = {}
+    as_of = _parse_date(text)
+    if as_of:
+        fields["as_of_date"] = as_of
+
+    fields["total_assets"] = _find_amount("total assets", text)
+    fields["total_liabilities"] = _find_amount("total liabilities", text)
+    fields["total_equity"] = _find_amount("total equity|shareholders'? equity|members'? equity", text)
+
+    for k in ["total_assets", "total_liabilities", "total_equity"]:
+        v = fields.get(k)
+        if isinstance(v, str):
+            try:
+                fields[k] = float(v.replace("$", "").replace(",", ""))
+            except Exception:
+                pass
+
+    conf = 0.65
+    if fields.get("total_assets") is not None:
+        conf += 0.05
+    if fields.get("total_equity") is not None:
+        conf += 0.05
+
+    return {
+        "doc_type": "Balance_Sheet",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/src/extractors/p_and_l_statement.py
+++ b/ai-analyzer/src/extractors/p_and_l_statement.py
@@ -1,0 +1,78 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+DATE_RANGE = re.compile(r"(?:For the|For)\s+(?:period|year|quarter)\s+(.*?)(?:-|to)\s+(.*)", re.IGNORECASE)
+MONEY = r"[-+]?\$?\s?\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?"
+
+
+def _parse_date(s: str) -> Optional[str]:
+    for fmt in ("%b %d, %Y", "%B %d, %Y", "%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s.strip(), fmt).date().isoformat()
+        except Exception:
+            pass
+    return None
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return any(k in t for k in ["profit and loss", "p&l", "income statement", "statement of operations"])
+
+
+def _find_amount(label: str, text: str) -> Optional[str]:
+    pat = re.compile(rf"(?:{label}).*?({MONEY})", re.IGNORECASE)
+    m = pat.search(text)
+    return m.group(1).replace("$", "").replace(",", "").strip() if m else None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    period_start = period_end = None
+    m = DATE_RANGE.search(text)
+    if m:
+        period_start = _parse_date(m.group(1))
+        period_end = _parse_date(m.group(2))
+
+    fields: Dict[str, Any] = {}
+    if period_start:
+        fields["period_start"] = period_start
+    if period_end:
+        fields["period_end"] = period_end
+
+    fields["total_revenue"] = _find_amount("total revenue|revenue|sales", text)
+    fields["cogs"] = _find_amount("cost of goods sold|cogs", text)
+    fields["gross_profit"] = _find_amount("gross profit", text)
+    fields["total_expenses"] = _find_amount("total expenses", text)
+    fields["net_income"] = _find_amount("net income|net profit|loss", text)
+
+    for k in list(fields.keys()):
+        v = fields[k]
+        if isinstance(v, str):
+            try:
+                fields[k] = float(v.replace("$", "").replace(",", ""))
+            except Exception:
+                pass
+
+    conf = 0.65
+    if fields.get("net_income") is not None:
+        conf += 0.05
+    if fields.get("total_revenue") is not None:
+        conf += 0.05
+
+    return {
+        "doc_type": "Profit_And_Loss_Statement",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/test_balance_sheet.py
+++ b/ai-analyzer/tests/test_balance_sheet.py
@@ -1,0 +1,30 @@
+from src.detectors import identify
+from src.extractors.balance_sheet import detect, extract
+
+SAMPLE = """Balance Sheet
+As of December 31, 2024
+Total Assets $750,000
+Total Liabilities $300,000
+Total Equity $450,000
+"""
+
+NEGATIVE = "This is not a financial statement."
+
+
+def test_detect_and_extract():
+    assert detect(SAMPLE) is True
+    det = identify(SAMPLE)
+    assert det["type_key"] == "Balance_Sheet"
+    out = extract(SAMPLE, "bs.pdf")
+    assert out["doc_type"] == "Balance_Sheet"
+    fields = out["fields"]
+    assert fields["as_of_date"] == "2024-12-31"
+    assert fields["total_assets"] == 750000.0
+    assert fields["total_liabilities"] == 300000.0
+    assert fields["total_equity"] == 450000.0
+
+
+def test_negative_sample():
+    assert detect(NEGATIVE) is False
+    det = identify(NEGATIVE)
+    assert det == {}

--- a/ai-analyzer/tests/test_p_and_l_statement.py
+++ b/ai-analyzer/tests/test_p_and_l_statement.py
@@ -1,0 +1,32 @@
+from src.detectors import identify
+from src.extractors.p_and_l_statement import detect, extract
+
+SAMPLE = """Profit and Loss Statement
+For the period Jan 1, 2024 - Dec 31, 2024
+Total Revenue $500,000
+Cost of Goods Sold $200,000
+Gross Profit $300,000
+Total Expenses $250,000
+Net Income $50,000
+"""
+
+NEGATIVE = "This document discusses future plans only."
+
+
+def test_detect_and_extract():
+    assert detect(SAMPLE) is True
+    det = identify(SAMPLE)
+    assert det["type_key"] == "Profit_And_Loss_Statement"
+    out = extract(SAMPLE, "pnl.pdf")
+    assert out["doc_type"] == "Profit_And_Loss_Statement"
+    fields = out["fields"]
+    assert fields["period_start"] == "2024-01-01"
+    assert fields["period_end"] == "2024-12-31"
+    assert fields["total_revenue"] == 500000.0
+    assert fields["net_income"] == 50000.0
+
+
+def test_negative_sample():
+    assert detect(NEGATIVE) is False
+    det = identify(NEGATIVE)
+    assert det == {}

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -207,5 +207,65 @@
     "aliases": [],
     "target": "ertc_reference",
     "type": "bool"
+  },
+  "period_start": {
+    "aliases": ["periodStart"],
+    "target": "period_start",
+    "type": "date"
+  },
+  "period_end": {
+    "aliases": ["periodEnd"],
+    "target": "period_end",
+    "type": "date"
+  },
+  "total_revenue": {
+    "aliases": ["revenue", "totalRevenue"],
+    "target": "total_revenue",
+    "type": "currency"
+  },
+  "cogs": {
+    "aliases": ["cost_of_goods_sold", "costOfGoodsSold"],
+    "target": "cogs",
+    "type": "currency"
+  },
+  "gross_profit": {
+    "aliases": ["grossProfit"],
+    "target": "gross_profit",
+    "type": "currency"
+  },
+  "total_expenses": {
+    "aliases": ["expensesTotal", "totalExpenses"],
+    "target": "total_expenses",
+    "type": "currency"
+  },
+  "net_income": {
+    "aliases": ["netIncome", "net_profit", "netProfit", "loss"],
+    "target": "net_income",
+    "type": "currency"
+  },
+  "as_of_date": {
+    "aliases": ["asOf", "as_of", "asOfDate"],
+    "target": "as_of_date",
+    "type": "date"
+  },
+  "total_assets": {
+    "aliases": ["assetsTotal", "totalAssets"],
+    "target": "total_assets",
+    "type": "currency"
+  },
+  "total_liabilities": {
+    "aliases": ["liabilitiesTotal", "totalLiabilities"],
+    "target": "total_liabilities",
+    "type": "currency"
+  },
+  "total_equity": {
+    "aliases": ["equityTotal", "totalEquity", "shareholders_equity", "shareholdersEquity"],
+    "target": "total_equity",
+    "type": "currency"
+  },
+  "currency": {
+    "aliases": [],
+    "target": "currency",
+    "type": "string"
   }
 }

--- a/server/tests/checklist.financial_statements.test.js
+++ b/server/tests/checklist.financial_statements.test.js
@@ -1,0 +1,153 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+let getCase;
+
+describe('Financial Statements checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    getCase = store.getCase;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        grantA: { required_docs: ['Financial_Statements'], common_docs: [] },
+        grantB: { required_docs: ['Financial_Statements'], common_docs: [] },
+      });
+    const CaseModel = require('../models/Case');
+    jest.spyOn(CaseModel, 'findOne').mockImplementation(({ caseId }) => ({
+      lean: async () => ({ ...(await getCase('dev-user', caseId)) }),
+    }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('expands financial statements and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter((d) =>
+      ['Profit_And_Loss_Statement', 'Balance_Sheet'].includes(d.doc_type)
+    );
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.status)).toEqual(['not_uploaded', 'not_uploaded']);
+
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Profit_And_Loss_Statement',
+          fields: { total_revenue: 1000, net_income: 100 },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'grantA', score: 1 },
+            { key: 'grantB', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('dummy'), 'pnl.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter((d) =>
+      ['Profit_And_Loss_Statement', 'Balance_Sheet'].includes(d.doc_type)
+    );
+    const statusAfterPnl = items.reduce((m, i) => ({ ...m, [i.doc_type]: i.status }), {});
+    expect(statusAfterPnl['Profit_And_Loss_Statement']).toBe('extracted');
+    expect(statusAfterPnl['Balance_Sheet']).toBe('not_uploaded');
+
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Balance_Sheet',
+          fields: { total_assets: 2000, total_equity: 2000 },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'grantA', score: 1 },
+            { key: 'grantB', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('dummy'), 'bs.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter((d) =>
+      ['Profit_And_Loss_Statement', 'Balance_Sheet'].includes(d.doc_type)
+    );
+    const statusAfterBs = items.reduce((m, i) => ({ ...m, [i.doc_type]: i.status }), {});
+    expect(statusAfterBs['Profit_And_Loss_Statement']).toBe('extracted');
+    expect(statusAfterBs['Balance_Sheet']).toBe('extracted');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ key: 'grantB', score: 1 }] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter((d) =>
+      ['Profit_And_Loss_Statement', 'Balance_Sheet'].includes(d.doc_type)
+    );
+    items.forEach((i) => expect(i.status).toBe('extracted'));
+
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter((d) =>
+      ['Profit_And_Loss_Statement', 'Balance_Sheet'].includes(d.doc_type)
+    );
+    expect(checklistItems).toHaveLength(2);
+    checklistItems.forEach((i) => expect(i.status).toBe('extracted'));
+  });
+});

--- a/server/utils/checklistBuilder.js
+++ b/server/utils/checklistBuilder.js
@@ -15,18 +15,26 @@ async function buildChecklist({
 }) {
   const lower = (s) => (s || '').toLowerCase();
 
+  const expandDocTypes = (d) =>
+    d === 'Financial_Statements'
+      ? ['Profit_And_Loss_Statement', 'Balance_Sheet']
+      : [d];
+
   const commonDocs = new Map(); // lower -> original
   const grantDocsMap = new Map(); // docTypeLower -> { doc_type, grants: Set() }
 
   for (const g of shortlistedGrants || []) {
     const cfg = grantsLibrary[g] || {};
-    for (const d of cfg.common_docs || []) commonDocs.set(lower(d), d);
+    for (const d of cfg.common_docs || [])
+      for (const doc of expandDocTypes(d)) commonDocs.set(lower(doc), doc);
     for (const d of cfg.required_docs || []) {
-      const k = lower(d);
-      if (!grantDocsMap.has(k)) {
-        grantDocsMap.set(k, { doc_type: d, grants: new Set([g]) });
-      } else {
-        grantDocsMap.get(k).grants.add(g);
+      for (const doc of expandDocTypes(d)) {
+        const k = lower(doc);
+        if (!grantDocsMap.has(k)) {
+          grantDocsMap.set(k, { doc_type: doc, grants: new Set([g]) });
+        } else {
+          grantDocsMap.get(k).grants.add(g);
+        }
       }
     }
   }

--- a/server/utils/documentLibrary.js
+++ b/server/utils/documentLibrary.js
@@ -48,10 +48,17 @@ function getRequiredDocs(grantKey, caseDocs = []) {
   const g = lib.grants[grantKey];
   if (!g) return null;
   const types = loadDocTypes();
+  const expandDocType = (d) =>
+    d.doc_type === 'Financial_Statements'
+      ? [
+          { ...d, doc_type: 'Profit_And_Loss_Statement' },
+          { ...d, doc_type: 'Balance_Sheet' },
+        ]
+      : [d];
   const all = [
     ...(lib.common_documents || []),
     ...(g.required_documents || []),
-  ];
+  ].flatMap(expandDocType);
   const seen = new Map();
   for (const d of all) {
     const key = d.doc_type || d.key;

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -5,8 +5,8 @@
     { "doc_type": "W9_Form", "label": "IRS W-9" },
     { "doc_type": "EIN_Letter", "label": "EIN Letter (CP-575)" },
     {
-      "doc_type": "Basic_Financials",
-      "label": "Basic Financials (P&L / Balance Sheet)"
+      "doc_type": "Financial_Statements",
+      "label": "Financial Statements (P&L and Balance Sheet)"
     },
     {
       "doc_type": "Basic_Tax_Return",
@@ -69,7 +69,7 @@
         "Articles_Of_Incorporation",
         "EIN_Letter",
         "W9_Form",
-        "Financials_Basic",
+        "Financial_Statements",
         "Tax_Returns",
         "Business_Plan",
         "Grant_Use_Statement"
@@ -83,7 +83,7 @@
         "Articles_Of_Incorporation",
         "EIN_Letter",
         "W9_Form",
-        "Financials_Basic",
+        "Financial_Statements",
         "Tax_Returns",
         "Business_Plan",
         "Grant_Use_Statement"
@@ -97,7 +97,7 @@
         "Articles_Of_Incorporation",
         "EIN_Letter",
         "W9_Form",
-        "Financials_Basic",
+        "Financial_Statements",
         "Tax_Returns",
         "Business_Plan",
         "Grant_Use_Statement"

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -113,6 +113,57 @@
         "signature_date": "date"
       },
       "examples": ["IRS Form W-9"]
+    },
+    "Profit_And_Loss_Statement": {
+      "extractor": "p_and_l_statement",
+      "detector": {
+        "keywords": [
+          "Profit and Loss",
+          "P&L",
+          "Income Statement",
+          "Statement of Operations"
+        ]
+      },
+      "fields": {
+        "period_start": "date",
+        "period_end": "date",
+        "total_revenue": "number",
+        "cogs": "number",
+        "gross_profit": "number",
+        "total_expenses": "number",
+        "net_income": "number",
+        "currency": "string"
+      },
+      "examples": [
+        "P&L statement showing revenues, expenses and net income"
+      ]
+    },
+    "Balance_Sheet": {
+      "extractor": "balance_sheet",
+      "detector": {
+        "keywords": [
+          "Balance Sheet",
+          "Statement of Financial Position"
+        ]
+      },
+      "fields": {
+        "as_of_date": "date",
+        "total_assets": "number",
+        "total_liabilities": "number",
+        "total_equity": "number",
+        "currency": "string"
+      },
+      "examples": [
+        "Balance Sheet showing Assets, Liabilities, Equity"
+      ]
+    },
+    "Financial_Statements": {
+      "composite": true,
+      "expands_to": [
+        "Profit_And_Loss_Statement",
+        "Balance_Sheet"
+      ],
+      "description": "Complete financial statements (P&L and Balance Sheet)"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Profit & Loss Statement and Balance Sheet document types and composite Financial_Statements
- expand checklist and document library to handle Financial_Statements
- add extractors and tests for P&L and Balance Sheet

## Testing
- `pytest ai-analyzer/tests/test_p_and_l_statement.py -q`
- `pytest ai-analyzer/tests/test_balance_sheet.py -q`
- `cd server && npm test tests/checklist.financial_statements.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b5c44602f483279af30560a9d1bd38