### PR TITLE
feat: add insurance certificate parsing

### DIFF
--- a/config/insurance_synonyms.yaml
+++ b/config/insurance_synonyms.yaml
@@ -1,0 +1,15 @@
+general_liability:
+  - General Liability
+  - Commercial General Liability
+auto:
+  - Automobile Liability
+  - Auto
+umbrella:
+  - Umbrella
+  - Excess Liability
+workers_comp:
+  - Workers Compensation
+  - Workers Comp
+property:
+  - Property
+  - Property Insurance

--- a/docs/extraction/insurance_certificate.md
+++ b/docs/extraction/insurance_certificate.md
@@ -1,0 +1,43 @@
+# Insurance Certificate Extraction
+
+Supports common ACORD insurance certificate forms (25, 23, 27, 28) and generic certificates of insurance.
+
+## Signals
+- Titles such as "CERTIFICATE OF LIABILITY INSURANCE" or "EVIDENCE OF PROPERTY INSURANCE"
+- Section headers: Producer, Insured, Insurers Affording Coverage, Coverages, Certificate Holder
+- Table columns: Policy Number, Eff Date, Exp Date, Limits
+- Optional ACORD form number
+
+## Schema
+```json
+{
+  "doc_type": "insurance_certificate",
+  "form": "ACORD25|ACORD23|ACORD27|ACORD28|other",
+  "producer": { "name": "string|null", "contact": "string|null" },
+  "insured": { "name": "string|null", "address": "string|null" },
+  "insurers": [ { "letter": "A|B|C|D|E|F", "name": "string|null", "naic": "string|null" } ],
+  "coverages": [
+    {
+      "coverage_type": "general_liability|auto|umbrella|workers_comp|property|other",
+      "policy_number": "string|null",
+      "effective_date": "YYYY-MM-DD|null",
+      "expiration_date": "YYYY-MM-DD|null",
+      "limits": {
+        "each_occurrence": 0,
+        "aggregate": 0,
+        "property_damage": 0,
+        "other": "string|null"
+      }
+    }
+  ],
+  "certificate_holder": "string|null",
+  "cancellation_clause": "string|null",
+  "signature": "string|null",
+  "confidence": 0.0,
+  "warnings": []
+}
+```
+
+## Extending
+Coverage type synonyms can be tuned via `config/insurance_synonyms.yaml` to handle custom wording. The extractor is layout
+agnostic and relies on heuristics so additional certificate formats can be supported by editing the config.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js server/services/docType.resume.test.js server/services/extractors/resume.test.js server/routes/upload.resume.int.test.js",
+    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js server/services/docType.resume.test.js server/services/extractors/resume.test.js server/routes/upload.resume.int.test.js server/services/docType.insurance.test.js server/services/extractors/insuranceCertificate.test.js server/routes/upload.insurance.int.test.js",
     "k6:smoke": "k6 run load/k6/smoke.js",
     "k6:baseline": "k6 run load/k6/baseline.js",
     "k6:stress": "k6 run load/k6/stress.js",

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -26,6 +26,7 @@ const { extractBankStatement } = require('../services/extractors/bankStatement')
 const { extractPOA } = require('../services/extractors/poa');
 const { extractProofOfAddress } = require('../services/extractors/proofOfAddress');
 const { extractResume } = require('../services/extractors/resume');
+const { extractInsuranceCertificate } = require('../services/extractors/insuranceCertificate');
 
 const router = express.Router();
 
@@ -146,6 +147,18 @@ router.post('/files/upload', (req, res) => {
         team_documents: {
           ...(fields_clean?.team_documents || {}),
           resumes: [...existingResumes, resume],
+        },
+      };
+    }
+    if (detected.type === 'insurance_certificate' && detected.confidence >= 0.8) {
+      const cert = extractInsuranceCertificate({ text: ocrText, hints: detected.hints || {}, confidence: detected.confidence });
+      const existingCerts =
+        (fields_clean && fields_clean.compliance && fields_clean.compliance.insurance) || [];
+      fields_clean = {
+        ...(fields_clean || {}),
+        compliance: {
+          ...(fields_clean?.compliance || {}),
+          insurance: [...existingCerts, cert],
         },
       };
     }

