### PR TITLE
Integrate Energy Savings Report across analyzer and eligibility

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -46,6 +46,7 @@ EXTRACTORS = {
     "Installer_Contract": ("installer_contract", "extract"),
     "Equipment_Specs": ("equipment_specs", "extract"),
     "Invoices_or_Quotes": ("invoices_or_quotes", "extract"),
+    "Energy_Savings_Report": ("energy_savings_report", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/__init__.py
+++ b/ai-analyzer/src/extractors/__init__.py
@@ -6,6 +6,10 @@ from .installer_contract import (
 )
 from .equipment_specs import detect as detect_equipment_specs, extract as extract_equipment_specs
 from .invoices_or_quotes import detect as detect_invoices_or_quotes, extract as extract_invoices_or_quotes
+from .energy_savings_report import (
+    detect as detect_energy_savings_report,
+    extract as extract_energy_savings_report,
+)
 
 EXTRACTORS = {
     "business_plan": {
@@ -27,6 +31,10 @@ EXTRACTORS.update({
         "detect": detect_invoices_or_quotes,
         "extract": extract_invoices_or_quotes,
     },
+    "energy_savings_report": {
+        "detect": detect_energy_savings_report,
+        "extract": extract_energy_savings_report,
+    },
 })
 
 __all__ = [
@@ -41,4 +49,6 @@ __all__ = [
     "extract_equipment_specs",
     "detect_invoices_or_quotes",
     "extract_invoices_or_quotes",
+    "detect_energy_savings_report",
+    "extract_energy_savings_report",
 ]

--- a/ai-analyzer/src/extractors/energy_savings_report.py
+++ b/ai-analyzer/src/extractors/energy_savings_report.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+from datetime import datetime
+import re
+from typing import List
+from pydantic import BaseModel
+
+KEYWORDS = [
+    "Energy Savings Report",
+    "Engineering Report",
+    "Measurement and Verification",
+    "M&V",
+    "Baseline",
+    "Post-Installation",
+    "kWh Saved",
+    "Payback",
+    "NPV",
+    "IRR",
+    "ASHRAE",
+    "IPMVP",
+]
+
+
+def detect(text: str) -> bool:
+    t = text.lower()
+    return any(k.lower() in t for k in KEYWORDS)
+
+
+class EnergySavingsFields(BaseModel):
+    report_date: str | None = None
+    business_name: str | None = None
+    site_address: str | None = None
+    measure_type: str | None = None
+    baseline_kwh_annual: float | None = None
+    post_kwh_annual: float | None = None
+    kwh_saved_annual: float | None = None
+    demand_reduction_kw: float | None = None
+    tariff_rate_usd_per_kwh: float | None = None
+    annual_savings_usd: float | None = None
+    capex_usd: float | None = None
+    opex_usd: float | None = None
+    payback_years: float | None = None
+    npv_usd: float | None = None
+    irr_percent: float | None = None
+    standards_refs: List[str] = []
+    prepared_by_name: str | None = None
+    prepared_by_license: str | None = None
+
+
+DATE_RE = re.compile(r"(?i)(?:report date|date)[:\s]+([\w\-/, ]{4,20})")
+BUSINESS_RE = re.compile(r"(?i)(?:business|customer|site)[:\s]+(.+)")
+ADDRESS_RE = re.compile(r"(?i)(?:site|facility) address[:\s]+(.+)")
+MEASURE_RE = re.compile(
+    r"(?i)(solar|hvac|lighting|heat pump|vfd|wind|battery|insulation)")
+BASELINE_KWH_RE = re.compile(
+    r"(?i)baseline[^\n]*?([0-9,]+)\s*kWh(?:[^\n]*annual)?"
+)
+POST_KWH_RE = re.compile(
+    r"(?i)post[- ]?(?:install(?:ation)?)?[^\n]*?([0-9,]+)\s*kWh"
+)
+KWH_SAVED_RE = re.compile(r"(?i)kWh saved[^\n]*?([0-9,]+)")
+DEMAND_RE = re.compile(
+    r"(?i)(?:demand|peak) reduction[^\n]*?([0-9.,]+)\s*kW"
+)
+TARIFF_RE = re.compile(r"\$([0-9.]+)\s*/\s*kWh")
+ANNUAL_SAVINGS_RE = re.compile(
+    r"(?i)annual savings[^\n]*?\$([0-9,]+(?:\.[0-9]{2})?)"
+)
+CAPEX_RE = re.compile(r"(?i)(?:capex|capital cost)[^\n]*?\$([0-9,]+(?:\.[0-9]{2})?)")
+OPEX_RE = re.compile(r"(?i)(?:opex|operating cost)[^\n]*?\$([0-9,]+(?:\.[0-9]{2})?)")
+PAYBACK_RE = re.compile(r"(?i)payback[^\n]*?([0-9]+(?:\.[0-9]+)?)\s*(?:years|yrs)")
+NPV_RE = re.compile(r"(?i)npv[^\n]*?\$([0-9,.-]+)")
+IRR_RE = re.compile(r"(?i)irr[^\n]*?([0-9]+(?:\.[0-9]+)?)\s*%")
+STANDARDS_RE = re.compile(r"(?i)\b(ASHRAE\s?\d{1,3}\.\d|IPMVP(?: Option [A-D])?)\b")
+PREPARED_NAME_RE = re.compile(
+    r"(?i)prepared by[:\s]+(.+?)(?:,|\n)")
+PREPARED_LICENSE_RE = re.compile(r"(?i)(?:license|pe)[:#\s]+([A-Za-z0-9#-]+)")
+
+
+def _to_number(val: str) -> float:
+    return float(val.replace(",", ""))
+
+
+def _norm_date(val: str) -> str:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%B %d, %Y", "%b %d, %Y"):
+        try:
+            return datetime.strptime(val.strip(), fmt).date().isoformat()
+        except ValueError:
+            continue
+    return val.strip()
+
+
+def extract(text: str) -> dict:
+    f = EnergySavingsFields()
+    if m := DATE_RE.search(text):
+        f.report_date = _norm_date(m.group(1))
+    if m := BUSINESS_RE.search(text):
+        f.business_name = m.group(1).strip()
+    if m := ADDRESS_RE.search(text):
+        f.site_address = m.group(1).strip()
+    if m := MEASURE_RE.search(text):
+        f.measure_type = m.group(1).title()
+    if m := BASELINE_KWH_RE.search(text):
+        f.baseline_kwh_annual = _to_number(m.group(1))
+    if m := POST_KWH_RE.search(text):
+        f.post_kwh_annual = _to_number(m.group(1))
+    if m := KWH_SAVED_RE.search(text):
+        f.kwh_saved_annual = _to_number(m.group(1))
+    if f.baseline_kwh_annual and f.post_kwh_annual and f.kwh_saved_annual is None:
+        f.kwh_saved_annual = f.baseline_kwh_annual - f.post_kwh_annual
+    if m := DEMAND_RE.search(text):
+        f.demand_reduction_kw = _to_number(m.group(1))
+    if m := TARIFF_RE.search(text):
+        f.tariff_rate_usd_per_kwh = float(m.group(1))
+    if m := ANNUAL_SAVINGS_RE.search(text):
+        f.annual_savings_usd = _to_number(m.group(1))
+    if m := CAPEX_RE.search(text):
+        f.capex_usd = _to_number(m.group(1))
+    if m := OPEX_RE.search(text):
+        f.opex_usd = _to_number(m.group(1))
+    if m := PAYBACK_RE.search(text):
+        f.payback_years = float(m.group(1))
+    if m := NPV_RE.search(text):
+        f.npv_usd = _to_number(m.group(1))
+    if m := IRR_RE.search(text):
+        f.irr_percent = float(m.group(1))
+    f.standards_refs = [m.group(1).strip() for m in STANDARDS_RE.finditer(text)]
+    if m := PREPARED_NAME_RE.search(text):
+        f.prepared_by_name = m.group(1).strip()
+    if m := PREPARED_LICENSE_RE.search(text):
+        f.prepared_by_license = m.group(1).strip()
+
+    confidence = 0.6
+    if f.baseline_kwh_annual is not None and f.post_kwh_annual is not None:
+        confidence += 0.15
+    if f.kwh_saved_annual is not None:
+        confidence += 0.1
+    if any([f.payback_years, f.npv_usd, f.irr_percent]):
+        confidence += 0.1
+    if f.standards_refs:
+        confidence += 0.05
+    if confidence > 0.95:
+        confidence = 0.95
+
+    return {"fields": f.model_dump(), "confidence": confidence}
+

--- a/ai-analyzer/tests/fixtures/energy_savings_report_negative.txt
+++ b/ai-analyzer/tests/fixtures/energy_savings_report_negative.txt
@@ -1,0 +1,2 @@
+This document discusses general energy policies and history.
+It contains no measurements, savings data, or financial analysis.

--- a/ai-analyzer/tests/fixtures/energy_savings_report_sample.txt
+++ b/ai-analyzer/tests/fixtures/energy_savings_report_sample.txt
@@ -1,0 +1,20 @@
+Energy Savings Report
+Report Date: August 1, 2025
+Business Name: Acme Manufacturing
+Site Address: 123 Main St, Springfield, CA
+
+Measure Type: HVAC
+
+Baseline Annual Energy Consumption: 180,000 kWh
+Post-Installation Annual Energy Consumption: 132,000 kWh
+Demand Reduction: 15.2 kW
+Tariff Rate: $0.18/kWh
+kWh Saved: 48,000
+Annual Savings: $8,640
+CAPEX: $42,000
+OPEX: $500
+Payback: 4.9 years
+NPV: $6,200
+IRR: 13%
+Standards: ASHRAE 90.1, IPMVP Option B
+Prepared by: Green Engineering LLC, PE #AB1234

--- a/ai-analyzer/tests/test_energy_savings_report.py
+++ b/ai-analyzer/tests/test_energy_savings_report.py
@@ -1,0 +1,34 @@
+import os
+from src.detectors import identify
+from src.extractors.energy_savings_report import detect, extract
+
+
+def load_sample(name="energy_savings_report_sample.txt"):
+    p = os.path.join(os.path.dirname(__file__), "fixtures", name)
+    with open(p, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def test_detect_energy_savings_report():
+    text = load_sample()
+    assert detect(text)
+    det = identify(text)
+    assert det["type_key"] == "Energy_Savings_Report"
+    assert det["confidence"] >= 0.5
+
+
+def test_extract_energy_savings_report_fields():
+    text = load_sample()
+    result = extract(text)
+    fields = result["fields"]
+    assert fields["baseline_kwh_annual"] == 180000.0
+    assert fields["post_kwh_annual"] == 132000.0
+    assert fields["kwh_saved_annual"] == 48000.0
+    assert fields["payback_years"] == 4.9
+    assert "ASHRAE 90.1" in fields["standards_refs"]
+    assert result["confidence"] >= 0.85
+
+
+def test_negative_detection():
+    text = load_sample("energy_savings_report_negative.txt")
+    assert not detect(text)

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -408,5 +408,25 @@
     "tax_amount":        { "aliases": ["tax_amount","tax"], "type": "number" },
     "total_amount":      { "aliases": ["total_amount","amount_due","grand_total"], "type": "number" },
     "currency":          { "aliases": ["currency"], "type": "string" }
+  },
+  "energy_savings_report": {
+    "report_date":            { "aliases": ["report_date","date"], "type": "date" },
+    "business_name":          { "aliases": ["business_name","customer_name"], "type": "string" },
+    "site_address":           { "aliases": ["site_address","facility_address"], "type": "string" },
+    "measure_type":           { "aliases": ["measure_type","project_type"], "type": "string" },
+    "baseline_kwh_annual":    { "aliases": ["baseline_kwh_annual","baseline_kwh"], "type": "number" },
+    "post_kwh_annual":        { "aliases": ["post_kwh_annual","post_kwh"], "type": "number" },
+    "kwh_saved_annual":       { "aliases": ["kwh_saved_annual","annual_kwh_saved","kwh_savings"], "type": "number" },
+    "demand_reduction_kw":    { "aliases": ["demand_reduction_kw","kw_reduction"], "type": "number" },
+    "tariff_rate_usd_per_kwh":{ "aliases": ["tariff_rate_usd_per_kwh","rate_usd_per_kwh"], "type": "number" },
+    "annual_savings_usd":     { "aliases": ["annual_savings_usd","annual_savings"], "type": "number" },
+    "capex_usd":              { "aliases": ["capex_usd","capex"], "type": "number" },
+    "opex_usd":               { "aliases": ["opex_usd","opex"], "type": "number" },
+    "payback_years":          { "aliases": ["payback_years","payback"], "type": "number" },
+    "npv_usd":                { "aliases": ["npv_usd","npv"], "type": "number" },
+    "irr_percent":            { "aliases": ["irr_percent","irr"], "type": "number" },
+    "standards_refs":         { "aliases": ["standards_refs","standards"], "type": "array" },
+    "prepared_by_name":       { "aliases": ["prepared_by_name","engineer_name"], "type": "string" },
+    "prepared_by_license":    { "aliases": ["prepared_by_license","engineer_license"], "type": "string" }
   }
 }

--- a/server/tests/checklist.energy_savings_report.test.js
+++ b/server/tests/checklist.energy_savings_report.test.js
@@ -1,0 +1,139 @@
+process.env.SKIP_DB = 'true';
+const request = require('supertest');
+
+let createCase;
+let resetStoreFn;
+
+describe('Energy Savings Report checklist integration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const store = require('../utils/pipelineStore');
+    createCase = store.createCase;
+    resetStoreFn = store.resetStore;
+    resetStoreFn();
+    global.pipelineFetch = jest.fn();
+    jest
+      .spyOn(require('../utils/documentLibrary'), 'loadGrantsLibrary')
+      .mockResolvedValue({
+        green_energy_state_incentive: {
+          required_docs: ['Energy_Savings_Report'],
+          common_docs: [],
+        },
+        energy_efficiency_upgrade: {
+          required_docs: ['Energy_Savings_Report'],
+          common_docs: [],
+        },
+      });
+    jest
+      .spyOn(require('../models/Case'), 'findOne')
+      .mockImplementation(({ caseId }) => ({
+        lean: async () => {
+          const store = require('../utils/pipelineStore');
+          return store.getCase('dev-user', caseId);
+        },
+      }));
+    app = require('../index');
+  });
+
+  afterEach(() => {
+    resetStoreFn();
+    jest.restoreAllMocks();
+    delete global.pipelineFetch;
+  });
+
+  test('dedupes Energy Savings Report and preserves status', async () => {
+    const caseId = await createCase('dev-user');
+
+    // Initial eligibility: both grants shortlisted
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [
+          { key: 'green_energy_state_incentive', score: 1 },
+          { key: 'energy_efficiency_upgrade', score: 1 },
+        ],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    let res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    let items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Energy_Savings_Report'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('not_uploaded');
+
+    // Upload Energy Savings Report -> analyzer then eligibility
+    global.pipelineFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          doc_type: 'Energy_Savings_Report',
+          fields: {
+            baseline_kwh_annual: 180000,
+            post_kwh_annual: 132000,
+            kwh_saved_annual: 48000,
+          },
+          doc_confidence: 0.9,
+        }),
+        headers: { get: () => 'application/json' },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            { key: 'green_energy_state_incentive', score: 1 },
+            { key: 'energy_efficiency_upgrade', score: 1 },
+          ],
+        }),
+        headers: { get: () => 'application/json' },
+      });
+
+    res = await request(app)
+      .post('/api/files/upload')
+      .field('caseId', caseId)
+      .field('key', 'Energy_Savings_Report')
+      .attach('file', Buffer.from('dummy'), 'esr.pdf');
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Energy_Savings_Report'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Re-run eligibility with only one grant
+    global.pipelineFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ key: 'energy_efficiency_upgrade', score: 1 }],
+      }),
+      headers: { get: () => 'application/json' },
+    });
+
+    res = await request(app)
+      .post('/api/eligibility-report')
+      .send({ caseId, payload: { foo: 'bar' } });
+    expect(res.status).toBe(200);
+    items = res.body.requiredDocuments.filter(
+      (d) => d.doc_type === 'Energy_Savings_Report'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('extracted');
+
+    // Checklist endpoint reflects uploaded ESR
+    res = await request(app)
+      .get('/api/case/required-documents')
+      .query({ caseId });
+    expect(res.status).toBe(200);
+    const checklistItems = res.body.required.filter(
+      (d) => d.doc_type === 'Energy_Savings_Report'
+    );
+    expect(checklistItems).toHaveLength(1);
+    expect(checklistItems[0].status).toBe('extracted');
+  });
+});

