### PR TITLE
feat: parse letters of support

### DIFF
--- a/docs/extraction/letter_of_support.md
+++ b/docs/extraction/letter_of_support.md
@@ -1,0 +1,37 @@
+# Letter of Support / Recommendation Extraction
+
+The letter of support extractor identifies recommendation-style letters and normalizes key fields for eligibility review.
+
+## Detection
+
+`detectDocType` looks for textual signals such as headings ("Letter of Support", "Letter of Recommendation"), salutation phrases ("To Whom It May Concern", "Dear Grant Committee"), endorsement phrases ("I am pleased to recommend", "I write in support of"), signature closings ("Sincerely", "Respectfully", "Best regards"), and contact lines (email/phone). Documents with at least two signals and over 150 words are classified as `doc_type = "letter_of_support"` with confidence 0.6 + 0.1 per signal (capped at 0.95). An explicit heading adds an extra 0.05.
+
+## Extracted Schema
+
+```
+{
+  doc_type: 'letter_of_support',
+  recipient: string|null,
+  author: {
+    full_name: string|null,
+    title: string|null,
+    organization: string|null,
+    contact: string|null
+  },
+  relationship: string|null,
+  endorsement_text: string|null,
+  signature_block: {
+    has_signature_image: boolean,
+    closing: string|null
+  },
+  document_date: YYYY-MM-DD|null,
+  confidence: number,
+  warnings: string[]
+}
+```
+
+## Notes
+
+- `endorsement_text` is truncated to ~500 characters for downstream checks.
+- `relationship` captures the sentence describing how the author knows the applicant.
+- Extend detection by adding new relationship phrases or signature closings as needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js server/services/docType.resume.test.js server/services/extractors/resume.test.js server/routes/upload.resume.int.test.js server/services/docType.insurance.test.js server/services/extractors/insuranceCertificate.test.js server/routes/upload.insurance.int.test.js",
+    "test": "node --test server/services/docType.poa.test.js server/services/extractors/poa.test.js server/routes/upload.poa.int.test.js server/services/docType.proofOfAddress.test.js server/services/extractors/proofOfAddress.test.js server/routes/upload.proofOfAddress.int.test.js server/services/docType.resume.test.js server/services/extractors/resume.test.js server/routes/upload.resume.int.test.js server/services/docType.insurance.test.js server/services/extractors/insuranceCertificate.test.js server/routes/upload.insurance.int.test.js server/services/docType.letterOfSupport.test.js server/services/extractors/letterOfSupport.test.js server/routes/upload.letterOfSupport.int.test.js",
     "k6:smoke": "k6 run load/k6/smoke.js",
     "k6:baseline": "k6 run load/k6/baseline.js",
     "k6:stress": "k6 run load/k6/stress.js",

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -27,6 +27,7 @@ const { extractPOA } = require('../services/extractors/poa');
 const { extractProofOfAddress } = require('../services/extractors/proofOfAddress');
 const { extractResume } = require('../services/extractors/resume');
 const { extractInsuranceCertificate } = require('../services/extractors/insuranceCertificate');
+const { extractLetterOfSupport } = require('../services/extractors/letterOfSupport');
 
 const router = express.Router();
 
@@ -147,6 +148,22 @@ router.post('/files/upload', (req, res) => {
         team_documents: {
           ...(fields_clean?.team_documents || {}),
           resumes: [...existingResumes, resume],
+        },
+      };
+    }
+    if (
+      process.env.enableLettersOfSupportParsing === 'true' &&
+      detected.type === 'letter_of_support' &&
+      detected.confidence >= 0.8
+    ) {
+      const letter = extractLetterOfSupport({ text: ocrText, confidence: detected.confidence });
+      const existingLetters =
+        (fields_clean && fields_clean.team_documents && fields_clean.team_documents.letters) || [];
+      fields_clean = {
+        ...(fields_clean || {}),
+        team_documents: {
+          ...(fields_clean?.team_documents || {}),
+          letters: [...existingLetters, letter],
         },
       };
     }

