### PR TITLE
feat: add bank statement extraction

### DIFF
--- a/config/bank_patches.yaml
+++ b/config/bank_patches.yaml
@@ -1,0 +1,14 @@
+US Bank:
+  headings:
+    deposits: ["Other Deposits", "Deposits"]
+    withdrawals: ["Other Withdrawals", "Withdrawals"]
+    checks: ["Checks Presented Conventionally", "Checks Paid"]
+  synonyms:
+    ending_balance: ["Ending Balance", "Closing Balance"]
+    beginning_balance: ["Beginning Balance", "Starting Balance"]
+    deposits_total: ["Total Other Deposits", "Total Deposits"]
+    withdrawals_total: ["Total Other Withdrawals", "Total Withdrawals"]
+Chase:
+  synonyms: {}
+Bank of America:
+  synonyms: {}

--- a/docs/extraction/bank_statement.md
+++ b/docs/extraction/bank_statement.md
@@ -1,0 +1,16 @@
+# Bank Statement Extraction
+
+This module detects and parses bank statements from generic text.
+
+## Detector Signals
+- Keywords: Statement Period, Ending/Closing Balance, Beginning Balance, Account Number, Deposits, Withdrawals, Checks
+- Date range: `MMM d, yyyy through MMM d, yyyy`
+- Vendor hints: major US bank names or "Member FDIC"
+
+Confidence score = 0.6 + 0.1 per signal (max 0.95) +0.05 if vendor detected.
+
+## Schema
+See server/services/extractors/bankStatement.js for field descriptions.
+
+## Vendor Patches
+Optional synonyms and headings can be configured via `config/bank_patches.yaml`.

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "cors": "2.8.5",
     "dotenv": "^17.2.1",
     "express": "^4.21.2",
+    "js-yaml": "^4.1.0",
     "form-data": "4.0.4",
     "multer": "2.0.2",
     "node-fetch": "3.3.2",

--- a/server/services/docType.js
+++ b/server/services/docType.js
@@ -1,0 +1,33 @@
+const VENDOR_REGEX = /(U\.?S\.?\s*Bank|Chase|Bank of America|Wells Fargo|Citi|Citibank)/i;
+
+function detectDocType(text = '') {
+  const signals = [];
+  if (/Statement\s*Period/i.test(text)) signals.push('statement_period');
+  if (/(Ending|Closing)\s+Balance/i.test(text)) signals.push('ending_balance');
+  if (/Beginning\s+Balance/i.test(text)) signals.push('beginning_balance');
+  if (/(Account\s*Number|Acct\.?\s*No\.\?)/i.test(text)) signals.push('account_number');
+  if (/Deposits/i.test(text)) signals.push('deposits');
+  if (/Withdrawals/i.test(text)) signals.push('withdrawals');
+  if (/Checks/i.test(text)) signals.push('checks');
+  const dateRangePattern = /[A-Za-z]{3}\s+\d{1,2},?\s+\d{4}\s*(?:through|–|-|to)\s*[A-Za-z]{3}\s+\d{1,2},?\s+\d{4}/i;
+  const hasDateRange = dateRangePattern.test(text);
+  const vendorMatch = text.match(VENDOR_REGEX);
+
+  const type = signals.length >= 2 && hasDateRange ? 'bank_statement' : 'unknown';
+  let confidence = 0.4;
+  if (type === 'bank_statement') {
+    confidence = 0.6 + Math.min(signals.length, 3) * 0.1; // base 0.6 + 0.1 per signal
+    if (vendorMatch) confidence += 0.05;
+    confidence = Math.min(confidence, 0.95);
+  } else if (vendorMatch) {
+    confidence = 0.5; // vendor name alone isn't enough
+  }
+
+  return {
+    type,
+    confidence,
+    ...(vendorMatch ? { vendor: vendorMatch[0] } : {}),
+  };
+}
+
+module.exports = { detectDocType };

