### PR TITLE
Clean W-9 extractor output

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -370,7 +370,10 @@ async def analyze_text_flow(
     response["doc_type"] = type_info.get("key")
     response["doc_confidence"] = type_info.get("confidence", 0)
     extracted = det.get("extracted") or {}
-    response["fields"] = extracted.get("fields", extracted)
+    if isinstance(extracted, dict) and "fields" in extracted:
+        response["fields"] = extracted["fields"]
+    else:
+        response["fields"] = extracted
     extra = {"source": source}
     if filename:
         extra["upload_filename"] = filename

--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -93,7 +93,7 @@ def _extract_signature_date(text: str) -> Optional[str]:
             snippet = "\n".join(lines[i : i + 3])
             dt = _parse_date(snippet)
             if dt:
-                return dt
+                return _clean(dt)
     return None
 
 
@@ -156,17 +156,17 @@ def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
 
     fields: Dict[str, Any] = {}
     if legal_name:
-        fields["legal_name"] = legal_name
+        fields["legal_name"] = _clean(legal_name)
     if business_name:
-        fields["business_name"] = business_name
+        fields["business_name"] = _clean(business_name)
     if entity_type:
-        fields["entity_type"] = entity_type
+        fields["entity_type"] = _clean(entity_type)
     if tin:
         fields["tin"] = _clean(tin)
     if address:
-        fields["address"] = address
+        fields["address"] = _clean(address)
     if date_signed:
-        fields["date_signed"] = date_signed
+        fields["date_signed"] = _clean(date_signed)
 
     conf = 0.6 + (0.1 if tin else 0) + (0.1 if legal_name else 0)
 

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -103,3 +103,14 @@ def test_analyze_endpoint_returns_w9_fields():
         assert key in fields
     assert fields["tin"] == "12-3456789"
     assert fields["business_name"] == "JD Widgets LLC"
+
+
+def test_analyze_endpoint_trims_instructions():
+    resp = client.post("/analyze", json={"text": NOISY})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["doc_type"] == "W9_Form"
+    fields = data.get("fields", {})
+    assert fields["legal_name"] == "John Q Public"
+    assert fields["business_name"] == "Public Ventures LLC"
+    assert fields["date_signed"] == "2024-02-02"


### PR DESCRIPTION
## Summary
- sanitize W-9 form fields with `_clean` before returning
- ensure `/analyze` uses cleaned field dictionary
- add integration test for trimmed W-9 fields

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9c46b3c9083278a0a8052777621c3