--- a/server/utils/documentLibrary.js
+++ b/server/utils/documentLibrary.js
@@ -57,7 +57,7 @@ function getRequiredDocs(grantKey, caseDocs = []) {
       : [d];
   const all = [
     ...(lib.common_documents || []),
-    ...(g.required_documents || []),
+    ...(g.required_documents || g.required_docs || []),
   ].flatMap(expandDocType);
   const seen = new Map();
   for (const d of all) {

--- a/shared/document_library/grants_v1.json
+++ b/shared/document_library/grants_v1.json
@@ -111,6 +111,7 @@
         "Installer_Contract",
         "Equipment_Specs",
         "Invoices_or_Quotes",
+        "Energy_Savings_Report",
         "Grant_Use_Statement"
       ],
       "common_docs": [
@@ -127,6 +128,7 @@
         "Installer_Contract",
         "Equipment_Specs",
         "Invoices_or_Quotes",
+        "Energy_Savings_Report",
         "Grant_Use_Statement"
       ],
       "common_docs": [

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -302,6 +302,47 @@
       },
       "description": "Vendor invoice or quote/estimate showing equipment/services, unit costs, totals, and dates. Used to substantiate project costs."
     },
+    "Energy_Savings_Report": {
+      "extractor": "energy_savings_report",
+      "detector": {
+        "keywords": [
+          "Energy Savings Report",
+          "Engineering Report",
+          "Measurement and Verification",
+          "M&V",
+          "Baseline",
+          "Post-Installation",
+          "kWh Saved",
+          "Payback",
+          "NPV",
+          "IRR",
+          "ASHRAE",
+          "IPMVP"
+        ],
+        "regex": ["(?i)energy savings report"]
+      },
+      "fields": {
+        "report_date": "date",
+        "business_name": "string",
+        "site_address": "string",
+        "measure_type": "string",
+        "baseline_kwh_annual": "number",
+        "post_kwh_annual": "number",
+        "kwh_saved_annual": "number",
+        "demand_reduction_kw": "number",
+        "tariff_rate_usd_per_kwh": "number",
+        "annual_savings_usd": "number",
+        "capex_usd": "number",
+        "opex_usd": "number",
+        "payback_years": "number",
+        "npv_usd": "number",
+        "irr_percent": "number",
+        "standards_refs": "array",
+        "prepared_by_name": "string",
+        "prepared_by_license": "string"
+      },
+      "description": "Engineering/M&V report documenting baseline vs. post energy use, kWh savings, demand reduction, financial metrics, and standards compliance."
+    },
     "Financial_Statements": {
       "composite": true,
       "expands_to": [


### PR DESCRIPTION
## Summary
- add `Energy_Savings_Report` document type with extraction fields
- require Energy Savings Report for green energy grant programs
- implement analyzer detector/extractor and normalize fields for eligibility

## Testing
- `pytest ai-analyzer/tests/test_energy_savings_report.py -q`
- `cd server && npm test tests/checklist.energy_savings_report.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_68b71c2d9a948327be2c0550f4f0ef0d