### PR TITLE
feat: add W-2 document detection and extraction

### DIFF
--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -15,6 +15,19 @@ already available on your `PATH`.
 The `/analyze` endpoint also accepts raw text via JSON or `text/plain` payloads.
 The maximum text size is **100KB** and the response shape matches file uploads.
 
+## Supported Documents
+
+The analyzer performs document-type detection and structured extraction for:
+
+- IRS Form W-2 (Wage and Tax Statement)
+- IRS Form W-9 (Request for Taxpayer Identification Number and Certification)
+- IRS Form 1120X (Amended U.S. Corporation Income Tax Return)
+- IRS Form 941-X
+- Tax payment receipts
+- Business licenses, articles of incorporation, and EIN assignment letters
+- Financial statements (profit & loss statements and balance sheets)
+- Project documents such as business plans, grant use statements, energy savings reports, utility bills, installer contracts, equipment specs, and invoices/quotes
+
 ```bash
 # JSON body
 curl -X POST http://localhost:8000/analyze \

--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -374,6 +374,9 @@ async def analyze_text_flow(
         response["fields"] = extracted.get("fields", {})
         if "fields_clean" in extracted:
             response["fields_clean"] = extracted.get("fields_clean", {})
+        for meta_key in ("field_sources", "field_confidence", "warnings"):
+            if meta_key in extracted:
+                response[meta_key] = extracted.get(meta_key)
     else:
         response["fields"] = extracted
     extra = {"source": source}

--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -38,6 +38,7 @@ EXTRACTORS = {
     "Articles_Of_Incorporation": ("articles_of_incorporation", "extract"),
     "EIN_Letter": ("ein_letter", "extract"),
     "W9_Form": ("w9_form", "extract"),
+    "W2_Form": ("w2_form", "extract"),
     "Profit_And_Loss_Statement": ("p_and_l_statement", "extract"),
     "Balance_Sheet": ("balance_sheet", "extract"),
     "Business_Plan": ("business_plan", "extract"),
@@ -61,6 +62,8 @@ def identify(doc_text: str) -> dict:
             score += 0.5
         if any(re.search(r, text) for r in rx):
             score += 0.5
+        if score > 0:
+            score += spec["identify"].get("score_bonus", 0)
         if score > 0 and (not best or score > best["confidence"]):
             best = {"type_key": key, "confidence": score}
     return best or {}

--- a/ai-analyzer/src/extractors/w2_form.py
+++ b/ai-analyzer/src/extractors/w2_form.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import logging
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+FORM_TITLE_RE = re.compile(r"Form\s+W-2\s+Wage\s+and\s+Tax\s+Statement", re.IGNORECASE)
+OMB_RE = re.compile(r"OMB\s+No\.?\s*1545-0029", re.IGNORECASE)
+COPY_RE = re.compile(r"Copy\s+(?:A|B|C|D|1|2)\b", re.IGNORECASE)
+BOX_HEADER_RE = re.compile(r"^\s*(?:1|2|3|4|5|6|7|8|10|11|12|13|14|15|16|17|18|19|20)\b", re.IGNORECASE | re.MULTILINE)
+
+EIN_RE = re.compile(r"Employer\s+identification\s+number\s*(?:\(EIN\))?\s*[:#-]?\s*([0-9][0-9\-\s]{8,})", re.IGNORECASE)
+SSN_RE = re.compile(r"Employee'?s\s+social\s+security\s+number\s*[:#-]?\s*([0-9][0-9\-\s]{8,})", re.IGNORECASE)
+
+BOX_NUMBER_TO_KEY: Dict[int, str] = {
+    1: "box1_wages",
+    2: "box2_federal_income_tax_withheld",
+    3: "box3_social_security_wages",
+    4: "box4_social_security_tax_withheld",
+    5: "box5_medicare_wages_and_tips",
+    6: "box6_medicare_tax_withheld",
+    7: "box7_social_security_tips",
+    8: "box8_allocated_tips",
+    10: "box10_dependent_care_benefits",
+    11: "box11_nonqualified_plans",
+    16: "box16_state_wages",
+    17: "box17_state_income_tax",
+    18: "box18_local_wages",
+    19: "box19_local_income_tax",
+}
+
+FIELD_BOX_MAP: Dict[str, str] = {
+    "ein": "b",
+    "employer_name": "c",
+    "employer_address": "c",
+    "employer_zip": "c",
+    "employee_ssn": "a",
+    "employee_ssn_masked": "a",
+    "employee_name": "e",
+    "employee_address": "f",
+    "employee_zip": "f",
+    "box12": "12",
+    "box13_statutory_employee": "13",
+    "box13_retirement_plan": "13",
+    "box13_third_party_sick_pay": "13",
+    "box14_other": "14",
+    "box15_state": "15",
+    "box15_employer_state_id": "15",
+    "box16_state_wages": "16",
+    "box17_state_income_tax": "17",
+    "box18_local_wages": "18",
+    "box19_local_income_tax": "19",
+    "box20_locality_name": "20",
+}
+FIELD_BOX_MAP.update({key: str(num) for num, key in BOX_NUMBER_TO_KEY.items()})
+
+BOX_LINE_RE = re.compile(r"^(?P<num>\d{1,2})(?P<suffix>[a-d]?)\s+(?P<body>.+)$", re.IGNORECASE)
+BOX12_RE = re.compile(r"12([a-d])\s+([A-Z0-9]{1,3})\s+([$0-9,\.]+)", re.IGNORECASE)
+CHECK_TRUE_RE = re.compile(r"(☑|☒|✅|✔|\[\s*[xX]\s*\]|\(\s*[xX]\s*\)|\b[Xx]\b)")
+CHECK_FALSE_RE = re.compile(r"(☐|\[\s*\])")
+STATE_LINE_RE = re.compile(
+    r"15\s+State\s+([A-Z]{2})[^\n]*?state\s+ID\s+number\s+([A-Za-z0-9\-]+)",
+    re.IGNORECASE | re.DOTALL,
+)
+LOCALITY_RE = re.compile(r"20\s+Locality\s+name\s+([A-Za-z0-9 \-]+)", re.IGNORECASE)
+BOX14_LINE_RE = re.compile(r"^\s*14\s+Other\s+(.*)$", re.IGNORECASE)
+
+
+def detect(text: str) -> bool:
+    """Heuristic detection for IRS Form W-2 uploads."""
+    if not text:
+        return False
+    score = 0
+    if FORM_TITLE_RE.search(text):
+        score += 1
+    if OMB_RE.search(text):
+        score += 1
+    if COPY_RE.search(text):
+        score += 1
+    if len(BOX_HEADER_RE.findall(text)) >= 4:
+        score += 1
+    return score >= 2
+
+
+def _digits(value: str) -> str:
+    return re.sub(r"\D", "", value or "")
+
+
+def _parse_money(token: str) -> Optional[float]:
+    cleaned = (token or "").strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("$", "").replace(",", "")
+    cleaned = cleaned.replace("O", "0").replace("o", "0")
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    if cleaned in {"", "-", "--", "."}:
+        return None
+    try:
+        return float(Decimal(cleaned))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _mask_ssn(digits: str) -> Optional[str]:
+    if len(digits) == 9:
+        return f"***-**-{digits[-4:]}"
+    return None
+
+
+def _collect_block(lines: List[str], pattern: re.Pattern[str], max_lines: int = 4) -> List[str]:
+    for idx, line in enumerate(lines):
+        if pattern.search(line):
+            collected: List[str] = []
+            for offset in range(1, max_lines + 1):
+                if idx + offset >= len(lines):
+                    break
+                candidate = lines[idx + offset].strip()
+                if not candidate:
+                    if collected:
+                        break
+                    continue
+                if BOX_LINE_RE.match(candidate) or candidate.lower().startswith("copy"):
+                    break
+                collected.append(candidate)
+            return collected
+    return []
+
+
+def _extract_box_value(text: str, box_number: int) -> Tuple[Optional[str], Optional[float]]:
+    pattern = re.compile(
+        rf"(?im)^\s*{box_number}(?!\d)[^\n]*?([\$0-9,\.]+)\s*$"
+    )
+    match = pattern.search(text)
+    if match:
+        raw = match.group(1).strip()
+        return raw, _parse_money(raw)
+    # fallback: capture last numeric token on the line
+    pattern_fallback = re.compile(rf"(?im)^\s*{box_number}(?!\d)[^\n]*?([\$0-9,\.]+)")
+    match = pattern_fallback.search(text)
+    if match:
+        raw = match.group(1).strip()
+        return raw, _parse_money(raw)
+    return None, None
+
+
+def _parse_box14(line: str) -> Optional[Dict[str, Any]]:
+    match = BOX14_LINE_RE.match(line)
+    if not match:
+        return None
+    payload = match.group(1).strip()
+    if not payload:
+        return None
+    parts = payload.split()
+    amount = None
+    split_index: Optional[int] = None
+    for idx in range(len(parts) - 1, -1, -1):
+        token = parts[idx]
+        val = _parse_money(token)
+        if val is not None:
+            amount = val
+            split_index = idx
+            break
+    label_tokens = parts
+    if split_index is not None:
+        label_tokens = parts[:split_index]
+    label = " ".join(label_tokens).strip(" :")
+    result: Dict[str, Any] = {"label": label or "Other"}
+    if amount is not None:
+        result["amount"] = amount
+    return result
+
+
+def _checkbox_value(text: str, label: str) -> Optional[bool]:
+    pattern = re.compile(rf"{label}[^\n]*", re.IGNORECASE)
+    match = pattern.search(text)
+    if not match:
+        return None
+    snippet = match.group(0)
+    marker_match = re.search(
+        r"(☑|☒|✅|✔|\[\s*[xX]\s*\]|\(\s*[xX]\s*\)|\b[Xx]\b|☐|\[\s*\])",
+        snippet,
+    )
+    if marker_match:
+        marker = marker_match.group(0)
+        if CHECK_TRUE_RE.search(marker):
+            return True
+        if CHECK_FALSE_RE.search(marker):
+            return False
+    # textual cues
+    lowered = snippet.lower()
+    if "yes" in lowered:
+        return True
+    if "no" in lowered:
+        return False
+    return None
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "fields_clean": {},
+            "warnings": ["Document did not match W-2 heuristics"],
+            "evidence_key": evidence_key,
+        }
+
+    lines = text.splitlines()
+    fields: Dict[str, Any] = {}
+    fields_clean: Dict[str, Any] = {}
+    field_confidence: Dict[str, float] = {}
+    field_sources: Dict[str, Dict[str, Any]] = {}
+    warnings: List[str] = []
+
+    ein_raw = None
+    if m := EIN_RE.search(text):
+        ein_raw = m.group(1).strip()
+        fields["ein"] = ein_raw
+        digits = _digits(ein_raw)
+        if len(digits) == 9:
+            fields_clean["ein"] = digits
+            field_confidence["ein"] = 0.95
+        else:
+            warnings.append("Employer EIN appears malformed")
+    else:
+        warnings.append("Missing employer EIN (box b)")
+
+    if "ein" in fields:
+        field_sources["ein"] = {"page": 1, "box": FIELD_BOX_MAP.get("ein", "b")}
+
+    employer_block = _collect_block(
+        lines, re.compile(r"Employer'?s\s+name,\s+address", re.IGNORECASE)
+    )
+    if employer_block:
+        fields["employer_name"] = employer_block[0]
+        fields_clean["employer_name"] = employer_block[0]
+        address_lines = employer_block[1:] if len(employer_block) > 1 else []
+        if address_lines:
+            address = ", ".join(address_lines)
+            fields["employer_address"] = address
+            fields_clean["employer_address"] = address
+            zip_match = re.search(r"\b\d{5}(?:-\d{4})?\b", address)
+            if zip_match:
+                zip_val = zip_match.group(0)
+                fields["employer_zip"] = zip_val
+                fields_clean["employer_zip"] = zip_val
+        field_confidence["employer_name"] = 0.85
+        if "employer_address" in fields_clean:
+            field_confidence["employer_address"] = 0.75
+        field_sources["employer_name"] = {"page": 1, "box": FIELD_BOX_MAP.get("employer_name", "c")}
+        if "employer_address" in fields_clean:
+            field_sources["employer_address"] = {
+                "page": 1,
+                "box": FIELD_BOX_MAP.get("employer_address", "c"),
+            }
+        if "employer_zip" in fields_clean:
+            field_confidence["employer_zip"] = 0.7
+            field_sources["employer_zip"] = {
+                "page": 1,
+                "box": FIELD_BOX_MAP.get("employer_zip", "c"),
+            }
+    else:
+        warnings.append("Missing employer name/address block (box c)")
+
+    if m := SSN_RE.search(text):
+        ssn_raw = m.group(1).strip()
+        fields["employee_ssn"] = ssn_raw
+        digits = _digits(ssn_raw)
+        if len(digits) == 9:
+            fields_clean["employee_ssn"] = digits
+            masked = _mask_ssn(digits)
+            if masked:
+                fields_clean["employee_ssn_masked"] = masked
+            field_confidence["employee_ssn"] = 0.95
+            field_sources["employee_ssn"] = {"page": 1, "box": FIELD_BOX_MAP.get("employee_ssn", "a")}
+            field_sources["employee_ssn_masked"] = field_sources["employee_ssn"]
+        else:
+            warnings.append("Employee SSN appears malformed (box a)")
+    else:
+        warnings.append("Missing employee SSN (box a)")
+
+    employee_name_block = _collect_block(lines, re.compile(r"Employee'?s\s+name", re.IGNORECASE))
+    if employee_name_block:
+        fields["employee_name"] = employee_name_block[0]
+        fields_clean["employee_name"] = employee_name_block[0]
+        field_confidence["employee_name"] = 0.85
+        field_sources["employee_name"] = {"page": 1, "box": FIELD_BOX_MAP.get("employee_name", "e")}
+    else:
+        warnings.append("Missing employee name (box e)")
+
+    employee_address_block = _collect_block(
+        lines, re.compile(r"Employee'?s\s+address", re.IGNORECASE)
+    )
+    if employee_address_block:
+        address = ", ".join(employee_address_block)
+        fields["employee_address"] = address
+        fields_clean["employee_address"] = address
+        zip_match = re.search(r"\b\d{5}(?:-\d{4})?\b", address)
+        if zip_match:
+            zip_val = zip_match.group(0)
+            fields["employee_zip"] = zip_val
+            fields_clean["employee_zip"] = zip_val
+        field_confidence["employee_address"] = 0.75
+        field_sources["employee_address"] = {
+            "page": 1,
+            "box": FIELD_BOX_MAP.get("employee_address", "f"),
+        }
+        if "employee_zip" in fields_clean:
+            field_confidence["employee_zip"] = 0.7
+            field_sources["employee_zip"] = {
+                "page": 1,
+                "box": FIELD_BOX_MAP.get("employee_zip", "f"),
+            }
+    else:
+        warnings.append("Missing employee address (box f)")
+
+    # Box 12 codes
+    box12_matches = BOX12_RE.findall(text)
+    if box12_matches:
+        entries = []
+        for suffix, code, amount_raw in box12_matches:
+            amount = _parse_money(amount_raw)
+            entry: Dict[str, Any] = {"box": suffix.lower(), "code": code.upper()}
+            if amount is not None:
+                entry["amount"] = amount
+            entries.append(entry)
+        fields["box12"] = entries
+        fields_clean["box12"] = [
+            {k: v for k, v in entry.items() if k != "box"} for entry in entries
+        ]
+        field_confidence["box12"] = 0.8
+        field_sources["box12"] = {"page": 1, "box": FIELD_BOX_MAP.get("box12", "12")}
+
+    # Numeric boxes
+    for box_number, key in BOX_NUMBER_TO_KEY.items():
+        raw, normalized = _extract_box_value(text, box_number)
+        if raw is None and normalized is None:
+            continue
+        if raw is not None:
+            fields[key] = raw
+        if normalized is not None:
+            fields_clean[key] = normalized
+            field_confidence[key] = 0.8
+            field_sources[key] = {"page": 1, "box": FIELD_BOX_MAP.get(key, str(box_number))}
+        else:
+            warnings.append(f"Box {box_number} value appears malformed")
+
+    # Box 13 checkboxes
+    stat_emp = _checkbox_value(text, "Statutory employee")
+    if stat_emp is not None:
+        fields_clean["box13_statutory_employee"] = stat_emp
+        field_confidence["box13_statutory_employee"] = 0.7
+        field_sources["box13_statutory_employee"] = {
+            "page": 1,
+            "box": FIELD_BOX_MAP.get("box13_statutory_employee", "13"),
+        }
+    retire_plan = _checkbox_value(text, "Retirement plan")
+    if retire_plan is not None:
+        fields_clean["box13_retirement_plan"] = retire_plan
+        field_confidence["box13_retirement_plan"] = 0.7
+        field_sources["box13_retirement_plan"] = {
+            "page": 1,
+            "box": FIELD_BOX_MAP.get("box13_retirement_plan", "13"),
+        }
+    sick_pay = _checkbox_value(text, "Third-party sick pay")
+    if sick_pay is not None:
+        fields_clean["box13_third_party_sick_pay"] = sick_pay
+        field_confidence["box13_third_party_sick_pay"] = 0.7
+        field_sources["box13_third_party_sick_pay"] = {
+            "page": 1,
+            "box": FIELD_BOX_MAP.get("box13_third_party_sick_pay", "13"),
+        }
+
+    # Box 14 other
+    box14_entries: List[Dict[str, Any]] = []
+    for line in lines:
+        parsed = _parse_box14(line)
+        if parsed:
+            box14_entries.append(parsed)
+    if box14_entries:
+        fields["box14_other"] = box14_entries
+        fields_clean["box14_other"] = box14_entries
+        field_confidence["box14_other"] = 0.7
+        field_sources["box14_other"] = {"page": 1, "box": FIELD_BOX_MAP.get("box14_other", "14")}
+
+    # State and locality (boxes 15-20)
+    if m := STATE_LINE_RE.search(text):
+        state_abbrev, employer_state_id = m.groups()
+        state_abbrev = state_abbrev.upper()
+        employer_state_id = employer_state_id.strip()
+        fields["box15_state"] = state_abbrev
+        fields["box15_employer_state_id"] = employer_state_id
+        fields_clean["box15_state"] = state_abbrev
+        fields_clean["box15_employer_state_id"] = employer_state_id
+        field_confidence["box15_state"] = 0.75
+        field_confidence["box15_employer_state_id"] = 0.75
+        field_sources["box15_state"] = {"page": 1, "box": FIELD_BOX_MAP.get("box15_state", "15")}
+        field_sources["box15_employer_state_id"] = {
+            "page": 1,
+            "box": FIELD_BOX_MAP.get("box15_employer_state_id", "15"),
+        }
+    else:
+        warnings.append("Missing state abbreviation (box 15)")
+
+    if m := LOCALITY_RE.search(text):
+        locality = m.group(1).strip()
+        fields["box20_locality_name"] = locality
+        fields_clean["box20_locality_name"] = locality
+        field_confidence["box20_locality_name"] = 0.7
+        field_sources["box20_locality_name"] = {"page": 1, "box": FIELD_BOX_MAP.get("box20_locality_name", "20")}
+
+    required_keys = ["ein", "employee_ssn", "box1_wages", "box2_federal_income_tax_withheld"]
+    for key in required_keys:
+        if key not in fields_clean:
+            if key == "employee_ssn":
+                warnings.append("Missing normalized employee SSN")
+            elif key == "ein":
+                warnings.append("Missing normalized employer EIN")
+            elif key == "box1_wages":
+                warnings.append("Missing Box 1 wages")
+            elif key == "box2_federal_income_tax_withheld":
+                warnings.append("Missing Box 2 federal withholding")
+
+    doc_conf = 0.55
+    if "ein" in fields_clean:
+        doc_conf += 0.1
+    if "employee_ssn" in fields_clean:
+        doc_conf += 0.1
+    if "box1_wages" in fields_clean:
+        doc_conf += 0.1
+    if "box2_federal_income_tax_withheld" in fields_clean:
+        doc_conf += 0.1
+    if "box12" in fields_clean:
+        doc_conf += 0.05
+    if "box13_statutory_employee" in fields_clean or "box13_retirement_plan" in fields_clean:
+        doc_conf += 0.05
+    if "box16_state_wages" in fields_clean and "box17_state_income_tax" in fields_clean:
+        doc_conf += 0.05
+    if doc_conf > 0.95:
+        doc_conf = 0.95
+    missing_penalty = 0.05 * sum(1 for w in warnings if w.lower().startswith("missing"))
+    if missing_penalty:
+        doc_conf = max(0.3, doc_conf - missing_penalty)
+
+    logger.info(
+        "w2_form.extract",
+        extra={
+            "found": sorted(fields_clean.keys()),
+            "warnings": warnings,
+            "evidence_key": evidence_key,
+        },
+    )
+
+    return {
+        "doc_type": "W2_Form",
+        "confidence": doc_conf,
+        "fields": fields,
+        "fields_clean": fields_clean,
+        "field_confidence": field_confidence,
+        "field_sources": field_sources,
+        "warnings": warnings,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/fixtures/w2_sample_ocr.txt
+++ b/ai-analyzer/tests/fixtures/w2_sample_ocr.txt
@@ -1,0 +1,33 @@
+FORM W-2 WAGE AND TAX STATEMENT
+OMB NO.1545-0029
+COPY C FOR EMPLOYEE'S RECORDS
+b Employer identification number 98 7654321
+c Employer's name, address, and ZIP code:
+Example Manufacturing LLC
+455 Industrial Ave Building 5
+Los Angeles CA 90012
+A Employee's social security number 987 65 4321
+e Employee's name
+Jane M Example
+f Employee's address and ZIP code
+1020 Broad Ave Apt 3B
+Los Angeles CA 90012
+1 WAGES TIPS OTHER COMP 45,000.00
+2 FEDERAL INCOME TAX WITHHELD $5,200.00
+3 SOCIAL SECURITY WAGES 45,000.00
+4 SOCIAL SECURITY TAX WITHHELD $2,790.00
+5 MEDICARE WAGES AND TIPS 45,000.00
+6 MEDICARE TAX WITHHELD 652.50
+7 SOCIAL SECURITY TIPS 0.00
+8 ALLOCATED TIPS 0.00
+10 DEPENDENT CARE BENEFITS 0.00
+11 NONQUALIFIED PLANS 0.00
+12a E 900.00 12b DD 2800.00 12c D 450.00
+13 Statutory employee [ ] Retirement plan ☒ Third-party sick pay ☐
+14 Other Health Insurance 1,200.00
+15 State CA Employer's state ID number CA-1234567
+16 State wages, tips, etc. 45,000.00
+17 State income tax 1,800.00
+18 Local wages, tips, etc. 45,000.00
+19 Local income tax 900.00
+20 Locality name Los Angeles City

--- a/ai-analyzer/tests/fixtures/w2_sample_pdf.txt
+++ b/ai-analyzer/tests/fixtures/w2_sample_pdf.txt
@@ -1,0 +1,33 @@
+Form W-2 Wage and Tax Statement
+OMB No. 1545-0029
+Copy B For Employee's Records
+Employer identification number (EIN) 12-3456789
+Employer's name, address, and ZIP code
+Acme Corporation
+123 Business Road Suite 400
+Metropolis, NY 10101
+Employee's social security number 123-45-6789
+Employee's name
+John Q Worker
+Employee's address and ZIP code
+789 Main Street
+Smallville, NY 10010
+1 Wages, tips, other compensation 55,000.00
+2 Federal income tax withheld 6,500.00
+3 Social security wages 55,000.00
+4 Social security tax withheld 3,410.00
+5 Medicare wages and tips 55,000.00
+6 Medicare tax withheld 797.50
+7 Social security tips 0.00
+8 Allocated tips 0.00
+10 Dependent care benefits 0.00
+11 Nonqualified plans 0.00
+12a D 1500.00 12b DD 3200.00
+13 Statutory employee (x) Retirement plan [ ] Third-party sick pay [ ]
+14 Other Union dues 200.00
+15 State NY Employer's state ID number 12-34567
+16 State wages, tips, etc. 55,000.00
+17 State income tax 2,200.00
+18 Local wages, tips, etc. 55,000.00
+19 Local income tax 1,100.00
+20 Locality name Gotham

--- a/ai-analyzer/tests/test_w2_form.py
+++ b/ai-analyzer/tests/test_w2_form.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ai_analyzer.main import app
+from src.detectors import identify
+from src.extractors.w2_form import detect as detect_w2, extract
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+PDF_SAMPLE = (FIXTURES / "w2_sample_pdf.txt").read_text()
+OCR_SAMPLE = (FIXTURES / "w2_sample_ocr.txt").read_text()
+
+client = TestClient(app)
+
+
+def test_detects_w2_pdf_sample() -> None:
+    assert detect_w2(PDF_SAMPLE) is True
+    det = identify(PDF_SAMPLE)
+    assert det["type_key"] == "W2_Form"
+    assert det["confidence"] >= 0.5
+
+
+def test_extracts_structured_fields_from_pdf() -> None:
+    out = extract(PDF_SAMPLE, evidence_key="uploads/w2.pdf")
+    assert out["doc_type"] == "W2_Form"
+    clean = out["fields_clean"]
+    assert clean["ein"] == "123456789"
+    assert clean["employee_ssn"] == "123456789"
+    assert clean["employee_ssn_masked"] == "***-**-6789"
+    assert clean["employee_name"] == "John Q Worker"
+    assert clean["employer_name"] == "Acme Corporation"
+    assert clean["box1_wages"] == pytest.approx(55000.0)
+    assert clean["box2_federal_income_tax_withheld"] == pytest.approx(6500.0)
+    assert clean["box12"] == [
+        {"code": "D", "amount": 1500.0},
+        {"code": "DD", "amount": 3200.0},
+    ]
+    assert clean["box13_statutory_employee"] is True
+    assert clean["box13_retirement_plan"] is False
+    assert clean["box13_third_party_sick_pay"] is False
+    assert clean["box14_other"][0]["label"].lower() == "union dues"
+    assert clean["box15_state"] == "NY"
+    assert clean["box17_state_income_tax"] == pytest.approx(2200.0)
+    assert clean["box20_locality_name"] == "Gotham"
+
+    assert out["field_sources"]["ein"]["box"].lower() == "b"
+    assert out["field_sources"]["box1_wages"]["box"] == "1"
+    assert out["field_confidence"]["box1_wages"] >= 0.7
+    assert out["warnings"] == []
+
+
+def test_ocr_variant_parses_multiple_box12_entries() -> None:
+    out = extract(OCR_SAMPLE)
+    clean = out["fields_clean"]
+    assert clean["ein"] == "987654321"
+    assert clean["employee_ssn_masked"] == "***-**-4321"
+    assert clean["box12"] == [
+        {"code": "E", "amount": 900.0},
+        {"code": "DD", "amount": 2800.0},
+        {"code": "D", "amount": 450.0},
+    ]
+    assert clean["box13_retirement_plan"] is True
+    assert clean.get("box13_statutory_employee") is False
+    assert clean["box17_state_income_tax"] == pytest.approx(1800.0)
+    assert out["confidence"] >= 0.75
+
+
+def test_analyze_endpoint_exposes_metadata() -> None:
+    resp = client.post("/analyze", json={"text": PDF_SAMPLE})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["doc_type"] == "W2_Form"
+    assert data["fields_clean"]["ein"] == "123456789"
+    assert data["field_sources"]["box2_federal_income_tax_withheld"]["box"] == "2"
+    assert data["field_confidence"]["box2_federal_income_tax_withheld"] >= 0.7
+
+
+def test_missing_ein_yields_warning() -> None:
+    text = PDF_SAMPLE.replace("Employer identification number (EIN) 12-3456789\n", "")
+    out = extract(text)
+    assert any("EIN" in warning for warning in out["warnings"])
+    assert out["confidence"] < 0.9
+
+
+def test_detect_requires_multiple_clues() -> None:
+    random_text = "This is not a tax form. It only mentions wages without context."
+    assert detect_w2(random_text) is False
+    assert identify(random_text) == {}

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -428,5 +428,47 @@
     "standards_refs":         { "aliases": ["standards_refs","standards"], "type": "array" },
     "prepared_by_name":       { "aliases": ["prepared_by_name","engineer_name"], "type": "string" },
     "prepared_by_license":    { "aliases": ["prepared_by_license","engineer_license"], "type": "string" }
+  },
+  "w2_form": {
+    "ein": { "aliases": ["ein", "employer_ein"], "type": "ein" },
+    "employer_name": { "aliases": ["employer_name"], "type": "string" },
+    "employer_address": { "aliases": ["employer_address"], "type": "string" },
+    "employer_zip": { "aliases": ["employer_zip", "employer_postal_code"], "type": "string" },
+    "employee_ssn": { "aliases": ["employee_ssn", "ssn"], "type": "string" },
+    "employee_ssn_masked": { "aliases": ["employee_ssn_masked"], "type": "string" },
+    "employee_name": { "aliases": ["employee_name"], "type": "string" },
+    "employee_address": { "aliases": ["employee_address"], "type": "string" },
+    "employee_zip": { "aliases": ["employee_zip", "employee_postal_code"], "type": "string" },
+    "box1_wages": { "aliases": ["box1", "wages", "wages_box1"], "type": "currency" },
+    "box2_federal_income_tax_withheld": {
+      "aliases": ["box2", "federal_withholding", "federal_income_tax_withheld"],
+      "type": "currency"
+    },
+    "box3_social_security_wages": { "aliases": ["box3", "social_security_wages"], "type": "currency" },
+    "box4_social_security_tax_withheld": {
+      "aliases": ["box4", "social_security_tax", "social_security_tax_withheld"],
+      "type": "currency"
+    },
+    "box5_medicare_wages_and_tips": { "aliases": ["box5", "medicare_wages"], "type": "currency" },
+    "box6_medicare_tax_withheld": { "aliases": ["box6", "medicare_tax"], "type": "currency" },
+    "box7_social_security_tips": { "aliases": ["box7", "social_security_tips"], "type": "currency" },
+    "box8_allocated_tips": { "aliases": ["box8", "allocated_tips"], "type": "currency" },
+    "box10_dependent_care_benefits": { "aliases": ["box10", "dependent_care_benefits"], "type": "currency" },
+    "box11_nonqualified_plans": { "aliases": ["box11", "nonqualified_plans"], "type": "currency" },
+    "box12": { "aliases": ["box12", "box12_entries"], "type": "array" },
+    "box13_statutory_employee": { "aliases": ["statutory_employee"], "type": "bool" },
+    "box13_retirement_plan": { "aliases": ["retirement_plan"], "type": "bool" },
+    "box13_third_party_sick_pay": { "aliases": ["third_party_sick_pay"], "type": "bool" },
+    "box14_other": { "aliases": ["box14", "box14_other"], "type": "array" },
+    "box15_state": { "aliases": ["box15_state", "state"], "type": "string" },
+    "box15_employer_state_id": {
+      "aliases": ["box15_employer_state_id", "employer_state_id"],
+      "type": "string"
+    },
+    "box16_state_wages": { "aliases": ["box16", "state_wages"], "type": "currency" },
+    "box17_state_income_tax": { "aliases": ["box17", "state_income_tax"], "type": "currency" },
+    "box18_local_wages": { "aliases": ["box18", "local_wages"], "type": "currency" },
+    "box19_local_income_tax": { "aliases": ["box19", "local_income_tax"], "type": "currency" },
+    "box20_locality_name": { "aliases": ["box20", "locality_name"], "type": "string" }
   }
 }

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -119,6 +119,32 @@
       },
       "examples": ["IRS Form W-9"]
     },
+    "W2_Form": {
+      "display_name": "IRS Form W-2 (Wage and Tax Statement)",
+      "identify": {
+        "keywords_any": [
+          "Form W-2 Wage and Tax Statement",
+          "Wage and Tax Statement",
+          "OMB No. 1545-0029"
+        ],
+        "regex_any": [
+          "(?i)Form\\s+W-2\\s+Wage\\s+and\\s+Tax\\s+Statement",
+          "(?i)OMB\\s+No\\.\\s*1545-0029",
+          "(?i)Copy\\s+(?:A|B|C|D|1|2)"
+        ],
+        "score_bonus": 0.2,
+        "check_pages": [1]
+      },
+      "extract_fields": [
+        "ein",
+        "employee_ssn",
+        "box1_wages",
+        "box2_federal_income_tax_withheld"
+      ],
+      "normalize": {
+        "ein": "ein"
+      }
+    },
     "Profit_And_Loss_Statement": {
       "extractor": "p_and_l_statement",
       "detector": {


### PR DESCRIPTION
## Summary
- add W-2 detection heuristics and extractor with normalized output, per-field confidence, and warnings
- wire canonical W-2 fields into the shared catalog and eligibility field map and document support in the analyzer README
- add sample fixtures plus unit and integration tests covering W-2 extraction scenarios

## Testing
- pytest ai-analyzer/tests/test_w2_form.py


------
https://chatgpt.com/codex/tasks/task_b_68d06ebf23e48327867d357a201c2598