### PR TITLE
feat: add utility bill document type

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -42,6 +42,7 @@ EXTRACTORS = {
     "Balance_Sheet": ("balance_sheet", "extract"),
     "Business_Plan": ("business_plan", "extract"),
     "Grant_Use_Statement": ("grant_use_statement", "extract"),
+    "Utility_Bill": ("utility_bill", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/__init__.py
+++ b/ai-analyzer/src/extractors/__init__.py
@@ -1,4 +1,5 @@
 from .business_plan import detect as detect_business_plan, extract as extract_business_plan
+from .utility_bill import detect as detect_utility_bill, extract as extract_utility_bill
 
 EXTRACTORS = {
     "business_plan": {
@@ -6,5 +7,14 @@ EXTRACTORS = {
         "extract": extract_business_plan,
     }
 }
+EXTRACTORS.update({
+    "utility_bill": {"detect": detect_utility_bill, "extract": extract_utility_bill}
+})
 
-__all__ = ["EXTRACTORS", "detect_business_plan", "extract_business_plan"]
+__all__ = [
+    "EXTRACTORS",
+    "detect_business_plan",
+    "extract_business_plan",
+    "detect_utility_bill",
+    "extract_utility_bill",
+]

--- a/ai-analyzer/src/extractors/utility_bill.py
+++ b/ai-analyzer/src/extractors/utility_bill.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+import re
+from pydantic import BaseModel
+
+KEYWORDS = [
+    "Electricity bill",
+    "Utility bill",
+    "kWh",
+    "Billing period",
+    "Service address",
+    "Meter read",
+]
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return any(k.lower() in t for k in KEYWORDS)
+
+
+class UtilityBillFields(BaseModel):
+    utility_provider: str | None = None
+    service_address: str | None = None
+    billing_period_start: str | None = None
+    billing_period_end: str | None = None
+    total_kwh: float | None = None
+    total_amount_due: float | None = None
+    account_number: str | None = None
+    statement_date: str | None = None
+
+
+def _norm_date(val: str) -> str:
+    for fmt in ("%b %d, %Y", "%B %d, %Y", "%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(val.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val.strip()
+
+
+UTILITY_PROVIDER_RE = re.compile(r"^(?!.*bill)(.*(?:Energy|Electric|Power|Utilities)[^\n]*)", re.I | re.M)
+SERVICE_ADDRESS_RE = re.compile(r"Service address[:\s]+(.+)", re.I)
+BILLING_PERIOD_RE = re.compile(
+    r"Billing period[:\s]+(.*?)(?:to|\-|\u2013|\u2014)(.*?)$", re.I | re.M
+)
+TOTAL_KWH_RE = re.compile(
+    r"(?i)(?:total (?:electricity|usage).*?\(kWh\)|kWh total|Total Usage \(kWh\))[:\s]*([0-9,]+(?:\.\d+)?)"
+)
+TOTAL_AMOUNT_DUE_RE = re.compile(
+    r"(?i)total amount (?:due|owed)[:\s\$]*([0-9,]+(?:\.\d{2})?)"
+)
+ACCOUNT_NUMBER_RE = re.compile(
+    r"(?i)(?:account|customer) (?:no\.?|number)[:\s]+([\w-]+)"
+)
+STATEMENT_DATE_RE = re.compile(
+    r"(?i)(?:bill (?:prepared|date)|statement date)[:\s]+([A-Za-z]{3,9} \d{1,2},? \d{4}|\d{1,2}/\d{1,2}/\d{2,4})"
+)
+
+
+def extract(text: str) -> dict:
+    f = UtilityBillFields()
+    if m := UTILITY_PROVIDER_RE.search(text):
+        f.utility_provider = m.group(1).strip()
+    if m := SERVICE_ADDRESS_RE.search(text):
+        f.service_address = m.group(1).strip()
+    if m := BILLING_PERIOD_RE.search(text):
+        f.billing_period_start = _norm_date(m.group(1))
+        f.billing_period_end = _norm_date(m.group(2))
+    if m := TOTAL_KWH_RE.search(text):
+        f.total_kwh = float(m.group(1).replace(",", ""))
+    if m := TOTAL_AMOUNT_DUE_RE.search(text):
+        f.total_amount_due = float(m.group(1).replace(",", ""))
+    if m := ACCOUNT_NUMBER_RE.search(text):
+        f.account_number = m.group(1).strip()
+    if m := STATEMENT_DATE_RE.search(text):
+        f.statement_date = _norm_date(m.group(1))
+
+    confidence = 0.6
+    if f.billing_period_start and f.billing_period_end:
+        confidence += 0.1
+    if f.total_kwh is not None:
+        confidence += 0.1
+    if f.total_amount_due is not None:
+        confidence += 0.1
+
+    return {"fields": f.model_dump(), "confidence": confidence}
+

--- a/ai-analyzer/tests/fixtures/utility_bill_sample.txt
+++ b/ai-analyzer/tests/fixtures/utility_bill_sample.txt
@@ -1,0 +1,9 @@
+Monthly Electricity Bill
+ACME Energy Services
+Account Number: 12345-6789
+Service Address: 123 Green St, Springfield, CA 98765
+Billing Period: Jan 1, 2024 - Jan 31, 2024
+Statement Date: Feb 2, 2024
+Meter Read: 000123 to 000357
+Total Usage (kWh): 234
+Total Amount Due: $56.78

--- a/ai-analyzer/tests/test_utility_bill.py
+++ b/ai-analyzer/tests/test_utility_bill.py
@@ -1,0 +1,32 @@
+import os
+from src.detectors import identify
+from src.extractors.utility_bill import detect, extract
+
+
+def load_sample():
+    p = os.path.join(os.path.dirname(__file__), "fixtures", "utility_bill_sample.txt")
+    with open(p, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_detect_utility_bill():
+    text = load_sample()
+    assert detect(text)
+    det = identify(text)
+    assert det["type_key"] == "Utility_Bill"
+    assert det["confidence"] >= 0.5
+
+
+def test_extract_utility_bill_fields():
+    text = load_sample()
+    result = extract(text)
+    fields = result["fields"]
+    assert fields["utility_provider"] == "ACME Energy Services"
+    assert fields["service_address"].startswith("123 Green St")
+    assert fields["billing_period_start"] == "2024-01-01"
+    assert fields["billing_period_end"] == "2024-01-31"
+    assert fields["total_kwh"] == 234.0
+    assert fields["total_amount_due"] == 56.78
+    assert fields["account_number"] == "12345-6789"
+    assert fields["statement_date"] == "2024-02-02"
+    assert result["confidence"] >= 0.8

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -307,5 +307,21 @@
     "aliases": ["date_signed"],
     "target": "date_signed",
     "type": "date"
+  },
+  "utility_bill": {
+    "utility_provider": { "aliases": ["utility_provider"], "type": "string" },
+    "service_address": { "aliases": ["service_address"], "type": "string" },
+    "billing_period_start": { "aliases": ["billing_period_start"], "type": "date" },
+    "billing_period_end": { "aliases": ["billing_period_end"], "type": "date" },
+    "total_kwh": { "aliases": ["total_kwh", "kwh_total"], "type": "number" },
+    "total_amount_due": {
+      "aliases": ["total_amount_due", "amount_due", "total_amount"],
+      "type": "number"
+    },
+    "account_number": {
+      "aliases": ["account_number", "customer_account"],
+      "type": "string"
+    },
+    "statement_date": { "aliases": ["statement_date", "bill_date"], "type": "date" }
   }
 }

--- a/server/tests/checklist.utility_bill.test.js
+++ b/server/tests/checklist.utility_bill.test.js
@@ -1,0 +1,135 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('Utility Bill checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        green_energy_state_incentive: { required_docs: ['Utility_Bill'], common_docs: [] },
+        energy_efficiency_upgrade: { required_docs: ['Utility_Bill'], common_docs: [] },
+      });
+    jest
+      .spyOn(require('../models/Case'), 'findOne')
+      .mockImplementation(({ caseId }) => ({
+        lean: async () => {
+          const store = require('../utils/pipelineStore');
+          return store.getCase('dev-user', caseId);
+        },
+      }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes Utility Bill and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility: both grants shortlisted
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'green_energy_state_incentive', score: 1 },
+          { key: 'energy_efficiency_upgrade', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Utility_Bill'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload Utility Bill -> analyzer then eligibility
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Utility_Bill',
+          fields: {
+            billing_period_start: '2024-01-01',
+            billing_period_end: '2024-01-31',
+            total_kwh: 234,
+            total_amount_due: 56.78,
+            utility_provider: 'ACME Energy',
+          },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'green_energy_state_incentive', score: 1 },
+            { key: 'energy_efficiency_upgrade', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .field('key', 'Utility_Bill')
+      .attach('file', Buffer.from('dummy'), 'bill.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Utility_Bill'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Re-run eligibility with only one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ key: 'energy_efficiency_upgrade', score: 1 }],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Utility_Bill'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Checklist endpoint reflects uploaded Utility Bill
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'Utility_Bill'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -103,6 +103,38 @@
         "Grant_Use_Statement"
       ],
       "common_docs": ["Owner_ID", "Bank_Statements"]
+    },
+    "green_energy_state_incentive": {
+      "title": "Green Energy State Incentive",
+      "required_docs": [
+        "Utility_Bill",
+        "Installer_Contract",
+        "Equipment_Specs",
+        "Invoices_or_Quotes",
+        "Grant_Use_Statement"
+      ],
+      "common_docs": [
+        "W9_Form",
+        "EIN_Letter",
+        "Financial_Statements",
+        "Business_License"
+      ]
+    },
+    "energy_efficiency_upgrade": {
+      "title": "Energy Efficiency Upgrade Program",
+      "required_docs": [
+        "Utility_Bill",
+        "Installer_Contract",
+        "Equipment_Specs",
+        "Invoices_or_Quotes",
+        "Grant_Use_Statement"
+      ],
+      "common_docs": [
+        "W9_Form",
+        "EIN_Letter",
+        "Financial_Statements",
+        "Business_License"
+      ]
     }
   }
 }

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -201,6 +201,30 @@
       },
       "description": "Declaration of how grant funds will be used, including categories, amounts, and justification."
     },
+    "Utility_Bill": {
+      "extractor": "utility_bill",
+      "detector": {
+        "keywords": [
+          "Electricity Bill",
+          "Utility Bill",
+          "kWh",
+          "Meter Read",
+          "Service Address",
+          "Billing Period"
+        ]
+      },
+      "fields": {
+        "utility_provider": "string",
+        "service_address": "string",
+        "billing_period_start": "date",
+        "billing_period_end": "date",
+        "total_kwh": "number",
+        "total_amount_due": "number",
+        "account_number": "string",
+        "statement_date": "date"
+      },
+      "description": "Monthly electricity/utility bill showing service address, billing period, kWh usage and amount due."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- add Utility_Bill document type with detector and extractor
- require Utility_Bill for green energy grants and map fields for eligibility
- cover analyzer and server checklist flows with tests

## Testing
- `pytest ai-analyzer/tests/test_utility_bill.py -q`
- `cd server && npm test tests/checklist.utility_bill.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_68b700ffe6048327a7496aea68f6228a