### PR TITLE
feat: add Grant Use Statement document support

### DIFF
--- a/DATA_CONTRACTS.md
+++ b/DATA_CONTRACTS.md
@@ -50,6 +50,9 @@ The following table enumerates all canonical keys understood by the eligibility 
 | year_founded | integer | Year the company was founded | Accept 1800..current year | No | `2008` | Analyzer |
 | minority_owned | boolean | Business identified as minority‑owned | Parse yes/no | No | `true` | Analyzer |
 | female_owned | boolean | Business identified as woman‑owned | Parse yes/no | No | `true` | Analyzer |
+| intended_categories | array | Planned categories for grant funds | Lowercase strings | No | `["payroll", "rent"]` | Analyzer |
+| justification | string | Rationale for using funds | Trim whitespace | No | `Retain staff` | Analyzer |
+| date_signed | date | Date the statement was signed | ISO-8601 date | No | `2024-01-01` | Analyzer |
 | ppp_reference | boolean | PPP loan is referenced in documents | Parse yes/no | No | `true` | Analyzer |
 | ertc_reference | boolean | ERTC reference detected in documents | Parse yes/no | No | `true` | Analyzer |
 

--- a/ai-agent/form_templates/grant_use_statement.json
+++ b/ai-agent/form_templates/grant_use_statement.json
@@ -1,0 +1,12 @@
+{
+  "template": "Grant Use Statement",
+  "sections": [
+    { "template": "Business Name: {{business_name}}" },
+    { "template": "Funding Request: ${{funding_request_amount}}" },
+    { "template": "Planned Use of Funds:" },
+    { "template": "{{#each intended_categories}}- {{this}}\n{{/each}}" },
+    { "template": "Justification: {{justification}}" },
+    { "template": "Date: {{date_signed}}" },
+    { "template": "Signature: ________________________" }
+  ]
+}

--- a/ai-agent/tests/test_form_generation.py
+++ b/ai-agent/tests/test_form_generation.py
@@ -1,0 +1,15 @@
+from fill_form import fill_form
+
+def test_grant_use_statement_generation():
+    data = {
+        "business_name": "Acme Co",
+        "funding_request_amount": 50000,
+        "intended_categories": ["payroll"],
+        "justification": "Retain staff",
+        "date_signed": "2024-01-01",
+    }
+    filled = fill_form("grant_use_statement", data)
+    sections = filled.get("sections", [])
+    text = "\n".join(sections)
+    assert "Funding Request: $50000" in text
+    assert "- payroll" in text

