### PR TITLE
feat: add business plan document type

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -40,6 +40,7 @@ EXTRACTORS = {
     "W9_Form": ("w9_form", "extract"),
     "Profit_And_Loss_Statement": ("p_and_l_statement", "extract"),
     "Balance_Sheet": ("balance_sheet", "extract"),
+    "Business_Plan": ("business_plan", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/__init__.py
+++ b/ai-analyzer/src/extractors/__init__.py
@@ -1,0 +1,10 @@
+from .business_plan import detect as detect_business_plan, extract as extract_business_plan
+
+EXTRACTORS = {
+    "business_plan": {
+        "detect": detect_business_plan,
+        "extract": extract_business_plan,
+    }
+}
+
+__all__ = ["EXTRACTORS", "detect_business_plan", "extract_business_plan"]

--- a/ai-analyzer/src/extractors/business_plan.py
+++ b/ai-analyzer/src/extractors/business_plan.py
@@ -1,0 +1,154 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+SECONDARY_SECTIONS = [
+    "Executive Summary",
+    "Market Analysis",
+    "Financial Projections",
+    "Funding Request",
+]
+
+
+def detect(text: str) -> bool:
+    tl = text.lower()
+    if "business plan" not in tl:
+        return False
+    return any(sec.lower() in tl for sec in SECONDARY_SECTIONS)
+
+
+def _parse_business_name(text: str) -> Optional[str]:
+    for line in text.splitlines():
+        line_s = line.strip()
+        if (
+            line_s
+            and line_s.isupper()
+            and not any(ch.isdigit() for ch in line_s)
+            and "BUSINESS PLAN" not in line_s
+        ):
+            return line_s
+    return None
+
+
+SENTENCE_RE = re.compile(r"[^.!?]+[.!?]")
+
+
+def _extract_executive_summary(text: str) -> Optional[str]:
+    m = re.search(r"Executive Summary\s*(.+)", text, re.IGNORECASE | re.DOTALL)
+    if not m:
+        return None
+    after = m.group(1).strip()
+    sentences = SENTENCE_RE.findall(after)
+    if not sentences:
+        return None
+    return " ".join(sentences[:6]).strip()
+
+
+AMOUNT_RE = re.compile(
+    r"(funding request|grant amount|funding amount|use of funds)[^\d$]*(\$?[\d,]+)",
+    re.IGNORECASE,
+)
+
+
+def _parse_amount(text: str) -> Optional[int]:
+    m = AMOUNT_RE.search(text)
+    if not m:
+        return None
+    raw = m.group(2).replace("$", "").replace(",", "")
+    try:
+        return int(raw)
+    except ValueError:
+        try:
+            return int(float(raw))
+        except ValueError:
+            return None
+
+
+PERIOD_RE = re.compile(r"(\d+)[-\s]?year (projection|forecast|plan)", re.IGNORECASE)
+
+
+def _parse_period_years(text: str) -> Optional[int]:
+    m = PERIOD_RE.search(text)
+    if m:
+        try:
+            return int(m.group(1))
+        except ValueError:
+            return None
+    return None
+
+
+DATE_PATTERNS = [
+    (re.compile(r"(\d{1,2}/\d{1,2}/\d{4})"), ["%m/%d/%Y"]),
+    (
+        re.compile(
+            r"((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4})"
+        ),
+        ["%B %d, %Y"],
+    ),
+]
+
+
+def _parse_last_updated(text: str) -> Optional[str]:
+    lines = text.splitlines()[:20]
+    for line in lines:
+        for rx, fmts in DATE_PATTERNS:
+            m = rx.search(line)
+            if m:
+                raw = m.group(1)
+                for fmt in fmts:
+                    try:
+                        return datetime.strptime(raw, fmt).date().isoformat()
+                    except Exception:
+                        continue
+    return None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    business_name = _parse_business_name(text)
+    executive_summary = _extract_executive_summary(text)
+    amount = _parse_amount(text)
+    period_years = _parse_period_years(text)
+    last_updated = _parse_last_updated(text)
+
+    fields: Dict[str, Any] = {}
+    if business_name:
+        fields["business_name"] = business_name
+    if executive_summary:
+        fields["executive_summary"] = executive_summary
+    if amount is not None:
+        fields["funding_request_amount"] = amount
+    if period_years is not None:
+        fields["period_years"] = period_years
+    if last_updated:
+        fields["last_updated"] = last_updated
+
+    conf = 0.6
+    if business_name:
+        conf += 0.1
+    if executive_summary:
+        conf += 0.1
+    if amount is not None:
+        conf += 0.05
+    if period_years is not None:
+        conf += 0.05
+    if last_updated:
+        conf += 0.05
+
+    return {
+        "doc_type": "Business_Plan",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]
+

--- a/ai-analyzer/tests/fixtures/business_plan_sample.txt
+++ b/ai-analyzer/tests/fixtures/business_plan_sample.txt
@@ -1,0 +1,17 @@
+ACME MOTORS LLC
+Business Plan
+Last updated: August 31, 2025
+
+Executive Summary
+Acme Motors builds modular electric drivetrains for lightweight vehicles...
+We request a funding amount of $125,000 to expand manufacturing capacity
+and finance a 3-year go-to-market plan.
+
+Company Description
+...
+
+Market Analysis
+...
+
+Financial Projections
+We provide a 3-year projection with break-even in year 2...

--- a/ai-analyzer/tests/test_business_plan.py
+++ b/ai-analyzer/tests/test_business_plan.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from pathlib import Path
+from src.detectors import identify
+from src.extractors.business_plan import detect, extract
+
+SAMPLE = (Path(__file__).resolve().parent / "fixtures" / "business_plan_sample.txt").read_text()
+NEGATIVE = "This document talks about operations but lacks a plan."
+
+
+def test_detect_and_extract_business_plan():
+    assert detect(SAMPLE) is True
+    det = identify(SAMPLE)
+    assert det["type_key"] == "Business_Plan"
+    out = extract(SAMPLE, "uploads/bizplan.pdf")
+    assert out["doc_type"] == "Business_Plan"
+    fields = out["fields"]
+    assert fields["business_name"] == "ACME MOTORS LLC"
+    assert "Acme Motors builds modular electric drivetrains" in fields["executive_summary"]
+    assert fields["funding_request_amount"] == 125000
+    assert fields["period_years"] == 3
+    assert fields["last_updated"] == "2025-08-31"
+
+
+def test_negative_sample():
+    assert detect(NEGATIVE) is False
+    det = identify(NEGATIVE)
+    assert det == {}

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -267,5 +267,30 @@
     "aliases": [],
     "target": "currency",
     "type": "string"
+  },
+  "business_name": {
+    "aliases": ["business_name"],
+    "target": "business_name",
+    "type": "string"
+  },
+  "executive_summary": {
+    "aliases": ["executive_summary"],
+    "target": "executive_summary",
+    "type": "string"
+  },
+  "funding_request_amount": {
+    "aliases": ["funding_request_amount", "grant_amount"],
+    "target": "funding_request_amount",
+    "type": "currency"
+  },
+  "period_years": {
+    "aliases": ["period_years", "projection_years"],
+    "target": "period_years",
+    "type": "int"
+  },
+  "last_updated": {
+    "aliases": ["last_updated"],
+    "target": "last_updated",
+    "type": "date"
   }
 }

