### PR TITLE
fix: normalize EIN extraction with flexible separators

### DIFF
--- a/ai-analyzer/tests/fixtures/w9_form_dcg.txt
+++ b/ai-analyzer/tests/fixtures/w9_form_dcg.txt
@@ -1,0 +1,7 @@
+Form W-9 (Rev. October 2018)
+Request for Taxpayer Identification Number and Certification
+
+1 Name (as shown on your income tax return) DCG Demo Corp
+2 Business name/disregarded entity name, if different from above DCG Demo
+TIN: 3 3 - _ 1 3 4 _ 0 4 8 2
+Signature of U.S. person Jane Doe 03/03/2024


### PR DESCRIPTION
## Summary
- expand W-9 EIN regex to accept arbitrary non-digit separators
- normalize and emit EIN in canonical form in both fields and fields_clean
- add DCG W-9 fixture and regression tests

## Testing
- `pytest ai-analyzer/tests/test_w9_form.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68bf0680f3e88327ab582d4b6119974a