--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -41,6 +41,7 @@ EXTRACTORS = {
     "Profit_And_Loss_Statement": ("p_and_l_statement", "extract"),
     "Balance_Sheet": ("balance_sheet", "extract"),
     "Business_Plan": ("business_plan", "extract"),
+    "Grant_Use_Statement": ("grant_use_statement", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/grant_use_statement.py
+++ b/ai-analyzer/src/extractors/grant_use_statement.py
@@ -1,0 +1,97 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+KEYWORDS = [
+    "Use of Funds",
+    "Grant Use Statement",
+    "Intended Use of Grant Funds",
+    "Statement of Intended Use",
+]
+
+AMOUNT_RE = re.compile(r"(?:Funding Request|Amount|Use of Funds)[:\s]*\$?([0-9,]+)", re.IGNORECASE)
+DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})\b")
+
+
+def detect(text: str) -> bool:
+    tl = text.lower()
+    return any(k.lower() in tl for k in KEYWORDS)
+
+
+def _parse_amount(text: str) -> Optional[float]:
+    m = AMOUNT_RE.search(text)
+    if m:
+        val = m.group(1).replace(",", "")
+        try:
+            return float(val)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_categories(text: str) -> list[str]:
+    cats = []
+    for line in text.splitlines():
+        line = line.strip()
+        if re.match(r"[-\u2022]", line):
+            item = re.sub(r"^[-\u2022]\s*", "", line)
+            if item:
+                cats.append(item.lower())
+    return cats
+
+
+def _parse_justification(text: str) -> Optional[str]:
+    m = re.search(r"Justification[:\s]*(.+)", text, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _parse_date(text: str) -> Optional[str]:
+    m = DATE_RE.search(text)
+    if not m:
+        return None
+    raw = m.group(1)
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(raw, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+    fields: Dict[str, Any] = {}
+    amt = _parse_amount(text)
+    if amt is not None:
+        fields["funding_request_amount"] = amt
+    cats = _parse_categories(text)
+    if cats:
+        fields["intended_categories"] = cats
+    just = _parse_justification(text)
+    if just:
+        fields["justification"] = just
+    dt = _parse_date(text)
+    if dt:
+        fields["date_signed"] = dt
+    conf = 0.6
+    if "funding_request_amount" in fields:
+        conf += 0.2
+    if "intended_categories" in fields:
+        conf += 0.1
+    return {
+        "doc_type": "Grant_Use_Statement",
+        "confidence": min(conf, 0.95),
+        "fields": fields,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/test_grant_use_statement.py
+++ b/ai-analyzer/tests/test_grant_use_statement.py
@@ -1,0 +1,20 @@
+from src.detectors import identify
+from src.extractors.grant_use_statement import extract
+
+POSITIVE = """Statement of Intended Use of Grant Funds\nFunding Request: $50,000\nPlanned Use of Funds:\n- payroll\nJustification: Retain staff\nDate: 01/15/2024"""
+
+NEGATIVE = "Random unrelated text without keywords"
+
+
+def test_detect_grant_use_statement():
+    det = identify(POSITIVE)
+    assert det["type_key"] == "Grant_Use_Statement"
+    result = extract(POSITIVE)
+    fields = result["fields"]
+    assert fields["funding_request_amount"] == 50000
+    assert "payroll" in fields.get("intended_categories", [])
+
+
+def test_negative_case():
+    det = identify(NEGATIVE)
+    assert det == {} or det.get("type_key") != "Grant_Use_Statement"

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -292,5 +292,20 @@
     "aliases": ["last_updated"],
     "target": "last_updated",
     "type": "date"
+  },
+  "intended_categories": {
+    "aliases": ["intended_categories"],
+    "target": "intended_categories",
+    "type": "array"
+  },
+  "justification": {
+    "aliases": ["justification"],
+    "target": "justification",
+    "type": "string"
+  },
+  "date_signed": {
+    "aliases": ["date_signed"],
+    "target": "date_signed",
+    "type": "date"
   }
 }

--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -8,7 +8,11 @@ const mongoose = require('mongoose');
 const documentSchema = new mongoose.Schema(
   {
     doc_type: String,
-    status: { type: String, default: 'uploaded' },
+    status: {
+      type: String,
+      enum: ['not_uploaded', 'uploaded', 'extracted', 'mismatch', 'generated', 'approved'],
+      default: 'uploaded',
+    },
     evidence_key: String,
     analyzer_fields: mongoose.Schema.Types.Mixed,
   },

--- a/server/tests/checklist.grant_use_statement.test.js
+++ b/server/tests/checklist.grant_use_statement.test.js
@@ -1,0 +1,111 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let getCase;
+let updateCase;
+let resetStoreFn;
+
+describe('Grant Use Statement checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    getCase = store.getCase;
+    updateCase = store.updateCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        grantA: { required_docs: ['Grant_Use_Statement'], common_docs: [] },
+        grantB: { required_docs: ['Grant_Use_Statement'], common_docs: [] },
+      });
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('appears once and preserves generated status', async () => {
+    const caseId = await createCase('dev-user');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Grant_Use_Statement'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    const c = await getCase('dev-user', caseId);
+    c.documents.push({ doc_type: 'Grant_Use_Statement', status: 'generated' });
+    await updateCase(caseId, { documents: c.documents });
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'grantA', score: 1 },
+          { key: 'grantB', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Grant_Use_Statement'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('generated');
+
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ key: 'grantB', score: 1 }] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Grant_Use_Statement'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('generated');
+
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'Grant_Use_Statement'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('generated');
+  });
+});

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -180,6 +180,27 @@
       },
       "description": "Full business plan including executive summary, company details, market analysis, funding request,\n        and financial projections."
     },
+    "Grant_Use_Statement": {
+      "extractor": "grant_use_statement",
+      "detector": {
+        "keywords": [
+          "Use of Funds",
+          "Grant Use Statement",
+          "Intended Use of Grant Funds",
+          "Statement of Intended Use",
+          "Funding Request"
+        ],
+        "regex": ["(?i)use of funds"]
+      },
+      "fields": {
+        "business_name": "string",
+        "funding_request_amount": "number",
+        "intended_categories": "array",
+        "justification": "string",
+        "date_signed": "date"
+      },
+      "description": "Declaration of how grant funds will be used, including categories, amounts, and justification."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- add Grant_Use_Statement document type and extraction logic
- enable AI agent template generation for Grant Use Statement
- cover Grant Use Statement in checklist and field mappings

## Testing
- `PYTHONPATH=.:ai-agent:ai-analyzer:eligibility-engine:common pytest ai-analyzer/tests/test_grant_use_statement.py ai-agent/tests/test_form_generation.py` (passed)
- `PYTHONPATH=ai-agent:ai-analyzer:eligibility-engine pytest` (failed: field_map coverage, check_envelope)
- `npm test --prefix server` (failed: port 8002 not reachable)


------
https://chatgpt.com/codex/tasks/task_b_68b5dcc1ae9083278b51a2a9be824c6a