### PR TITLE
Ensure analyzer returns cleaned W-9 fields

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -370,8 +370,13 @@ async def analyze_text_flow(
     response["doc_type"] = type_info.get("key")
     response["doc_confidence"] = type_info.get("confidence", 0)
     extracted = det.get("extracted") or {}
-    if isinstance(extracted, dict) and "fields" in extracted:
-        response["fields"] = extracted["fields"]
+    if isinstance(extracted, dict):
+        if "fields_clean" in extracted:
+            response["fields"] = extracted["fields_clean"]
+        elif "fields" in extracted:
+            response["fields"] = extracted["fields"]
+        else:
+            response["fields"] = extracted
     else:
         response["fields"] = extracted
     extra = {"source": source}


### PR DESCRIPTION
## Summary
- Prefer `fields_clean` from extractors when available to avoid returning raw regex matches
- Add regression test verifying `/analyze` endpoint uses normalized extractor output

## Testing
- `pytest tests/test_w9_form.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba22e430dc832792f589e9dc771b93