### PR TITLE
Handle raw vs clean W-9 fields

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -371,10 +371,11 @@ async def analyze_text_flow(
     response["doc_confidence"] = type_info.get("confidence", 0)
     extracted = det.get("extracted") or {}
     if isinstance(extracted, dict):
-        doc_fields = extracted.get("fields_clean", extracted.get("fields", extracted))
+        response["fields"] = extracted.get("fields", {})
+        if "fields_clean" in extracted:
+            response["fields_clean"] = extracted.get("fields_clean", {})
     else:
-        doc_fields = extracted
-    response["fields"] = doc_fields
+        response["fields"] = extracted
     extra = {"source": source}
     if filename:
         extra["upload_filename"] = filename


### PR DESCRIPTION
## Summary
- split W-9 extractor output into raw `fields` and sanitized `fields_clean`
- strip instructional text from cleaned W-9 values
- expose raw and cleaned fields separately from `/analyze` and expand tests

## Testing
- `pytest ai-analyzer/tests -q`

------
https://chatgpt.com/codex/tasks/task_b_68bef955e454832799f96689f648ac09