### PR TITLE
Handle spaced or unformatted TINs in W-9 extractor

### DIFF
--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -2,8 +2,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-EIN_RE = re.compile(r"\b\d{2}-\d{7}\b")
-SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+EIN_RE = re.compile(r"\b\d{2}[-\s]?\d{7}\b")
+SSN_RE = re.compile(r"\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b")
 DATE_PATS = [
     r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b",
     r"\b[A-Za-z]{3,9}\s+\d{1,2},\s+\d{4}\b",
@@ -53,7 +53,13 @@ def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
 
     ein = EIN_RE.search(text)
     ssn = SSN_RE.search(text)
-    tin = ein.group(0) if ein else (ssn.group(0) if ssn else None)
+    tin = None
+    if ein:
+        digits = re.sub(r"\D", "", ein.group(0)).strip()
+        tin = f"{digits[:2]}-{digits[2:]}"
+    elif ssn:
+        digits = re.sub(r"\D", "", ssn.group(0)).strip()
+        tin = f"{digits[:3]}-{digits[3:5]}-{digits[5:]}"
 
     legal_name = None
     m_name = re.search(

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -16,6 +16,9 @@ Signature of U.S. person John Doe 01/15/2024
 
 NEGATIVE = "This is just a random letter with no tax info."
 
+SAMPLE_NO_HYPHEN = SAMPLE.replace("TIN: 12-3456789", "TIN: 123456789")
+SAMPLE_SPACED = SAMPLE.replace("TIN: 12-3456789", "TIN: 12 3456789")
+
 SAMPLE_NEXTLINE = """Form W-9
 Request for Taxpayer Identification Number and Certification
 Name (as shown on your income tax return)
@@ -48,3 +51,10 @@ def test_negative_sample():
 def test_name_on_next_line():
     out = extract(SAMPLE_NEXTLINE)
     assert out["fields"]["legal_name"] == "Jane Nextline"
+
+
+def test_tin_variants_normalize():
+    out = extract(SAMPLE_NO_HYPHEN)
+    assert out["fields"]["tin"] == "12-3456789"
+    out = extract(SAMPLE_SPACED)
+    assert out["fields"]["tin"] == "12-3456789"


### PR DESCRIPTION
## Summary
- broaden W-9 EIN/SSN regex to allow spaces or missing hyphens
- normalize matched TINs by stripping non-digits and formatting
- cover additional TIN formats in tests

## Testing
- `cd ai-analyzer && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_b_68b9b31ff444832791c7e7f2caf6cd93