### PR TITLE
Handle space-separated EIN digits in W-9 extractor

### DIFF
--- a/ai-analyzer/src/extractors/w9_form.py
+++ b/ai-analyzer/src/extractors/w9_form.py
@@ -2,7 +2,12 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-EIN_RE = re.compile(r"\b\d{2}[-\s]?\d{7}\b")
+# Match EIN even when digits are separated by spaces or rendered in
+# individual OCR tokens (e.g. "3 3 - 1 3 4 0 4 8 2"). Allow optional
+# whitespace between all digits and an optional hyphen after the first two
+# digits. Canonical format is still two digits, optional hyphen, then seven
+# digits.
+EIN_RE = re.compile(r"\b(?:\d[\s]*){2}(?:-\s*)?(?:\d[\s]*){7}\b")
 SSN_RE = re.compile(r"\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b")
 DATE_PATS = [
     r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b",

--- a/ai-analyzer/tests/fixtures/w9_form_boxed.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_boxed.txt
@@ -1,0 +1,11 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+1 Name (as shown on your income tax return) John Doe
+2 Business name/disregarded entity name, if different from above JD Widgets LLC
+Limited Liability Company (LLC)
+5 Address (number, street, and apt. or suite no.)
+123 Main St
+6 City, state, and ZIP code
+Anytown CA 90210
+TIN: 1 2 - 3 4 5 6 7 8 9
+Signature of U.S. person John Doe 01/15/2024

--- a/ai-analyzer/tests/test_w9_form.py
+++ b/ai-analyzer/tests/test_w9_form.py
@@ -12,6 +12,9 @@ NOISY = (FIXTURES / "w9_form_noisy.txt").read_text()
 MULTILINE = (FIXTURES / "w9_form_multiline.txt").read_text()
 INSTRUCTIONAL = (FIXTURES / "w9_form_instructional.txt").read_text()
 NEGATIVE = "This is just a random letter with no tax info."
+BOXED = (FIXTURES / "w9_form_boxed.txt").read_text()
+BOXED_NO_HYPHEN = BOXED.replace("TIN: 1 2 - 3 4 5 6 7 8 9", "TIN: 1 2 3 4 5 6 7 8 9")
+BOXED_EXTRA_WS = BOXED.replace("TIN: 1 2 - 3 4 5 6 7 8 9", "TIN:   1  2-   3 4 5 6 7 8 9  ")
 
 MISSING_NAME = "\n".join(
     [
@@ -93,6 +96,18 @@ def test_tin_variants_normalize():
     out = extract(SAMPLE_NO_HYPHEN)
     assert out["fields_clean"]["tin"] == "12-3456789"
     out = extract(SAMPLE_SPACED)
+    assert out["fields_clean"]["tin"] == "12-3456789"
+
+
+def test_box_separated_ein_variants():
+    out = extract(BOXED)
+    assert out["fields"]["tin"] == "1 2 - 3 4 5 6 7 8 9"
+    assert out["fields_clean"]["tin"] == "12-3456789"
+    out = extract(BOXED_NO_HYPHEN)
+    assert out["fields"]["tin"]
+    assert out["fields_clean"]["tin"] == "12-3456789"
+    out = extract(BOXED_EXTRA_WS)
+    assert out["fields"]["tin"]
     assert out["fields_clean"]["tin"] == "12-3456789"
 
 


### PR DESCRIPTION
## Summary
- detect EINs even when digits are spaced or boxed and normalize to NN-NNNNNNN
- add fixtures and tests for boxed, spaced, and irregular EIN formats

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68beff85e74883279d23844e67a70087