### PR TITLE
Improve W-9 field extraction and add test coverage

### DIFF
--- a/ai-analyzer/tests/fixtures/w9_form_multiline.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_multiline.txt
@@ -1,0 +1,15 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+1 Name (as shown on your income tax return)
+Mega
+Corp Inc
+2 Business name/disregarded entity name, if different from above:
+Mega Holdings
+LLC
+Corporation
+5 Address (number, street, and apt. or suite no.)
+789 Corporate Plaza
+6 City, state, and ZIP code
+Bigcity TX 73301
+TIN: 11-1111111
+Signature of U.S. person Mega CEO 03-03-2024

--- a/ai-analyzer/tests/fixtures/w9_form_noisy.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_noisy.txt
@@ -1,0 +1,14 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+1 Name (as shown on your income tax return) Do not leave blank
+John Q Public
+2 Business name/disregarded entity name, if different from above Enter if applicable
+Public Ventures LLC
+Partnership
+5 Address (number, street, and apt. or suite no.)
+456 Side St
+6 City, state, and ZIP code
+Othertown NY 10001
+TIN: 98-7654321
+Signature of U.S. person
+John Q Public 02/02/2024

--- a/ai-analyzer/tests/fixtures/w9_form_sample.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_sample.txt
@@ -1,0 +1,11 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+1 Name (as shown on your income tax return) John Doe
+2 Business name/disregarded entity name, if different from above JD Widgets LLC
+Limited Liability Company (LLC)
+5 Address (number, street, and apt. or suite no.)
+123 Main St
+6 City, state, and ZIP code
+Anytown CA 90210
+TIN: 12-3456789
+Signature of U.S. person John Doe 01/15/2024


### PR DESCRIPTION
## Summary
- refine W-9 extractor to strip instructional text, trim business names, and limit signature date detection
- normalize whitespace and punctuation in returned fields
- add fixtures and unit tests for noisy, multiline, and alternate TIN/date layouts

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9bf22d7ec8327bc66778c0b192c69