### PR TITLE
feat: prefer cleaned analyzer fields

### DIFF
--- a/server/routes/case.js
+++ b/server/routes/case.js
@@ -3,6 +3,7 @@ const { createCase, getCase } = require('../utils/pipelineStore');
 const { buildChecklist } = require('../utils/checklistBuilder');
 const Case = require('../models/Case');
 const { loadGrantsLibrary } = require('../utils/documentLibrary');
+const { preferCleanFields } = require('../utils/preferCleanFields');
 
 const router = express.Router();
 
@@ -26,7 +27,7 @@ async function caseStatusHandler(req, res) {
     createdAt: c.createdAt,
     status: c.status,
     analyzer: c.analyzer,
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     questionnaire: {
       data: c.questionnaire?.data || {},
       missingFieldsHint: missing,
@@ -55,7 +56,7 @@ router.post('/case/init', async (req, res) => {
     createdAt: c.createdAt,
     status: c.status,
     analyzer: c.analyzer,
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     questionnaire: {
       data: c.questionnaire?.data || {},
       missingFieldsHint: missing,

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -21,6 +21,7 @@ const {
   toNumber,
   currency,
 } = require('../utils/normalizeAnswers');
+const { preferCleanFields } = require('../utils/preferCleanFields');
 const {
   mapSF424,
   mapSF424A,
@@ -104,7 +105,7 @@ router.get('/eligibility-report', async (req, res) => {
     caseId,
     eligibility: c.eligibility,
     missingFieldsSummary: missing,
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     documents: c.documents,
     status: c.status,
     generatedForms: c.generatedForms,
@@ -124,7 +125,7 @@ router.post('/eligibility-report', async (req, res) => {
     existingCase = await getCase(userId, caseId);
     if (!existingCase)
       return res.status(404).json({ message: 'Case not found' });
-    analyzerFields = existingCase.analyzer?.fields || {};
+    analyzerFields = preferCleanFields(existingCase.analyzer || {});
     base = { ...analyzerFields, ...payload };
   } else {
     caseId = await createCase(userId);
@@ -427,7 +428,7 @@ router.post('/eligibility-report', async (req, res) => {
     caseId,
     eligibility,
     missingFieldsSummary: missing,
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     documents: c.documents,
     status: c.status,
     generatedForms: c.generatedForms,

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -29,6 +29,7 @@ const {
   map8974,
   map6765,
 } = require('../utils/formMappers');
+const { preferCleanFields } = require('../utils/preferCleanFields');
 
 function mapForForm(formId, answers, { testMode = false } = {}) {
   switch (formId) {
@@ -110,7 +111,8 @@ router.post('/submit-case', upload.any(), validate(schemas.pipelineSubmit), asyn
         await updateCase(caseId, { status: 'error', error: text });
         return res.status(502).json({ message: `AI analyzer error ${resp.status}`, details: text });
       }
-      const fields = await resp.json();
+      const analysis = await resp.json();
+      const fields = preferCleanFields(analysis);
       extracted = { ...extracted, ...fields };
     }
     const overrideKeys = Object.keys(basePayload).filter((key) =>
@@ -362,7 +364,7 @@ router.get('/status/:caseId', async (req, res) => {
     createdAt: c.createdAt,
     status: c.status,
     analyzer: c.analyzer,
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     questionnaire: {
       data: c.questionnaire?.data || {},
       missingFieldsHint: missing,

--- a/server/routes/questionnaire.js
+++ b/server/routes/questionnaire.js
@@ -4,6 +4,7 @@ const logger = require('../utils/logger');
 const { getRequiredDocuments } = require('../utils/requiredDocuments');
 const { safeMerge } = require('../utils/safeMerge');
 const { normalizeAnswers } = require('../utils/normalizeAnswers');
+const { preferCleanFields } = require('../utils/preferCleanFields');
 
 const router = express.Router();
 
@@ -28,7 +29,7 @@ router.get(['/questionnaire', '/case/questionnaire'], async (req, res) => {
       missingFieldsHint: missing,
       lastUpdated: c.questionnaire?.lastUpdated,
     },
-    analyzerFields: c.analyzer?.fields,
+    analyzerFields: preferCleanFields(c.analyzer || {}),
     eligibility: c.eligibility?.results,
     documents: c.documents,
     status: c.status,
@@ -50,7 +51,7 @@ router.post(['/questionnaire', '/case/questionnaire'], async (req, res) => {
     caseId = await createCase(userId);
     c = await getCase(userId, caseId);
   }
-  const existingFields = (c.analyzer && c.analyzer.fields) || {};
+  const existingFields = preferCleanFields(c.analyzer || {});
   const keyMap = {
     entityType: 'entity_type',
     employees: 'w2_employee_count',
@@ -103,7 +104,7 @@ router.post(['/questionnaire', '/case/questionnaire'], async (req, res) => {
     caseId,
     status: updated.status,
     analyzer: updated.analyzer,
-    analyzerFields: updated.analyzer?.fields,
+    analyzerFields: preferCleanFields(updated.analyzer || {}),
     eligibility: updated.eligibility,
     documents: updated.documents,
     requiredDocuments: updated.requiredDocuments,

--- a/server/tests/files.preferCleanFields.test.js
+++ b/server/tests/files.preferCleanFields.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+process.env.SKIP_DB = 'true';
+
+global.pipelineFetch = jest.fn();
+const app = require('../index');
+const { getCase } = require('../utils/pipelineStore');
+
+afterEach(() => {
+  global.pipelineFetch.mockReset();
+});
+
+afterAll(() => {
+  delete global.pipelineFetch;
+});
+
+test('uses fields_clean when provided by analyzer', async () => {
+  global.pipelineFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        doc_type: 'W9_Form',
+        fields: { tin: 'raw-000' },
+        fields_clean: { tin: '33-1340482' },
+        doc_confidence: 0.9,
+      }),
+      headers: { get: () => 'application/json' },
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [] }),
+      headers: { get: () => 'application/json' },
+    });
+
+  const res = await request(app)
+    .post('/api/files/upload')
+    .attach('file', Buffer.from('dummy'), 'w9.pdf');
+
+  expect(res.status).toBe(200);
+  expect(res.body.analyzerFields.employer_identification_number).toBe('33-1340482');
+  const c = await getCase('dev-user', res.body.caseId);
+  expect(c.analyzer.fields.employer_identification_number).toBe('33-1340482');
+});

--- a/server/tests/preferCleanFields.test.js
+++ b/server/tests/preferCleanFields.test.js
@@ -1,0 +1,16 @@
+const { preferCleanFields } = require('../utils/preferCleanFields');
+
+test('uses fields_clean when available', () => {
+  const resp = { fields: { a: 'raw' }, fields_clean: { a: 'clean' } };
+  expect(preferCleanFields(resp)).toEqual({ a: 'clean' });
+});
+
+test('falls back to fields', () => {
+  const resp = { fields: { a: 'raw' } };
+  expect(preferCleanFields(resp)).toEqual({ a: 'raw' });
+});
+
+test('handles direct field object', () => {
+  const resp = { a: 'value' };
+  expect(preferCleanFields(resp)).toEqual({ a: 'value' });
+});

--- a/server/utils/preferCleanFields.js
+++ b/server/utils/preferCleanFields.js
@@ -1,0 +1,20 @@
+const logger = require('./logger');
+
+let logged = false;
+
+function preferCleanFields(analyzerResp = {}) {
+  if (analyzerResp && analyzerResp.fields_clean) {
+    if (!logged) {
+      const logFn = logger.debug ? logger.debug.bind(logger) : logger.info.bind(logger);
+      logFn('preferCleanFields using fields_clean');
+      logged = true;
+    }
+    return analyzerResp.fields_clean;
+  }
+  if (analyzerResp && analyzerResp.fields) {
+    return analyzerResp.fields;
+  }
+  return analyzerResp || {};
+}
+
+module.exports = { preferCleanFields };

--- a/server/utils/requiredDocuments.js
+++ b/server/utils/requiredDocuments.js
@@ -8,6 +8,8 @@ const ALWAYS_REQUIRED = [
   "Financial Statements (P&L + Balance Sheet)",
 ];
 
+const { preferCleanFields } = require('./preferCleanFields');
+
 function hasEligibility(caseObj, name) {
   const list = caseObj?.eligibility?.results || caseObj?.eligibility || [];
   return Array.isArray(list) && list.some((r) => r.name === name);
@@ -16,7 +18,10 @@ function hasEligibility(caseObj, name) {
 function getRequiredDocuments(caseObj = {}) {
   const req = new Set(ALWAYS_REQUIRED);
   const q = caseObj.questionnaire?.data || {};
-  const fields = caseObj.analyzer?.fields || caseObj.analyzerFields || {};
+  const analyzerFields = preferCleanFields(caseObj.analyzer || {});
+  const fields = Object.keys(analyzerFields).length
+    ? analyzerFields
+    : caseObj.analyzerFields || {};
 
   const employees = Number(q.employees || q.numberOfEmployees || fields.employees || 0);
   if (employees > 0 || hasEligibility(caseObj, "ERC")) {


### PR DESCRIPTION
## Summary
- prioritize `fields_clean` over `fields` when merging analyzer output
- expose `preferCleanFields` helper and use across routes and utilities
- add tests ensuring cleaned fields are favored

## Testing
- `npm test` (fails: pipeline.submit.test.js, e2e_analyzer_engine_smoke.test.js, files.eligibilityRefresh.test.js, files.validateUploads.test.js, checklist.ein_letter.test.js, checklist.grant_use_statement.test.js)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bf0bb924c0832787c36c0b43360afc