### PR TITLE
Handle W9 legal name on following line

### DIFF
--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -61,10 +61,25 @@ def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
         text,
         flags=re.IGNORECASE,
     )
-    if not m_name:
-        m_name = re.search(r"(?:Name|Legal Name)\s*[:\-]\s*(.+)", text, flags=re.IGNORECASE)
     if m_name:
         legal_name = m_name.group(1).strip()
+    else:
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if re.search(r"Name\s*\(as shown on your income tax return\)", line, flags=re.IGNORECASE):
+                if i + 1 < len(lines):
+                    nxt = lines[i + 1].strip()
+                    if nxt:
+                        legal_name = nxt
+                break
+        if not legal_name:
+            m_name = re.search(
+                r"(?:Name|Legal Name)\s*[:\-]\s*(.+)",
+                text,
+                flags=re.IGNORECASE,
+            )
+            if m_name:
+                legal_name = m_name.group(1).strip()
 
     business_name = None
     m_biz = re.search(

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -16,6 +16,12 @@ Signature of U.S. person John Doe 01/15/2024
 
 NEGATIVE = "This is just a random letter with no tax info."
 
+SAMPLE_NEXTLINE = """Form W-9
+Request for Taxpayer Identification Number and Certification
+Name (as shown on your income tax return)
+Jane Nextline
+"""
+
 
 def test_detect_and_extract():
     assert detect(SAMPLE) is True
@@ -37,3 +43,8 @@ def test_negative_sample():
     assert detect(NEGATIVE) is False
     det = identify(NEGATIVE)
     assert det == {}
+
+
+def test_name_on_next_line():
+    out = extract(SAMPLE_NEXTLINE)
+    assert out["fields"]["legal_name"] == "Jane Nextline"


### PR DESCRIPTION
## Summary
- parse legal_name from W9 forms even when name is on next line after label
- add regression test for this scenario

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9b19eda588327b94358124a1feb67