### PR TITLE
feat: support installer contracts across platform

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -43,6 +43,7 @@ EXTRACTORS = {
     "Business_Plan": ("business_plan", "extract"),
     "Grant_Use_Statement": ("grant_use_statement", "extract"),
     "Utility_Bill": ("utility_bill", "extract"),
+    "Installer_Contract": ("installer_contract", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/__init__.py
+++ b/ai-analyzer/src/extractors/__init__.py
@@ -1,5 +1,9 @@
 from .business_plan import detect as detect_business_plan, extract as extract_business_plan
 from .utility_bill import detect as detect_utility_bill, extract as extract_utility_bill
+from .installer_contract import (
+    detect as detect_installer_contract,
+    extract as extract_installer_contract,
+)
 
 EXTRACTORS = {
     "business_plan": {
@@ -8,7 +12,11 @@ EXTRACTORS = {
     }
 }
 EXTRACTORS.update({
-    "utility_bill": {"detect": detect_utility_bill, "extract": extract_utility_bill}
+    "utility_bill": {"detect": detect_utility_bill, "extract": extract_utility_bill},
+    "installer_contract": {
+        "detect": detect_installer_contract,
+        "extract": extract_installer_contract,
+    },
 })
 
 __all__ = [
@@ -17,4 +25,6 @@ __all__ = [
     "extract_business_plan",
     "detect_utility_bill",
     "extract_utility_bill",
+    "detect_installer_contract",
+    "extract_installer_contract",
 ]

--- a/ai-analyzer/src/extractors/installer_contract.py
+++ b/ai-analyzer/src/extractors/installer_contract.py
@@ -1,0 +1,100 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+
+KEYWORDS = [
+    "Installation Contract",
+    "Installer Agreement",
+    "Supply, Delivery and Installation",
+    "Solar Installation",
+    "HVAC INSTALLATION CONTRACT",
+    "Installation Agreement",
+]
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return any(k.lower() in t for k in KEYWORDS)
+
+
+class InstallerContractFields(BaseModel):
+    provider_name: Optional[str] = None
+    client_name: Optional[str] = None
+    service_description: Optional[str] = None
+    contract_start_date: Optional[str] = None
+    contract_end_date: Optional[str] = None
+    total_amount: Optional[float] = None
+    contract_number: Optional[str] = None
+    signature_dates: list[str] = []
+
+
+def _norm_date(val: str) -> str:
+    for fmt in ("%Y-%m-%d", "%B %d, %Y", "%b %d, %Y", "%m/%d/%Y", "%m-%d-%Y"):
+        try:
+            return datetime.strptime(val.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val.strip()
+
+
+PROVIDER_RE = re.compile(r"(?:Provider|Contractor|Installer)[:\s]+(.+)", re.I)
+CLIENT_RE = re.compile(r"(?:Client|Customer)[:\s]+(.+)", re.I)
+SERVICE_RE = re.compile(r"(?:Scope of Work|Services?|The Service)[:\s]*([^\n]+)", re.I)
+START_DATE_RE = re.compile(r"(?:Start Date|Commence on|Effective Date)[:\s]+([^\n]+)", re.I)
+END_DATE_RE = re.compile(r"(?:End Date|terminate on)[:\s]+([^\n]+)", re.I)
+TOTAL_AMOUNT_RE = re.compile(r"(?:Payment Amount|Contract Value|Total|Compensation)[:\s\$]*([0-9,]+(?:\.\d{2})?)", re.I)
+CONTRACT_NUM_RE = re.compile(r"(?:Contract|Agreement) (?:No\.|Number)[:\s]+([\w\-\/]+)", re.I)
+SIGNATURE_DATE_RE = re.compile(r"Signature.*?(\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})", re.I)
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    f = InstallerContractFields()
+    if m := PROVIDER_RE.search(text):
+        f.provider_name = m.group(1).strip()
+    if m := CLIENT_RE.search(text):
+        f.client_name = m.group(1).strip()
+    if m := SERVICE_RE.search(text):
+        f.service_description = m.group(1).strip()
+    if m := START_DATE_RE.search(text):
+        f.contract_start_date = _norm_date(m.group(1))
+    if m := END_DATE_RE.search(text):
+        f.contract_end_date = _norm_date(m.group(1))
+    if m := TOTAL_AMOUNT_RE.search(text):
+        f.total_amount = float(m.group(1).replace(",", ""))
+    if m := CONTRACT_NUM_RE.search(text):
+        f.contract_number = m.group(1).strip()
+    f.signature_dates = [
+        _norm_date(d)
+        for d in SIGNATURE_DATE_RE.findall(text)
+    ]
+
+    confidence = 0.65
+    if f.provider_name and f.client_name:
+        confidence += 0.1
+    if f.total_amount is not None:
+        confidence += 0.1
+    if f.contract_start_date or f.contract_end_date:
+        confidence += 0.05
+    if f.signature_dates:
+        confidence += 0.05
+
+    return {
+        "doc_type": "Installer_Contract",
+        "confidence": min(confidence, 0.99),
+        "fields": f.model_dump(),
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/fixtures/installer_contract_sample.txt
+++ b/ai-analyzer/tests/fixtures/installer_contract_sample.txt
@@ -1,0 +1,16 @@
+INSTALLATION CONTRACT
+
+Contract Number: AG-2025-014
+
+Provider: Solar Installers Inc.
+Client: Green Energy LLC
+
+Scope of Work: Provide and install solar panels on client's property. Services include equipment delivery and installation.
+
+Start Date: January 15, 2025
+End Date: April 30, 2025
+
+Total Contract Value: $68,900
+
+Signature Provider: 2025-01-10
+Signature Client: 2025-01-12

--- a/ai-analyzer/tests/test_installer_contract.py
+++ b/ai-analyzer/tests/test_installer_contract.py
@@ -1,0 +1,43 @@
+import os
+
+import os
+
+from src.detectors import identify
+from src.extractors.installer_contract import detect, extract
+
+
+def load_sample():
+    p = os.path.join(
+        os.path.dirname(__file__),
+        "fixtures",
+        "installer_contract_sample.txt",
+    )
+    with open(p, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_detect_installer_contract():
+    text = load_sample()
+    assert detect(text)
+    det = identify(text)
+    assert det["type_key"] == "Installer_Contract"
+    assert det["confidence"] >= 0.5
+
+
+def test_extract_installer_contract_fields():
+    text = load_sample()
+    result = extract(text)
+    fields = result["fields"]
+    assert fields["provider_name"] == "Solar Installers Inc."
+    assert fields["client_name"] == "Green Energy LLC"
+    assert fields["service_description"].startswith("Provide and install solar panels")
+    assert fields["contract_start_date"] == "2025-01-15"
+    assert fields["contract_end_date"] == "2025-04-30"
+    assert fields["total_amount"] == 68900.0
+    assert fields["contract_number"] == "AG-2025-014"
+    assert fields["signature_dates"] == ["2025-01-10", "2025-01-12"]
+    assert result["confidence"] >= 0.8
+
+
+def test_detect_negative_sample():
+    assert not detect("This is not a contract at all")

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -323,5 +323,41 @@
       "type": "string"
     },
     "statement_date": { "aliases": ["statement_date", "bill_date"], "type": "date" }
+  },
+  "installer_contract": {
+    "provider_name": {
+      "aliases": ["provider_name", "contractor_name", "installer_name"],
+      "type": "string"
+    },
+    "client_name": {
+      "aliases": ["client_name", "customer_name"],
+      "type": "string"
+    },
+    "service_description": {
+      "aliases": ["service_description", "scope_of_work"],
+      "type": "string"
+    },
+    "contract_start_date": {
+      "aliases": [
+        "contract_start_date",
+        "start_date",
+        "commence_date",
+        "effective_date"
+      ],
+      "type": "date"
+    },
+    "contract_end_date": {
+      "aliases": ["contract_end_date", "end_date", "terminate_date"],
+      "type": "date"
+    },
+    "total_amount": {
+      "aliases": ["total_amount", "contract_value", "payment_amount"],
+      "type": "number"
+    },
+    "contract_number": {
+      "aliases": ["contract_number", "agreement_number"],
+      "type": "string"
+    },
+    "signature_dates": { "aliases": ["signature_dates"], "type": "array" }
   }
 }

--- a/server/tests/checklist.installer_contract.test.js
+++ b/server/tests/checklist.installer_contract.test.js
@@ -1,0 +1,135 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('Installer Contract checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        green_energy_state_incentive: { required_docs: ['Installer_Contract'], common_docs: [] },
+        energy_efficiency_upgrade: { required_docs: ['Installer_Contract'], common_docs: [] },
+      });
+    jest
+      .spyOn(require('../models/Case'), 'findOne')
+      .mockImplementation(({ caseId }) => ({
+        lean: async () => {
+          const store = require('../utils/pipelineStore');
+          return store.getCase('dev-user', caseId);
+        },
+      }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes Installer Contract and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility: both grants shortlisted
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'green_energy_state_incentive', score: 1 },
+          { key: 'energy_efficiency_upgrade', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Installer_Contract'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload Installer Contract -> analyzer then eligibility
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Installer_Contract',
+          fields: {
+            provider_name: 'Solar Installers Inc.',
+            client_name: 'Green Energy LLC',
+            contract_start_date: '2025-01-15',
+            contract_end_date: '2025-04-30',
+            total_amount: 68900,
+          },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'green_energy_state_incentive', score: 1 },
+            { key: 'energy_efficiency_upgrade', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .field('key', 'Installer_Contract')
+      .attach('file', Buffer.from('dummy'), 'contract.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Installer_Contract'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Re-run eligibility with only one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ key: 'energy_efficiency_upgrade', score: 1 }],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Installer_Contract'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Checklist endpoint reflects uploaded Installer Contract
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'Installer_Contract'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});

--- a/server/utils/fieldNormalizer.js
+++ b/server/utils/fieldNormalizer.js
@@ -2,13 +2,22 @@ const fieldMap = require('../../eligibility-engine/contracts/field_map.json');
 
 const aliasMap = (() => {
   const map = {};
-  for (const [canonical, info] of Object.entries(fieldMap)) {
-    const target = info.target || canonical;
-    map[canonical] = target;
-    (info.aliases || []).forEach((alias) => {
-      map[alias] = target;
-    });
-  }
+
+  const walk = (obj) => {
+    for (const [canonical, info] of Object.entries(obj)) {
+      if (info && typeof info === 'object' && !Array.isArray(info) && !('aliases' in info)) {
+        walk(info);
+        continue;
+      }
+      const target = info.target || canonical;
+      map[canonical] = target;
+      (info.aliases || []).forEach((alias) => {
+        map[alias] = target;
+      });
+    }
+  };
+
+  walk(fieldMap);
   return map;
 })();
 

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -225,6 +225,31 @@
       },
       "description": "Monthly electricity/utility bill showing service address, billing period, kWh usage and amount due."
     },
+    "Installer_Contract": {
+      "extractor": "installer_contract",
+      "detector": {
+        "keywords": [
+          "Installation Contract",
+          "Installer Agreement",
+          "Supply, Delivery and Installation",
+          "Solar Installation",
+          "HVAC INSTALLATION CONTRACT",
+          "Installation Agreement"
+        ],
+        "regex": ["(?i)Contract Number"]
+      },
+      "fields": {
+        "provider_name": "string",
+        "client_name": "string",
+        "service_description": "string",
+        "contract_start_date": "date",
+        "contract_end_date": "date",
+        "total_amount": "number",
+        "contract_number": "string",
+        "signature_dates": "array"
+      },
+      "description": "Signed agreement with a certified installer describing scope of work, dates, and price for green-energy equipment installation."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- add Installer_Contract document type with detector and field extraction
- normalize installer contract fields for eligibility and checklist
- add analyzer and server integration tests for installer contracts

## Testing
- `pytest ai-analyzer/tests/test_installer_contract.py -q`
- `cd server && npm test tests/checklist.installer_contract.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_68b7075dfb548327899f0cca3b678d1d