### PR TITLE
feat: add resume detection and extraction

### DIFF
--- a/docs/extraction/resume.md
+++ b/docs/extraction/resume.md
@@ -1,0 +1,38 @@
+# Resume Extraction
+
+The resume extractor detects common resume/CV layouts and normalizes core fields for case processing.
+
+## Detection
+
+`detectDocType` looks for strong signals such as section headers (`SUMMARY OF QUALIFICATIONS`, `PROFESSIONAL EXPERIENCE`, `EDUCATION`, `TECHNICAL SKILLS`) combined with contact info (email/phone). At least two headers plus contact details yield `doc_type = "resume"` with confidence ≥ 0.8.
+
+## Extracted Schema
+
+```
+{
+  doc_type: 'resume',
+  full_name: string|null,
+  contact: {
+    email: string|null,
+    phone: string|null,
+    location: { city, state, country },
+    links: { linkedin, github, website }
+  },
+  summary: string|null,
+  experience: [{ role_title, organization, location, start_date, end_date, currently, highlights[] }],
+  education: [{ degree, field, institution, location, start_date, end_date, gpa, honors[] }],
+  skills: { technical: string[], general: string[] },
+  certifications: string[],
+  affiliations: string[],
+  awards: string[],
+  last_updated: YYYY-MM-DD|null,
+  confidence: number,
+  warnings: string[]
+}
+```
+
+## Notes
+
+- Dates are normalized to `YYYY-MM` when possible.
+- Skills are split into basic technical vs. general keywords.
+- `last_updated` is derived from `Revision:` markers when present.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js",
+    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js server/services/docType.resume.test.js server/services/extractors/resume.test.js server/routes/upload.resume.int.test.js",
     "k6:smoke": "k6 run load/k6/smoke.js",
     "k6:baseline": "k6 run load/k6/baseline.js",
     "k6:stress": "k6 run load/k6/stress.js",

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -25,6 +25,7 @@ const { detectDocType } = require('../services/docType');
 const { extractBankStatement } = require('../services/extractors/bankStatement');
 const { extractPOA } = require('../services/extractors/poa');
 const { extractProofOfAddress } = require('../services/extractors/proofOfAddress');
+const { extractResume } = require('../services/extractors/resume');
 
 const router = express.Router();
 
@@ -133,6 +134,18 @@ router.post('/files/upload', (req, res) => {
         identity: {
           ...(fields_clean?.identity || {}),
           address_proofs: [...existingAddr, poaRes],
+        },
+      };
+    }
+    if (detected.type === 'resume' && detected.confidence >= 0.8) {
+      const resume = extractResume({ text: ocrText, confidence: detected.confidence });
+      const existingResumes =
+        (fields_clean && fields_clean.team_documents && fields_clean.team_documents.resumes) || [];
+      fields_clean = {
+        ...(fields_clean || {}),
+        team_documents: {
+          ...(fields_clean?.team_documents || {}),
+          resumes: [...existingResumes, resume],
         },
       };
     }