--- a/server/routes/upload.insurance.int.test.js
+++ b/server/routes/upload.insurance.int.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('assert');
+process.env.SKIP_DB = 'true';
+process.env.AI_ANALYZER_URL = 'http://fake-analyzer';
+process.env.ELIGIBILITY_ENGINE_URL = 'http://fake-eligibility';
+
+const express = require('express');
+const { resetStore } = require('../utils/pipelineStore');
+
+const certText = `CERTIFICATE OF LIABILITY INSURANCE\nACORD 25\nProducer: Alpha Insurance Agency\nInsured: My Bakery LLC\nINSR LTR A: Great Insurer NAIC#12345\nCoverages\nGeneral Liability Policy Number GL123 Eff Date 01/01/2024 Exp Date 01/01/2025 Each Occurrence $1,000,000 Aggregate $2,000,000\nCertificate Holder: City of Springfield`;
+
+test('upload flow extracts insurance certificate', async (t) => {
+  global.pipelineFetch = async (url) => {
+    if (url.includes('fake-analyzer')) {
+      return {
+        ok: true,
+        json: async () => ({ ocrText: certText, text: certText, fields_clean: { existing: { value: 1 } } }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    if (url.includes('fake-eligibility')) {
+      return {
+        ok: true,
+        json: async () => ({ results: [] }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  const filesRouter = require('./files');
+  const app = express();
+  app.use('/', filesRouter);
+  const server = app.listen(0);
+  t.after(() => server.close());
+
+  const port = server.address().port;
+  const form = new FormData();
+  form.append('file', new Blob(['dummy'], { type: 'application/pdf' }), 'cert.pdf');
+
+  const res = await fetch(`http://localhost:${port}/files/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.analyzerFields.compliance.insurance[0].doc_type, 'insurance_certificate');
+  assert.equal(body.analyzerFields.compliance.insurance[0].insured.name, 'My Bakery Llc');
+  assert.equal(body.analyzerFields.existing.value, 1);
+  resetStore();
+  delete global.pipelineFetch;
+});

--- a/server/services/docType.insurance.test.js
+++ b/server/services/docType.insurance.test.js
@@ -1,0 +1,27 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { detectDocType } = require('./docType');
+
+const accord25 = `CERTIFICATE OF LIABILITY INSURANCE\nACORD 25\nProducer: Alpha Agency\nInsured: My Biz\nInsurers Affording Coverage\nCoverages\nPolicy Number\nEff Date\nExp Date\nCertificate Holder`;
+const accord27 = `EVIDENCE OF PROPERTY INSURANCE\nACORD 27\nProducer: Beta Agency\nInsured: Some Biz\nCoverages\nPolicy Number\nEff Date\nExp Date\nCertificate Holder`;
+const resumeText = `W-9 Form\nRequest for Taxpayer Identification Number`;
+
+test('detects ACORD 25 insurance certificate', () => {
+  const res = detectDocType(accord25);
+  assert.equal(res.type, 'insurance_certificate');
+  assert.ok(res.confidence >= 0.9);
+  assert.equal(res.hints.form, 'ACORD25');
+});
+
+test('detects ACORD 27 insurance certificate', () => {
+  const res = detectDocType(accord27);
+  assert.equal(res.type, 'insurance_certificate');
+  assert.ok(res.confidence >= 0.9);
+  assert.equal(res.hints.form, 'ACORD27');
+});
+
+test('non-insurance docs have low confidence', () => {
+  const res = detectDocType(resumeText);
+  assert.notEqual(res.type, 'insurance_certificate');
+  assert.ok(res.confidence < 0.5);
+});

--- a/server/services/extractors/insuranceCertificate.js
+++ b/server/services/extractors/insuranceCertificate.js
@@ -1,0 +1,166 @@
+const fs = require('fs');
+const path = require('path');
+let yaml;
+try {
+  yaml = require('js-yaml');
+} catch (e) {
+  yaml = { load: () => ({}) };
+}
+
+let CACHE;
+function loadSynonyms() {
+  if (CACHE) return CACHE;
+  try {
+    const p = path.join(__dirname, '../../../config/insurance_synonyms.yaml');
+    CACHE = yaml.load(fs.readFileSync(p, 'utf8')) || {};
+  } catch (e) {
+    CACHE = {};
+  }
+  return CACHE;
+}
+
+function titleCase(str = '') {
+  return str
+    .toLowerCase()
+    .split(/\s+/)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ')
+    .trim();
+}
+
+function normalizeDate(str) {
+  if (!str) return null;
+  const d = new Date(str);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().split('T')[0];
+}
+
+function parseLimit(str) {
+  if (!str) return 0;
+  return parseInt(str.replace(/[^0-9]/g, ''), 10) || 0;
+}
+
+function mapCoverageType(name) {
+  const syn = loadSynonyms();
+  const lower = name.toLowerCase();
+  for (const [type, arr] of Object.entries(syn)) {
+    if (arr.some((s) => lower.includes(s.toLowerCase()))) return type;
+  }
+  if (/workers\s+comp/i.test(lower)) return 'workers_comp';
+  if (/auto/i.test(lower)) return 'auto';
+  if (/umbrella|excess/i.test(lower)) return 'umbrella';
+  if (/general/i.test(lower)) return 'general_liability';
+  if (/property/i.test(lower)) return 'property';
+  return 'other';
+}
+
+function extractInsuranceCertificate({ text = '', hints = {}, confidence = 0.9 }) {
+  const lines = text.split(/\r?\n/).map((l) => l.trim());
+  const form =
+    hints.form ||
+    (/ACORD\s*25/i.test(text)
+      ? 'ACORD25'
+      : /ACORD\s*23/i.test(text)
+      ? 'ACORD23'
+      : /ACORD\s*27/i.test(text)
+      ? 'ACORD27'
+      : /ACORD\s*28/i.test(text)
+      ? 'ACORD28'
+      : 'other');
+
+  const producer = { name: null, contact: null };
+  const prodIdx = lines.findIndex((l) => /^Producer/i.test(l));
+  if (prodIdx !== -1) {
+    const m = lines[prodIdx].match(/Producer[:\s]*(.*)/i);
+    if (m && m[1]) producer.name = titleCase(m[1]);
+    else if (lines[prodIdx + 1]) producer.name = titleCase(lines[prodIdx + 1]);
+    if (lines[prodIdx + 2] && /@|\d/.test(lines[prodIdx + 2])) producer.contact = lines[prodIdx + 2];
+  }
+
+  const insured = { name: null, address: null };
+  const insIdx = lines.findIndex((l) => /^Insured/i.test(l));
+  if (insIdx !== -1) {
+    const m = lines[insIdx].match(/Insured[:\s]*(.*)/i);
+    if (m && m[1]) {
+      insured.name = titleCase(m[1]);
+      if (lines[insIdx + 1]) insured.address = titleCase(lines[insIdx + 1]);
+    } else {
+      insured.name = titleCase(lines[insIdx + 1] || '');
+      insured.address = lines[insIdx + 2] ? titleCase(lines[insIdx + 2]) : null;
+    }
+  }
+
+  const insurers = [];
+  for (const line of lines) {
+    const m = line.match(/^([A-F])[:\s-]+([^,]+?)(?:\s+NAIC#?\s*(\d{3,}))?$/i);
+    if (m) {
+      insurers.push({ letter: m[1].toUpperCase(), name: titleCase(m[2].trim()), naic: m[3] || null });
+    }
+  }
+
+  const coverages = [];
+  for (const line of lines) {
+    const m = line.match(
+      /(General Liability|Automobile|Auto|Umbrella|Workers Comp(?:ensation)?|Property)[^\n]*Policy Number\s*([A-Z0-9-]+)[^\n]*Eff(?:ective)?\s*Date\s*([0-9\/-]+)[^\n]*Exp(?:iration)?\s*Date\s*([0-9\/-]+)([^\n]*)/i,
+    );
+    if (m) {
+      const type = mapCoverageType(m[1]);
+      const eff = normalizeDate(m[3]);
+      const exp = normalizeDate(m[4]);
+      const rest = m[5];
+      const each = rest.match(/Each\s+Occurrence\s*\$?([0-9,]+)/i);
+      const agg = rest.match(/Aggregate\s*\$?([0-9,]+)/i);
+      const prop = rest.match(/Property(?:\s+(?:Damage|Value))?\s*\$?([0-9,]+)/i);
+      coverages.push({
+        coverage_type: type,
+        policy_number: m[2],
+        effective_date: eff,
+        expiration_date: exp,
+        limits: {
+          each_occurrence: parseLimit(each && each[1]),
+          aggregate: parseLimit(agg && agg[1]),
+          property_damage: parseLimit(prop && prop[1]),
+          other: null,
+        },
+      });
+    }
+  }
+
+  const holderIdx = lines.findIndex((l) => /^Certificate Holder/i.test(l));
+  let certificate_holder = null;
+  if (holderIdx !== -1) {
+    const m = lines[holderIdx].match(/Certificate Holder[:\s]*(.*)/i);
+    certificate_holder = titleCase(m && m[1] ? m[1] : lines[holderIdx + 1] || '');
+  }
+
+  const cancellationMatch = text.match(/cancellation[^\n]+/i);
+  const cancellation_clause = cancellationMatch ? cancellationMatch[0].trim() : null;
+  const sigMatch = text.match(/Authorized Representative[:\s]*([A-Za-z ,.'-]+)/i);
+  const signature = sigMatch ? titleCase(sigMatch[1]) : null;
+
+  const warnings = [];
+  for (const c of coverages) {
+    if (c.effective_date && c.expiration_date) {
+      if (new Date(c.expiration_date) <= new Date(c.effective_date)) {
+        warnings.push('invalid_date_range');
+      }
+    }
+  }
+  if (!producer.name || !insured.name) warnings.push('missing_required_section');
+
+  return {
+    doc_type: 'insurance_certificate',
+    form,
+    producer,
+    insured,
+    insurers,
+    coverages,
+    certificate_holder,
+    cancellation_clause,
+    signature,
+    confidence,
+    warnings,
+  };
+}
+
+module.exports = { extractInsuranceCertificate };

--- a/server/services/extractors/insuranceCertificate.test.js
+++ b/server/services/extractors/insuranceCertificate.test.js
@@ -1,0 +1,26 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { extractInsuranceCertificate } = require('./insuranceCertificate');
+
+const accord25 = `CERTIFICATE OF LIABILITY INSURANCE\nACORD 25\nProducer: Alpha Insurance Agency\nInsured: My Bakery LLC\nINSR LTR A: Great Insurer NAIC#12345\nCoverages\nGeneral Liability Policy Number GL123 Eff Date 01/01/2024 Exp Date 01/01/2025 Each Occurrence $1,000,000 Aggregate $2,000,000\nCertificate Holder: City of Springfield`;
+
+const accord27 = `EVIDENCE OF PROPERTY INSURANCE\nACORD 27\nProducer: Beta Agency\nInsured: Some Shop\nProperty Policy Number PRP456 Eff Date 02/01/2024 Exp Date 02/01/2025 Property Value $500,000\nCertificate Holder: Bank`;
+
+test('extracts insured, producer, coverage and limits from ACORD 25', () => {
+  const res = extractInsuranceCertificate({ text: accord25, hints: { form: 'ACORD25' } });
+  assert.equal(res.insured.name, 'My Bakery Llc');
+  assert.equal(res.producer.name, 'Alpha Insurance Agency');
+  assert.equal(res.coverages[0].coverage_type, 'general_liability');
+  assert.equal(res.coverages[0].effective_date, '2024-01-01');
+  assert.equal(res.coverages[0].expiration_date, '2025-01-01');
+  assert.equal(res.coverages[0].limits.each_occurrence, 1000000);
+  assert.equal(res.coverages[0].limits.aggregate, 2000000);
+  assert.deepEqual(res.warnings, []);
+});
+
+test('extracts property coverage from ACORD 27', () => {
+  const res = extractInsuranceCertificate({ text: accord27, hints: { form: 'ACORD27' } });
+  assert.equal(res.coverages[0].coverage_type, 'property');
+  assert.equal(res.coverages[0].effective_date, '2024-02-01');
+  assert.equal(res.coverages[0].expiration_date, '2025-02-01');
+});


### PR DESCRIPTION
## Summary
- detect insurance certificates including ACORD 25/23/27/28
- parse producer, insured, insurers and coverage details into compliance.insurance
- add config and docs for insurance certificate extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c19060bf68832782d14e76eddcdebe