### PR TITLE
feat: support invoices or quotes documents

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -45,6 +45,7 @@ EXTRACTORS = {
     "Utility_Bill": ("utility_bill", "extract"),
     "Installer_Contract": ("installer_contract", "extract"),
     "Equipment_Specs": ("equipment_specs", "extract"),
+    "Invoices_or_Quotes": ("invoices_or_quotes", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/__init__.py
+++ b/ai-analyzer/src/extractors/__init__.py
@@ -5,6 +5,7 @@ from .installer_contract import (
     extract as extract_installer_contract,
 )
 from .equipment_specs import detect as detect_equipment_specs, extract as extract_equipment_specs
+from .invoices_or_quotes import detect as detect_invoices_or_quotes, extract as extract_invoices_or_quotes
 
 EXTRACTORS = {
     "business_plan": {
@@ -22,6 +23,10 @@ EXTRACTORS.update({
         "detect": detect_equipment_specs,
         "extract": extract_equipment_specs,
     },
+    "invoices_or_quotes": {
+        "detect": detect_invoices_or_quotes,
+        "extract": extract_invoices_or_quotes,
+    },
 })
 
 __all__ = [
@@ -34,4 +39,6 @@ __all__ = [
     "extract_installer_contract",
     "detect_equipment_specs",
     "extract_equipment_specs",
+    "detect_invoices_or_quotes",
+    "extract_invoices_or_quotes",
 ]

--- a/ai-analyzer/src/extractors/invoices_or_quotes.py
+++ b/ai-analyzer/src/extractors/invoices_or_quotes.py
@@ -1,0 +1,169 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+INVOICE_KEYWORDS = [
+    "Invoice",
+    "Tax Invoice",
+    "Commercial Invoice",
+    "Amount Due",
+]
+
+QUOTE_KEYWORDS = [
+    "Quote",
+    "Quotation",
+    "Estimate",
+    "Proposal",
+    "Valid until",
+]
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return any(k.lower() in t for k in INVOICE_KEYWORDS + QUOTE_KEYWORDS)
+
+
+class IOQFields(BaseModel):
+    doc_variant: Optional[str] = None
+    vendor_name: Optional[str] = None
+    vendor_tax_id: Optional[str] = None
+    customer_name: Optional[str] = None
+    customer_address: Optional[str] = None
+    invoice_number: Optional[str] = None
+    quote_number: Optional[str] = None
+    issue_date: Optional[str] = None
+    due_date: Optional[str] = None
+    quote_valid_until: Optional[str] = None
+    item_description: Optional[str] = None
+    quantity: Optional[float] = None
+    unit_price: Optional[float] = None
+    subtotal_amount: Optional[float] = None
+    tax_amount: Optional[float] = None
+    total_amount: Optional[float] = None
+    currency: Optional[str] = None
+
+
+DATE_FMTS = ["%Y-%m-%d", "%m/%d/%Y", "%B %d, %Y", "%b %d, %Y"]
+
+
+def _norm_date(val: str) -> str:
+    for fmt in DATE_FMTS:
+        try:
+            return datetime.strptime(val.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val.strip()
+
+
+VENDOR_TAX_ID_RE = re.compile(r"(EIN|TIN|VAT|Tax ID)[:\s]+([\w-]+)", re.I)
+INVOICE_NO_RE = re.compile(r"Invoice (?:No\.|#)[:\s]+([\w\-\/]+)", re.I)
+QUOTE_NO_RE = re.compile(r"(Quote|Estimate|Proposal) (?:No\.|#)[:\s]+([\w\-\/]+)", re.I)
+ISSUE_DATE_RE = re.compile(r"(Date|Issued?)[:\s]+([A-Za-z]{3,9} \d{1,2}, \d{4}|\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})", re.I)
+DUE_DATE_RE = re.compile(r"Due Date[:\s]+([A-Za-z]{3,9} \d{1,2}, \d{4}|\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})", re.I)
+VALID_UNTIL_RE = re.compile(r"Valid (?:Until|Thru|Through)[:\s]+([A-Za-z]{3,9} \d{1,2}, \d{4}|\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})", re.I)
+ITEM_LINE_RE = re.compile(r"^(.+?)\s{2,}(\d+(?:\.\d+)?)\s{2,}([\$€£₪]?)([0-9,]+(?:\.\d{2})?)", re.M)
+SUBTOTAL_RE = re.compile(r"Sub-?total[:\s]+([\$€£₪]?)([0-9,]+(?:\.\d{2})?)", re.I)
+TAX_RE = re.compile(r"(?:Tax|Sales Tax)[:\s]+([\$€£₪]?)([0-9,]+(?:\.\d{2})?)", re.I)
+TOTAL_RE = re.compile(r"(?:Total (?:Amount|Due)?|Amount Due|Grand Total)[:\s]+([\$€£₪]?)([0-9,]+(?:\.\d{2})?)", re.I)
+CURRENCY_TOKEN_RE = re.compile(r"\b(USD|EUR|ILS|GBP)\b", re.I)
+
+CURRENCY_SYMBOLS = {
+    "$": "USD",
+    "€": "EUR",
+    "₪": "ILS",
+    "£": "GBP",
+}
+
+
+def _parse_amount(symbol: str, value: str) -> tuple[Optional[float], Optional[str]]:
+    amount = float(value.replace(",", ""))
+    currency = CURRENCY_SYMBOLS.get(symbol)
+    return amount, currency
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "evidence_key": evidence_key,
+        }
+
+    f = IOQFields()
+    lower = text.lower()
+    if any(k.lower() in lower for k in INVOICE_KEYWORDS):
+        f.doc_variant = "invoice"
+    elif any(k.lower() in lower for k in QUOTE_KEYWORDS):
+        f.doc_variant = "quote"
+
+    lines = text.strip().splitlines()
+    if lines:
+        f.vendor_name = lines[0].strip()
+
+    if m := VENDOR_TAX_ID_RE.search(text):
+        f.vendor_tax_id = m.group(2).strip()
+
+    if m := re.search(r"(?:Bill To|Customer)[:\s]+([^\n]+)\n([^\n]+)?", text, re.I):
+        f.customer_name = m.group(1).strip()
+        if m.group(2):
+            f.customer_address = m.group(2).strip()
+
+    if m := INVOICE_NO_RE.search(text):
+        f.invoice_number = m.group(1).strip()
+    if m := QUOTE_NO_RE.search(text):
+        f.quote_number = m.group(2).strip()
+    if m := ISSUE_DATE_RE.search(text):
+        f.issue_date = _norm_date(m.group(2))
+    if m := DUE_DATE_RE.search(text):
+        f.due_date = _norm_date(m.group(1))
+    if m := VALID_UNTIL_RE.search(text):
+        f.quote_valid_until = _norm_date(m.group(1))
+    if m := ITEM_LINE_RE.search(text):
+        f.item_description = m.group(1).strip()
+        f.quantity = float(m.group(2))
+        amt, curr = _parse_amount(m.group(3), m.group(4))
+        f.unit_price = amt
+        if curr:
+            f.currency = curr
+    if m := SUBTOTAL_RE.search(text):
+        amt, curr = _parse_amount(m.group(1), m.group(2))
+        f.subtotal_amount = amt
+        if curr and not f.currency:
+            f.currency = curr
+    if m := TAX_RE.search(text):
+        amt, curr = _parse_amount(m.group(1), m.group(2))
+        f.tax_amount = amt
+        if curr and not f.currency:
+            f.currency = curr
+    if m := TOTAL_RE.search(text):
+        amt, curr = _parse_amount(m.group(1), m.group(2))
+        f.total_amount = amt
+        if curr and not f.currency:
+            f.currency = curr
+
+    if not f.currency:
+        if m := CURRENCY_TOKEN_RE.search(text):
+            f.currency = m.group(1).upper()
+
+    confidence = 0.6
+    has_number_date = (f.invoice_number or f.quote_number) and (f.issue_date or f.due_date or f.quote_valid_until)
+    if has_number_date:
+        confidence += 0.1
+    if f.vendor_name and f.customer_name:
+        confidence += 0.1
+    if f.total_amount is not None:
+        confidence += 0.1
+    confidence = min(confidence, 0.95)
+
+    return {
+        "doc_type": "Invoices_or_Quotes",
+        "confidence": confidence,
+        "fields": f.model_dump(),
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/fixtures/invoice_sample.txt
+++ b/ai-analyzer/tests/fixtures/invoice_sample.txt
@@ -1,0 +1,17 @@
+ACME Solar Corp
+Tax ID: 12-3456789
+
+INVOICE
+Invoice # INV-1001
+Date: January 5, 2025
+Due Date: February 5, 2025
+
+Bill To: Green Energy LLC
+123 Solar Way
+
+Item Description    Qty    Unit Price    Total
+Solar panels        10     $500.00       $5000.00
+
+Subtotal: $5000.00
+Tax: $400.00
+Total Amount: $5400.00

--- a/ai-analyzer/tests/fixtures/quote_sample.txt
+++ b/ai-analyzer/tests/fixtures/quote_sample.txt
@@ -1,0 +1,16 @@
+Sunshine Installers
+
+QUOTE
+Quote # Q-2002
+Quote Date: March 1, 2025
+Valid Until: March 31, 2025
+
+Customer: Green Energy LLC
+123 Solar Way
+
+Item Description    Qty    Unit Price    Total
+Inverter upgrade    2      $800.00       $1600.00
+
+Subtotal: $1600.00
+Sales Tax: $128.00
+Grand Total: $1728.00

--- a/ai-analyzer/tests/test_invoices_or_quotes.py
+++ b/ai-analyzer/tests/test_invoices_or_quotes.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+
+from src.detectors import identify
+from src.extractors.invoices_or_quotes import detect, extract
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def load(name: str) -> str:
+    with open(FIXTURES / name, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_invoice_detection_and_extraction():
+    text = load("invoice_sample.txt")
+    assert detect(text)
+    det = identify(text)
+    assert det["type_key"] == "Invoices_or_Quotes"
+    out = extract(text)
+    assert out["doc_type"] == "Invoices_or_Quotes"
+    fields = out["fields"]
+    assert fields["doc_variant"] == "invoice"
+    assert fields["invoice_number"] == "INV-1001"
+    assert fields["issue_date"] == "2025-01-05"
+    assert fields["total_amount"] == 5400.0
+    assert fields["vendor_name"] == "ACME Solar Corp"
+    assert fields["customer_name"] == "Green Energy LLC"
+    assert out["confidence"] >= 0.8
+
+
+def test_quote_detection_and_extraction():
+    text = load("quote_sample.txt")
+    assert detect(text)
+    det = identify(text)
+    assert det["type_key"] == "Invoices_or_Quotes"
+    out = extract(text)
+    fields = out["fields"]
+    assert fields["doc_variant"] == "quote"
+    assert fields["quote_number"] == "Q-2002"
+    assert fields["quote_valid_until"] == "2025-03-31"
+    assert fields["total_amount"] == 1728.0
+    assert fields["vendor_name"] == "Sunshine Installers"
+    assert fields["customer_name"] == "Green Energy LLC"
+    assert out["confidence"] >= 0.8
+
+
+def test_negative_sample():
+    text = load("business_plan_sample.txt")
+    assert not detect(text)
+    det = identify(text)
+    assert det.get("type_key") != "Invoices_or_Quotes"

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -389,5 +389,24 @@
       "aliases": ["issue_date", "date"],
       "type": "date"
     }
+    },
+    "invoices_or_quotes": {
+    "doc_variant":       { "aliases": ["doc_variant"], "type": "string" },
+    "vendor_name":       { "aliases": ["vendor_name","supplier_name"], "type": "string" },
+    "vendor_tax_id":     { "aliases": ["vendor_tax_id","supplier_tax_id","ein","tin","vat"], "type": "string" },
+    "customer_name":     { "aliases": ["customer_name","bill_to_name"], "type": "string" },
+    "customer_address":  { "aliases": ["customer_address","bill_to_address"], "type": "string" },
+    "invoice_number":    { "aliases": ["invoice_number"], "type": "string" },
+    "quote_number":      { "aliases": ["quote_number"], "type": "string" },
+    "issue_date":        { "aliases": ["issue_date","invoice_date","quote_date"], "type": "date" },
+    "due_date":          { "aliases": ["due_date"], "type": "date" },
+    "quote_valid_until": { "aliases": ["quote_valid_until","valid_until"], "type": "date" },
+    "item_description":  { "aliases": ["item_description","line_item_desc"], "type": "string" },
+    "quantity":          { "aliases": ["quantity","qty"], "type": "number" },
+    "unit_price":        { "aliases": ["unit_price","price_per_unit"], "type": "number" },
+    "subtotal_amount":   { "aliases": ["subtotal_amount","subtotal"], "type": "number" },
+    "tax_amount":        { "aliases": ["tax_amount","tax"], "type": "number" },
+    "total_amount":      { "aliases": ["total_amount","amount_due","grand_total"], "type": "number" },
+    "currency":          { "aliases": ["currency"], "type": "string" }
   }
 }

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -163,6 +163,9 @@ router.post('/files/upload', (req, res) => {
       if (key && doc_type && key !== doc_type) {
         status = 'mismatch';
       }
+      const existing = documents.find((d) => d.doc_type === doc_type);
+      const history = existing ? [...(existing.history || []), existing] : undefined;
+      documents = documents.filter((d) => d.doc_type !== doc_type);
       documents.push({
         doc_type,
         status,
@@ -171,16 +174,22 @@ router.post('/files/upload', (req, res) => {
         file_name: req.file.originalname,
         uploadedAt: now,
         requestId: req.headers['x-request-id'],
+        ...(history ? { history } : {}),
       });
     } else {
+      const docType = evidence_key || key;
+      const existing = documents.find((d) => d.doc_type === docType);
+      const history = existing ? [...(existing.history || []), existing] : undefined;
+      documents = documents.filter((d) => d.doc_type !== docType);
       documents.push({
-        doc_type: evidence_key || key,
+        doc_type: docType,
         status: 'uploaded',
         evidence_key: evidence_key || key,
         file_name: req.file.originalname,
         size: req.file.size,
         contentType: req.file.mimetype,
         uploadedAt: now,
+        ...(history ? { history } : {}),
       });
     }
 

--- a/server/tests/checklist.invoices_or_quotes.test.js
+++ b/server/tests/checklist.invoices_or_quotes.test.js
@@ -1,0 +1,184 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('Invoices_or_Quotes checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        green_energy_state_incentive: { required_docs: ['Invoices_or_Quotes'], common_docs: [] },
+        energy_efficiency_upgrade: { required_docs: ['Invoices_or_Quotes'], common_docs: [] },
+      });
+    jest
+      .spyOn(require('../models/Case'), 'findOne')
+      .mockImplementation(({ caseId }) => ({
+        lean: async () => {
+          const store = require('../utils/pipelineStore');
+          return store.getCase('dev-user', caseId);
+        },
+      }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('uploading invoice and quote dedupes and persists status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'green_energy_state_incentive', score: 1 },
+          { key: 'energy_efficiency_upgrade', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Invoices_or_Quotes'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload invoice
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Invoices_or_Quotes',
+          fields: {
+            doc_variant: 'invoice',
+            invoice_number: 'INV-1001',
+            issue_date: '2025-01-05',
+            total_amount: 5400,
+            vendor_name: 'ACME Solar Corp',
+            customer_name: 'Green Energy LLC',
+          },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'green_energy_state_incentive', score: 1 },
+            { key: 'energy_efficiency_upgrade', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .field('key', 'Invoices_or_Quotes')
+      .attach('file', Buffer.from('dummy'), 'invoice.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Invoices_or_Quotes'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+    expect(res.body.documents).toHaveLength(1);
+
+    // Upload quote later
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Invoices_or_Quotes',
+          fields: {
+            doc_variant: 'quote',
+            quote_number: 'Q-2002',
+            quote_valid_until: '2025-03-31',
+            total_amount: 1728,
+            vendor_name: 'Sunshine Installers',
+            customer_name: 'Green Energy LLC',
+          },
+          doc_confidence: 0.88,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'green_energy_state_incentive', score: 1 },
+            { key: 'energy_efficiency_upgrade', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .field('key', 'Invoices_or_Quotes')
+      .attach('file', Buffer.from('dummy'), 'quote.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Invoices_or_Quotes'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+    expect(res.body.documents).toHaveLength(1);
+
+    // Eligibility removes grants
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [] }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Invoices_or_Quotes'
+    );
+    expect(items).toHaveLength(0);
+
+    // Re-add one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ key: 'green_energy_state_incentive', score: 1 }],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Invoices_or_Quotes'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+  });
+});

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -273,6 +273,35 @@
       },
       "description": "Manufacturer’s technical datasheet for equipment, including power rating, efficiency, certifications, and model details."
     },
+    "Invoices_or_Quotes": {
+      "extractor": "invoices_or_quotes",
+      "detector": {
+        "keywords": [
+          "Invoice", "Tax Invoice", "Commercial Invoice",
+          "Quote", "Quotation", "Estimate", "Proposal"
+        ]
+      },
+      "fields": {
+        "doc_variant": "string",
+        "vendor_name": "string",
+        "vendor_tax_id": "string",
+        "customer_name": "string",
+        "customer_address": "string",
+        "invoice_number": "string",
+        "quote_number": "string",
+        "issue_date": "date",
+        "due_date": "date",
+        "quote_valid_until": "date",
+        "item_description": "string",
+        "quantity": "number",
+        "unit_price": "number",
+        "subtotal_amount": "number",
+        "tax_amount": "number",
+        "total_amount": "number",
+        "currency": "string"
+      },
+      "description": "Vendor invoice or quote/estimate showing equipment/services, unit costs, totals, and dates. Used to substantiate project costs."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- add Invoices_or_Quotes document type with detailed fields and detection keywords
- implement analyzer extractor to distinguish invoices vs quotes and parse core data
- normalize invoice/quote fields for eligibility and dedupe uploads on the server

## Testing
- `pytest ai-analyzer/tests/test_invoices_or_quotes.py -q`
- `cd server && SKIP_DB=true npm test tests/checklist.invoices_or_quotes.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_68b715b8ec208327b7f093423bc7223c