### PR TITLE
Sanitize W‑9 extraction output and add regression coverage

### DIFF
--- a/ai-analyzer/tests/fixtures/w9_form_instructional.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_instructional.txt
@@ -1,0 +1,14 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+1 Name (as shown on your income tax return) Name is required on this line
+DAM CAPITAL GROUP CORP
+2 Business name/disregarded entity name, if different from above Broker transactions or barter exchanges
+Lenderfy capital
+LLC - Limited Liability Company
+5 Address (number, street, and apt. or suite no.) This is where you should enter your address
+101 Diplomat Pkwy Unit 2301
+6 City, state, and ZIP code
+Hallandale Beach, FL 33009
+TIN: 12-3456789
+Signature of U.S. person Do not write here
+John Q Public 10/05/2023


### PR DESCRIPTION
## Summary
- Filter out additional instruction phrases when extracting W-9 fields
- Always return normalized `fields_clean` for W-9 forms and join address lines with commas
- Add noisy W-9 fixture and regression tests verifying sanitized `/analyze` output

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py::test_extract_provides_fields_clean -q`
- `pytest ai-analyzer/tests/test_w9_form.py::test_analyze_handles_instructional_noise -q`
- `pytest ai-analyzer/tests -q`

------
https://chatgpt.com/codex/tasks/task_b_68ba2676a57483279fe2105aa2009635