### PR TITLE
Prefer cleaned extractor fields in analyzer

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -371,14 +371,10 @@ async def analyze_text_flow(
     response["doc_confidence"] = type_info.get("confidence", 0)
     extracted = det.get("extracted") or {}
     if isinstance(extracted, dict):
-        if "fields_clean" in extracted:
-            response["fields"] = extracted["fields_clean"]
-        elif "fields" in extracted:
-            response["fields"] = extracted["fields"]
-        else:
-            response["fields"] = extracted
+        doc_fields = extracted.get("fields_clean", extracted.get("fields", extracted))
     else:
-        response["fields"] = extracted
+        doc_fields = extracted
+    response["fields"] = doc_fields
     extra = {"source": source}
     if filename:
         extra["upload_filename"] = filename

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -152,3 +152,18 @@ def test_analyze_prefers_clean_fields(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["fields"]["legal_name"] == "John Doe"
+
+
+def test_analyze_falls_back_to_raw_fields(monkeypatch):
+    def fake_extract(text, evidence_key=None):
+        return {
+            "doc_type": "W9_Form",
+            "confidence": 0.9,
+            "fields": {"legal_name": "Raw Name"},
+        }
+
+    monkeypatch.setattr("src.extractors.w9_form.extract", fake_extract)
+    resp = client.post("/analyze", json={"text": SAMPLE})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["fields"]["legal_name"] == "Raw Name"


### PR DESCRIPTION
## Summary
- Ensure `/analyze` uses `fields_clean` from extractors when available
- Add regression test covering clean-field preference and raw-field fallback

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68bef497a060832796f393ffe3eac972