--- a/server/tests/checklist.business_plan.test.js
+++ b/server/tests/checklist.business_plan.test.js
@@ -1,0 +1,126 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('Business Plan checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        grantA: { required_docs: ['Business_Plan'], common_docs: [] },
+        grantB: { required_docs: ['Business_Plan'], common_docs: [] },
+      });
+    jest
+      .spyOn(require('../models/Case'), 'findOne')
+      .mockImplementation(({ caseId }) => ({
+        lean: async () => {
+          const store = require('../utils/pipelineStore');
+          return store.getCase('dev-user', caseId);
+        },
+      }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes Business Plan and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility: both grants shortlisted
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Business_Plan'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload Business Plan -> analyzer then eligibility
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Business_Plan',
+          fields: { business_name: 'ACME MOTORS LLC' },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'grantA', score: 1 },
+            { key: 'grantB', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .attach('file', Buffer.from('dummy'), 'plan.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Business_Plan'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Re-run eligibility with only one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ key: 'grantB', score: 1 }] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Business_Plan'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Checklist endpoint reflects uploaded Business Plan
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'Business_Plan'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -157,6 +157,29 @@
         "Balance Sheet showing Assets, Liabilities, Equity"
       ]
     },
+    "Business_Plan": {
+      "extractor": "business_plan",
+      "detector": {
+        "keywords": [
+          "Business Plan",
+          "Executive Summary",
+          "Company Description",
+          "Market Analysis",
+          "Financial Projections",
+          "Funding Request",
+          "Go-to-Market",
+          "Operations Plan"
+        ]
+      },
+      "fields": {
+        "business_name": "string",
+        "executive_summary": "string",
+        "funding_request_amount": "number",
+        "period_years": "number",
+        "last_updated": "date"
+      },
+      "description": "Full business plan including executive summary, company details, market analysis, funding request,\n        and financial projections."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- support `Business_Plan` documents with keywords, fields and extractor
- normalize business plan fields for eligibility engine
- cover Business Plan in checklist flow and analyzer tests

## Testing
- `pytest ai-analyzer/tests/test_business_plan.py -q`
- `cd server && npm test tests/checklist.business_plan.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_68b5ca37991883278d554d6c458d0a27