### PR TITLE
feat: standardize signature date field

### DIFF
--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -123,7 +123,7 @@ def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
                 address = line.strip()
                 break
 
-    signature_date = _parse_date(text)
+    date_signed = _parse_date(text)
 
     fields: Dict[str, Any] = {}
     if legal_name:
@@ -136,8 +136,8 @@ def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
         fields["tin"] = tin
     if address:
         fields["address"] = address
-    if signature_date:
-        fields["signature_date"] = signature_date
+    if date_signed:
+        fields["date_signed"] = date_signed
 
     conf = 0.6 + (0.1 if tin else 0) + (0.1 if legal_name else 0)
 

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -33,13 +33,13 @@ def test_detect_and_extract():
     out = extract(SAMPLE, "uploads/w9.pdf")
     assert out["doc_type"] == "W9_Form"
     fields = out["fields"]
-    for key in ["legal_name", "tin", "entity_type", "address", "signature_date"]:
+    for key in ["legal_name", "tin", "entity_type", "address", "date_signed"]:
         assert key in fields
     assert fields["tin"] == "12-3456789"
     assert fields["legal_name"].startswith("John Doe")
     assert "LLC" in fields["entity_type"].upper()
     assert "Anytown" in fields["address"]
-    assert fields["signature_date"] == "2024-01-15"
+    assert fields["date_signed"] == "2024-01-15"
 
 
 def test_negative_sample():

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -304,7 +304,7 @@
     "type": "string"
   },
   "date_signed": {
-    "aliases": ["date_signed"],
+    "aliases": ["date_signed", "signature_date"],
     "target": "date_signed",
     "type": "date"
   },

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -115,7 +115,7 @@
         "entity_type": "string",
         "tin": "string",
         "address": "string",
-        "signature_date": "date"
+        "date_signed": "date"
       },
       "examples": ["IRS Form W-9"]
     },


### PR DESCRIPTION
## Summary
- add `signature_date` alias pointing to `date_signed`
- standardize W-9 extractor and catalog to use `date_signed`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=ai-analyzer pytest ai-analyzer/tests/test_w9_form.py`
- `PYTHONPATH=ai-analyzer pytest ai-analyzer/tests/test_installer_contract.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9b46bd58c83279d52b78309998418