--- a/server/routes/upload.letterOfSupport.int.test.js
+++ b/server/routes/upload.letterOfSupport.int.test.js
@@ -1,0 +1,94 @@
+const { test } = require('node:test');
+const assert = require('assert');
+process.env.SKIP_DB = 'true';
+process.env.AI_ANALYZER_URL = 'http://fake-analyzer';
+process.env.ELIGIBILITY_ENGINE_URL = 'http://fake-eligibility';
+process.env.enableLettersOfSupportParsing = 'true';
+
+const express = require('express');
+const { resetStore } = require('../utils/pipelineStore');
+
+const filler = 'John Doe has been an asset to our community and organization, providing support and dedication. '.repeat(20);
+const formalLetter = `Letter of Support\n\nDear Grant Committee,\n${filler}\nSincerely,\nJane Smith\nDirector, City Org\n555-123-4567\njane@city.org`;
+const informalLetter = `Dear Review Team,\nI am pleased to recommend John Doe for your program. ${filler}\nBest regards,\nSam Roe\nCEO, Example Inc.\n555-555-5555\nsam@example.com`;
+
+test('upload flow extracts support letter', async (t) => {
+  global.pipelineFetch = async (url, opts) => {
+    if (url.includes('fake-analyzer')) {
+      return {
+        ok: true,
+        json: async () => ({ ocrText: formalLetter, text: formalLetter, fields_clean: { existing: { value: 1 } } }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    if (url.includes('fake-eligibility')) {
+      return {
+        ok: true,
+        json: async () => ({ results: [] }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  const filesRouter = require('./files');
+  const app = express();
+  app.use('/', filesRouter);
+  const server = app.listen(0);
+  t.after(() => server.close());
+
+  const port = server.address().port;
+  const form = new FormData();
+  form.append('file', new Blob(['dummy'], { type: 'application/pdf' }), 'letter.pdf');
+
+  const res = await fetch(`http://localhost:${port}/files/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.analyzerFields.team_documents.letters[0].doc_type, 'letter_of_support');
+  assert.equal(body.analyzerFields.existing.value, 1);
+  resetStore();
+  delete global.pipelineFetch;
+});
+
+test('upload flow extracts informal recommendation letter', async (t) => {
+  global.pipelineFetch = async (url, opts) => {
+    if (url.includes('fake-analyzer')) {
+      return {
+        ok: true,
+        json: async () => ({ ocrText: informalLetter, text: informalLetter, fields_clean: {} }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    if (url.includes('fake-eligibility')) {
+      return {
+        ok: true,
+        json: async () => ({ results: [] }),
+        headers: { get: () => 'application/json' },
+      };
+    }
+    throw new Error('unexpected fetch ' + url);
+  };
+
+  const filesRouter = require('./files');
+  const app = express();
+  app.use('/', filesRouter);
+  const server = app.listen(0);
+  t.after(() => server.close());
+
+  const port = server.address().port;
+  const form = new FormData();
+  form.append('file', new Blob(['dummy'], { type: 'application/pdf' }), 'letter2.pdf');
+
+  const res = await fetch(`http://localhost:${port}/files/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.analyzerFields.team_documents.letters[0].doc_type, 'letter_of_support');
+  resetStore();
+  delete global.pipelineFetch;
+});

--- a/server/services/docType.letterOfSupport.test.js
+++ b/server/services/docType.letterOfSupport.test.js
@@ -1,0 +1,24 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { detectDocType } = require('./docType');
+
+const body = 'John Doe is an outstanding member of our community and has contributed greatly. '
+  .repeat(20);
+const letterText = `Letter of Support\n\nDear Grant Committee,\n${body}\nSincerely,\nJane Smith\nDirector, City Org\n555-123-4567\njane@city.org`;
+
+const resumeText = `JOHN DOE\njohn@example.com | (555) 123-4567\n\nSUMMARY OF QUALIFICATIONS\nSkilled engineer.`;
+const invoiceText = `Invoice\nAmount Due: $100\nThank you for your business.`;
+const insuranceText = `CERTIFICATE OF LIABILITY INSURANCE\nProducer: ABC Agency\nPolicy Number: 123`;
+
+test('detects letter of support documents', () => {
+  const res = detectDocType(letterText);
+  assert.equal(res.type, 'letter_of_support');
+  assert.ok(res.confidence >= 0.9);
+});
+
+test('non-letters have low confidence', () => {
+  for (const t of [resumeText, invoiceText, insuranceText]) {
+    const res = detectDocType(t);
+    assert.ok(res.type !== 'letter_of_support' || res.confidence < 0.5);
+  }
+});

--- a/server/services/extractors/letterOfSupport.js
+++ b/server/services/extractors/letterOfSupport.js
@@ -1,0 +1,129 @@
+const MONTHS = {
+  january: '01', february: '02', march: '03', april: '04', may: '05', june: '06',
+  july: '07', august: '08', september: '09', october: '10', november: '11', december: '12'
+};
+
+function titleCase(str = '') {
+  return str
+    .toLowerCase()
+    .split(/\s+/)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ')
+    .trim();
+}
+
+function parseDate(str) {
+  if (!str) return null;
+  const m = str.match(/([A-Za-z]+)\s+(\d{1,2}),?\s*(\d{4})/);
+  if (!m) return null;
+  const mo = MONTHS[m[1].toLowerCase()];
+  if (!mo) return null;
+  const day = String(m[2]).padStart(2, '0');
+  return `${m[3]}-${mo}-${day}`;
+}
+
+function extractLetterOfSupport({ text = '', confidence = 0.9 }) {
+  const lines = text
+    .replace(/\r/g, '')
+    .split(/\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length);
+
+  let recipient = null;
+  for (let i = 0; i < Math.min(10, lines.length); i++) {
+    const l = lines[i];
+    const dear = l.match(/^Dear\s+(.*)/i);
+    if (dear) {
+      recipient = titleCase(dear[1].replace(/[:;,]+$/, ''));
+      break;
+    }
+    if (/^To Whom It May Concern/i.test(l)) {
+      recipient = 'To Whom It May Concern';
+      break;
+    }
+  }
+
+  const dateMatch = text.match(/(?:Dated[:\s]*)?([A-Za-z]+\s+\d{1,2},?\s*\d{4})/i);
+  const document_date = dateMatch ? parseDate(dateMatch[1]) : null;
+
+  const closingIdx = lines.findIndex((l) => /(Sincerely|Respectfully|Best regards)/i.test(l));
+  const closing = closingIdx !== -1 ? lines[closingIdx] : null;
+  const afterClosing = closingIdx !== -1 ? lines.slice(closingIdx + 1) : [];
+
+  let full_name = null;
+  let title = null;
+  let organization = null;
+  let contact = null;
+  if (afterClosing.length) {
+    let idx = 0;
+    if (afterClosing[idx]) {
+      full_name = titleCase(afterClosing[idx]);
+      idx++;
+    }
+    if (afterClosing[idx]) {
+      const parts = afterClosing[idx].split(/,\s*/);
+      if (parts.length > 1) {
+        title = titleCase(parts[0]);
+        organization = titleCase(parts.slice(1).join(', '));
+        idx++;
+      } else {
+        title = titleCase(afterClosing[idx]);
+        idx++;
+        if (afterClosing[idx]) {
+          organization = titleCase(afterClosing[idx]);
+          idx++;
+        }
+      }
+    }
+    if (!organization && afterClosing[idx]) {
+      organization = titleCase(afterClosing[idx]);
+      idx++;
+    }
+    contact = afterClosing.slice(idx).join(' ') || null;
+  }
+
+  const REL_PATTERNS = [
+    /I have worked with[^.]*\./i,
+    /As a [^.]*\./i,
+    /I know [^.]*\./i,
+    /I have mentored [^.]*\./i,
+  ];
+  let relationship = null;
+  for (const r of REL_PATTERNS) {
+    const m = text.match(r);
+    if (m) {
+      relationship = m[0].trim();
+      break;
+    }
+  }
+
+  const salutationIdx = lines.findIndex((l) => /^Dear|^To Whom It May Concern/i.test(l));
+  const bodyStart = salutationIdx !== -1 ? salutationIdx + 1 : 0;
+  const bodyEnd = closingIdx !== -1 ? closingIdx : lines.length;
+  const body = lines.slice(bodyStart, bodyEnd).join(' ').trim();
+  const endorsement_text = body ? body.slice(0, 500) : null;
+
+  const hasSignatureImage = /\[signature\]|signature image/i.test(text);
+
+  return {
+    doc_type: 'letter_of_support',
+    recipient: recipient || null,
+    author: {
+      full_name: full_name || null,
+      title: title || null,
+      organization: organization || null,
+      contact: contact || null,
+    },
+    relationship: relationship || null,
+    endorsement_text: endorsement_text || null,
+    signature_block: {
+      has_signature_image: !!hasSignatureImage,
+      closing: closing || null,
+    },
+    document_date: document_date || null,
+    confidence,
+    warnings: [],
+  };
+}
+
+module.exports = { extractLetterOfSupport };

--- a/server/services/extractors/letterOfSupport.test.js
+++ b/server/services/extractors/letterOfSupport.test.js
@@ -1,0 +1,21 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { extractLetterOfSupport } = require('./letterOfSupport');
+
+const letter = `Letter of Support\nDated: July 1, 2024\n\nDear Grant Committee,\nI have worked with John Doe for three years at City Youth Org and know his dedication to service. John is always eager to help and demonstrates leadership.\n[signature image]\nSincerely,\nJane Smith\nDirector of Outreach, City Youth Org\n555-123-4567\njane@city.org`;
+
+test('extracts fields from letter of support', () => {
+  const res = extractLetterOfSupport({ text: letter, confidence: 0.92 });
+  assert.equal(res.doc_type, 'letter_of_support');
+  assert.equal(res.recipient, 'Grant Committee');
+  assert.equal(res.author.full_name, 'Jane Smith');
+  assert.equal(res.author.title, 'Director Of Outreach');
+  assert.equal(res.author.organization, 'City Youth Org');
+  assert.ok(res.author.contact.includes('555-123-4567'));
+  assert.ok(res.relationship.startsWith('I have worked with John Doe'));
+  assert.ok(res.endorsement_text.includes('John is always eager'));
+  assert.equal(res.signature_block.closing, 'Sincerely,');
+  assert.ok(res.signature_block.has_signature_image);
+  assert.equal(res.document_date, '2024-07-01');
+  assert.equal(res.confidence, 0.92);
+});


### PR DESCRIPTION
## Summary
- detect letters of support/recommendation in uploads
- extract author, recipient, relationship and endorsement text
- merge parsed letters into `fields_clean.team_documents.letters`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c194b63d248327b5a61fa7d36a7bae