--- a/server/routes/upload.resume.int.test.js
+++ b/server/routes/upload.resume.int.test.js
@@ -1,0 +1,51 @@
+const { test } = require('node:test');
+const assert = require('assert');
+process.env.SKIP_DB = 'true';
+process.env.AI_ANALYZER_URL = 'http://fake-analyzer';
+process.env.ELIGIBILITY_ENGINE_URL = 'http://fake-eligibility';
+
+const express = require('express');
+const { resetStore } = require('../utils/pipelineStore');
+
+const resumeText = `JOHN DOE\njohn@example.com | (555) 123-4567\n\nSUMMARY OF QUALIFICATIONS\nSkilled engineer.\n\nEDUCATION\nBS Computer Science`;
+
+test('upload flow extracts resume', async (t) => {
+  global.pipelineFetch = async (url, opts) => {
+    if (url.includes('fake-analyzer')) {
+      return {
+        ok: true,
+        json: async () => ({ ocrText: resumeText, text: resumeText, fields_clean: { existing: { value: 1 } } }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    if (url.includes('fake-eligibility')) {
+      return {
+        ok: true,
+        json: async () => ({ results: [] }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  const filesRouter = require('./files');
+  const app = express();
+  app.use('/', filesRouter);
+  const server = app.listen(0);
+  t.after(() => server.close());
+
+  const port = server.address().port;
+  const form = new FormData();
+  form.append('file', new Blob(['dummy'], { type: 'application/pdf' }), 'resume.pdf');
+
+  const res = await fetch(`http://localhost:${port}/files/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.analyzerFields.team_documents.resumes[0].doc_type, 'resume');
+  assert.equal(body.analyzerFields.existing.value, 1);
+  resetStore();
+  delete global.pipelineFetch;
+});

--- a/server/services/docType.resume.test.js
+++ b/server/services/docType.resume.test.js
@@ -1,0 +1,19 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { detectDocType } = require('./docType');
+
+const resumeText = `JOHN DOE\njohn@example.com | (555) 123-4567\n\nSUMMARY OF QUALIFICATIONS\nSkilled engineer.\n\nEDUCATION\nBS Computer Science`; 
+
+const nonResume = `W-9 Form\nRequest for Taxpayer Identification Number`;
+
+test('detects resume documents', () => {
+  const res = detectDocType(resumeText);
+  assert.equal(res.type, 'resume');
+  assert.ok(res.confidence >= 0.8);
+});
+
+test('non-resume text has low confidence', () => {
+  const res = detectDocType(nonResume);
+  assert.notEqual(res.type, 'resume');
+  assert.ok(res.confidence < 0.5);
+});

--- a/server/services/extractors/resume.js
+++ b/server/services/extractors/resume.js
@@ -1,0 +1,191 @@
+const MONTHS = {
+  jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06',
+  jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12'
+};
+
+function titleCase(str = '') {
+  return str
+    .toLowerCase()
+    .split(/\s+/)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ')
+    .trim();
+}
+
+function parseDate(str) {
+  if (!str) return null;
+  const m = str.match(/([A-Za-z]{3,9})\s*(\d{4})/);
+  if (m) {
+    const mo = MONTHS[m[1].slice(0,3).toLowerCase()];
+    if (mo) return `${m[2]}-${mo}`;
+  }
+  const year = str.match(/\b(\d{4})\b/);
+  if (year) return `${year[1]}-01`;
+  return null;
+}
+
+function extractSection(lines, nameRegex) {
+  const re = new RegExp(`^${nameRegex}$`, 'i');
+  const idx = lines.findIndex((l) => re.test(l));
+  if (idx === -1) return null;
+  const out = [];
+  for (let i = idx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^[A-Z][A-Z \-/&]{2,}$/.test(line)) break;
+    out.push(line);
+  }
+  return out;
+}
+
+function normalizeDegree(str = '') {
+  str = str.toLowerCase();
+  if (/b\.?s\.?|bachelor/.test(str)) return 'bachelor';
+  if (/m\.?s\.?|master/.test(str)) return 'master';
+  if (/phd|doctor/.test(str)) return 'phd';
+  if (/associate/.test(str)) return 'associate';
+  if (/certificate/.test(str)) return 'certificate';
+  return 'other';
+}
+
+function extractResume({ text = '', confidence = 0.9 }) {
+  const lines = text
+    .replace(/\r/g, '')
+    .split(/\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length);
+
+  const emailMatch = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  const phoneMatch = text.match(/\+?\d[\d\s().-]{7,}/);
+  let city = null;
+  let state = null;
+  for (let i = 0; i < Math.min(10, lines.length); i++) {
+    const m = lines[i].match(/([A-Za-z .]+),\s*([A-Z]{2})(?:\s+\d{5})?/);
+    if (m) { city = titleCase(m[1]); state = m[2]; break; }
+  }
+  let full_name = null;
+  for (let i = 0; i < Math.min(5, lines.length); i++) {
+    const l = lines[i];
+    if (emailMatch && l.includes(emailMatch[0])) continue;
+    if (phoneMatch && l.includes(phoneMatch[0])) continue;
+    if (/^(summary|professional experience|education|technical skills|skills|certifications)/i.test(l)) continue;
+    full_name = titleCase(l);
+    break;
+  }
+
+  const summaryLines = extractSection(lines, '(SUMMARY OF QUALIFICATIONS|SUMMARY|OBJECTIVE)');
+  const summary = summaryLines ? summaryLines.join(' ') : null;
+
+  const eduLines = extractSection(lines, 'EDUCATION') || [];
+  const education = [];
+  let currentEdu = null;
+  for (const line of eduLines) {
+    if (/^(gpa[:\s]+)/i.test(line)) {
+      if (currentEdu) currentEdu.gpa = line.replace(/gpa[:\s]*/i, '').trim();
+      continue;
+    }
+    const degreeMatch = line.match(/(Bachelor|Master|Associate|B\.S\.|B\.A\.|M\.S\.|MBA|PhD|Certificate)[^,\n]*?(?:in\s+([^,]+))?,?\s*([^,\n]+)?/i);
+    if (degreeMatch) {
+      if (currentEdu) education.push(currentEdu);
+      currentEdu = {
+        degree: normalizeDegree(degreeMatch[1]),
+        field: degreeMatch[2] ? titleCase(degreeMatch[2]) : null,
+        institution: degreeMatch[3] ? titleCase(degreeMatch[3]) : null,
+        location: null,
+        start_date: null,
+        end_date: null,
+        gpa: null,
+        honors: [],
+      };
+      const dateMatch = line.match(/(\d{4})/g);
+      if (dateMatch) currentEdu.end_date = `${dateMatch.pop()}-01`;
+      continue;
+    }
+    const locMatch = line.match(/([A-Za-z .]+),\s*([A-Z]{2})/);
+    if (locMatch && currentEdu) {
+      currentEdu.location = `${titleCase(locMatch[1])}, ${locMatch[2]}`;
+      const year = line.match(/(\d{4})/);
+      if (year) currentEdu.end_date = `${year[1]}-01`;
+    }
+  }
+  if (currentEdu) education.push(currentEdu);
+
+  const expLines = extractSection(lines, '(PROFESSIONAL EXPERIENCE|WORK HISTORY|EXPERIENCE)') || [];
+  const experience = [];
+  let currentExp = null;
+  for (const line of expLines) {
+    if (/^[-•]/.test(line)) {
+      if (currentExp) currentExp.highlights.push(line.replace(/^[-•]\s*/, ''));
+      continue;
+    }
+    const jobMatch = line.match(/^(.*?),\s*(.*?),\s*([A-Za-z .]+),\s*([A-Z]{2})\s*\(([^)]+)\)/);
+    if (jobMatch) {
+      if (currentExp) experience.push(currentExp);
+      const range = jobMatch[5];
+      let start = null;
+      let end = null;
+      let currently = false;
+      const parts = range.split(/\s*(?:-|–|to)\s*/);
+      if (parts[0]) start = parseDate(parts[0]);
+      if (parts[1]) {
+        if (/present/i.test(parts[1])) { currently = true; }
+        else end = parseDate(parts[1]);
+      }
+      currentExp = {
+        role_title: jobMatch[1].trim(),
+        organization: jobMatch[2].trim(),
+        location: `${titleCase(jobMatch[3])}, ${jobMatch[4]}`,
+        start_date: start,
+        end_date: end,
+        currently,
+        highlights: [],
+      };
+      continue;
+    }
+  }
+  if (currentExp) experience.push(currentExp);
+
+  const skillsLines = extractSection(lines, '(TECHNICAL SKILLS|COMPUTER SKILLS|SKILLS|TECHNICAL KNOWLEDGE AND SKILLS)') || [];
+  const tokens = skillsLines.join(',').split(/[,;]+/).map((t) => t.trim()).filter(Boolean);
+  const skills = { technical: [], general: [] };
+  for (const t of tokens) {
+    if (/javascript|node|python|java|c\+\+|sql|aws|docker|kubernetes|html|css|react/i.test(t)) skills.technical.push(t);
+    else skills.general.push(t);
+  }
+
+  const certLines = extractSection(lines, '(CERTIFICATIONS|CERTIFICATION)') || [];
+  const certifications = certLines.map((l) => l.replace(/^[-•]\s*/, '').trim()).filter(Boolean);
+
+  let last_updated = null;
+  const rev = text.match(/Revision[:\s]+([A-Za-z]{3,9})\s*(\d{4})/i);
+  if (rev) {
+    const mo = MONTHS[rev[1].slice(0,3).toLowerCase()];
+    if (mo) last_updated = `${rev[2]}-${mo}-01`;
+  }
+
+  const warnings = [];
+  if (!full_name && !(emailMatch && phoneMatch)) warnings.push('missing_name_or_contact');
+  if (education.length === 0 && experience.length === 0) warnings.push('missing_education_and_experience');
+
+  return {
+    doc_type: 'resume',
+    full_name: full_name || null,
+    contact: {
+      email: emailMatch ? emailMatch[0] : null,
+      phone: phoneMatch ? phoneMatch[0] : null,
+      location: { city, state, country: null },
+      links: { linkedin: null, github: null, website: null },
+    },
+    summary,
+    experience,
+    education,
+    skills,
+    certifications,
+    affiliations: [],
+    awards: [],
+    last_updated,
+    confidence,
+    warnings,
+  };
+}
+
+module.exports = { extractResume };

--- a/server/services/extractors/resume.test.js
+++ b/server/services/extractors/resume.test.js
@@ -1,0 +1,20 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { extractResume } = require('./resume');
+
+const text = `JOHN DOE\n123 Main St, Springfield, IL 62701\njohn@example.com | (555) 123-4567\n\nSUMMARY OF QUALIFICATIONS\nExperienced software engineer with a passion for building applications.\n\nPROFESSIONAL EXPERIENCE\nSoftware Engineer, Acme Corp, Springfield, IL (Jan 2020 - Present)\n- Developed features\n- Improved performance\n\nEDUCATION\nBachelor of Science in Computer Science, University of Nowhere, Springfield, IL 2016\nGPA: 3.8\n\nTECHNICAL SKILLS\nJavaScript, Node.js, Leadership, Communication\n\nCERTIFICATIONS\nAWS Certified Solutions Architect\n\nRevision: June 2015`;
+
+test('extracts core resume fields', () => {
+  const res = extractResume({ text });
+  assert.equal(res.full_name, 'John Doe');
+  assert.equal(res.contact.email, 'john@example.com');
+  assert.equal(res.contact.phone.includes('555'), true);
+  assert.equal(res.contact.location.city, 'Springfield');
+  assert.equal(res.summary.startsWith('Experienced software engineer'), true);
+  assert.equal(res.experience[0].role_title, 'Software Engineer');
+  assert.equal(res.education[0].degree, 'bachelor');
+  assert.ok(res.skills.technical.includes('JavaScript'));
+  assert.ok(res.skills.general.includes('Leadership'));
+  assert.equal(res.certifications[0], 'AWS Certified Solutions Architect');
+  assert.equal(res.last_updated, '2015-06-01');
+});


### PR DESCRIPTION
## Summary
- detect resume documents via docType with strong section headers and contact signals
- extract normalized resume data (name, contact, summary, education, experience, skills)
- merge resume extraction into file upload pipeline
- document resume extraction schema and behavior
- add unit and integration tests for resume detection and extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c05b3fa3fc83278c61c9199363907f