--- a/server/services/extractors/bankStatement.js
+++ b/server/services/extractors/bankStatement.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+let CACHE;
+function loadPatches() {
+  if (CACHE) return CACHE;
+  try {
+    const p = path.join(__dirname, '../../../config/bank_patches.yaml');
+    CACHE = yaml.load(fs.readFileSync(p, 'utf8')) || {};
+  } catch (e) {
+    CACHE = {};
+  }
+  return CACHE;
+}
+
+function normalizeDate(str) {
+  const m = str.match(/([A-Za-z]{3})\s+(\d{1,2}),?\s+(\d{4})/);
+  if (!m) return null;
+  const months = {Jan:'01',Feb:'02',Mar:'03',Apr:'04',May:'05',Jun:'06',Jul:'07',Aug:'08',Sep:'09',Oct:'10',Nov:'11',Dec:'12'};
+  return `${m[3]}-${months[m[1].slice(0,3)]}-${m[2].padStart(2,'0')}`;
+}
+
+function parseAmount(text, label, alt=[]) {
+  const labels=[label,...alt];
+  for (const l of labels) {
+    const re=new RegExp(l+"[^0-9$]*\\$?\\s*([0-9,]+\\.\\d{2})(?:-)?","i");
+    const m=text.match(re);
+    if(m) return parseFloat(m[1].replace(/,/g,''));
+  }
+  return null;
+}
+
+function extractBankStatement({text='',vendor,confidence=0.9}) {
+  const patches=loadPatches();
+  const patch=vendor&&patches[vendor]?patches[vendor]:{};
+  const syn=patch.synonyms||{};
+
+  const acct=/(Account\s*Number|Acct\.?\s*No\.?)\s*:?[\s\-]*([*Xx\d\s-]{4,})/i;
+  const mAcct=text.match(acct);
+  let last4=null;
+  if(mAcct){last4=mAcct[2].replace(/\D/g,'').slice(-4);}
+
+  const period=/(Statement\s*Period|Period)\s*:?[\s]*([A-Za-z]{3}\s+\d{1,2},?\s+\d{4})\s*(?:through|–|-|to)\s*([A-Za-z]{3}\s+\d{1,2},?\s+\d{4})/i;
+  const mPer=text.match(period);
+  const statement_period=mPer?{start:normalizeDate(mPer[2]),end:normalizeDate(mPer[3])}:{start:null,end:null};
+
+  const beginning_balance=parseAmount(text,'Beginning Balance',syn.beginning_balance||['Starting Balance'])||0;
+  const ending_balance=parseAmount(text,'Ending Balance',syn.ending_balance||['Closing Balance'])||0;
+  const deposits=parseAmount(text,'Total Deposits',syn.deposits_total||[])||0;
+  const withdrawals=parseAmount(text,'Total Withdrawals',syn.withdrawals_total||[])||0;
+  const checks_paid=parseAmount(text,'Total Checks',syn.checks_total||[])||0;
+
+  const transactions=[];
+  const lines=text.split(/\n+/);
+  const token=/^(?:[A-Za-z]{3}\s+\d{1,2}|\d{2}\/\d{2}|\d{4}-\d{2}-\d{2})/;
+  for(const line of lines){
+    if(token.test(line)){
+      const dateStr=line.match(token)[0];
+      let date;
+      if(/^[A-Za-z]{3}/.test(dateStr)){
+        const y=statement_period.start?statement_period.start.slice(0,4):'1970';
+        date=normalizeDate(`${dateStr}, ${y}`);
+      }else if(/\d{4}-\d{2}-\d{2}/.test(dateStr)){
+        date=dateStr;
+      }else{
+        const [m,d]=dateStr.split('/');
+        const y=statement_period.start?statement_period.start.slice(0,4):'1970';
+        date=`${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
+      }
+      const a=line.match(/\$?\s*([0-9,]+\.\d{2})(\-)?/);
+      if(a){
+        const amt=parseFloat(a[1].replace(/,/g,''));
+        const neg=a[2]!=null;
+        transactions.push({date,type:neg?'withdrawal':'deposit',counterparty:null,amount:amt});
+      }
+      if(transactions.length>=20) break;
+    }
+  }
+
+  const warnings=[];
+  const expected=beginning_balance+deposits-withdrawals-checks_paid;
+  if(Math.abs(expected-ending_balance)>1) warnings.push('balance_mismatch');
+
+  return {
+    doc_type:'bank_statement',
+    bank_name:vendor||null,
+    account_number_last4:last4,
+    statement_period,
+    beginning_balance,
+    ending_balance,
+    totals:{deposits,withdrawals,checks_paid},
+    transactions,
+    confidence,
+    warnings,
+  };
+}
+
+module.exports={extractBankStatement};
+

--- a/server/tests/bankStatement.extractor.test.js
+++ b/server/tests/bankStatement.extractor.test.js
@@ -1,0 +1,16 @@
+const { extractBankStatement } = require('../services/extractors/bankStatement');
+
+describe('extractBankStatement', () => {
+  const sample = `Statement Period: Jan 1, 2024 through Jan 31, 2024\nAccount Number: ****5678\nBeginning Balance $1,000.00\nClosing Balance $1,500.00\nTotal Deposits $600.00\nTotal Withdrawals $100.00`;
+  test('parses core fields', () => {
+    const res = extractBankStatement({ text: sample, vendor: 'US Bank', confidence: 0.9 });
+    expect(res.account_number_last4).toBe('5678');
+    expect(res.statement_period.start).toBe('2024-01-01');
+    expect(res.statement_period.end).toBe('2024-01-31');
+    expect(res.beginning_balance).toBe(1000);
+    expect(res.ending_balance).toBe(1500);
+    expect(res.totals.deposits).toBe(600);
+    expect(res.totals.withdrawals).toBe(100);
+    expect(res.warnings).toHaveLength(0);
+  });
+});

--- a/server/tests/docType.test.js
+++ b/server/tests/docType.test.js
@@ -1,0 +1,17 @@
+const { detectDocType } = require('../services/docType');
+
+describe('detectDocType', () => {
+  test('detects bank statement text', () => {
+    const text = `Statement Period: Jan 1, 2024 through Jan 31, 2024\nAccount Number: XXXX1234\nBeginning Balance $100.00\nEnding Balance $150.00\nDeposits\nWithdrawals`;
+    const res = detectDocType(text);
+    expect(res.type).toBe('bank_statement');
+    expect(res.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  test('non bank document', () => {
+    const text = 'Invoice #123 for services rendered.';
+    const res = detectDocType(text);
+    expect(res.type).not.toBe('bank_statement');
+    expect(res.confidence).toBeLessThan(0.5);
+  });
+});

--- a/server/tests/upload.bankStatement.int.test.js
+++ b/server/tests/upload.bankStatement.int.test.js
@@ -1,0 +1,38 @@
+const request = require('supertest');
+process.env.SKIP_DB = 'true';
+
+global.pipelineFetch = jest.fn();
+const app = require('../index');
+const { getCase } = require('../utils/pipelineStore');
+
+afterEach(() => {
+  global.pipelineFetch.mockReset();
+});
+
+afterAll(() => {
+  delete global.pipelineFetch;
+});
+
+test('parses bank statement from upload', async () => {
+  const ocr = `Statement Period: Jan 1, 2024 through Jan 31, 2024\nAccount Number: XXXX4321\nBeginning Balance $100.00\nEnding Balance $150.00\nTotal Deposits $75.00\nTotal Withdrawals $25.00`;
+  global.pipelineFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ocrText: ocr, fields: {}, fields_clean: {} }),
+      headers: { get: () => 'application/json' },
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [] }),
+      headers: { get: () => 'application/json' },
+    });
+
+  const res = await request(app)
+    .post('/api/files/upload')
+    .attach('file', Buffer.from('dummy'), 'stmt.pdf');
+
+  expect(res.status).toBe(200);
+  expect(res.body.analyzerFields.bank_statements[0].account_number_last4).toBe('4321');
+  const c = await getCase('dev-user', res.body.caseId);
+  expect(c.analyzer.fields.bank_statements[0].ending_balance).toBe(150);
+});


### PR DESCRIPTION
## Summary
- add vendor-agnostic bank statement detector and extractor
- integrate statement parsing into upload route
- document schema and add bank-specific patches

## Testing
- `npm test --prefix server` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_b_68c0446a63188327b27bd57fe3e1f268