### PR TITLE
Add payroll register detection and extraction

### DIFF
--- a/ai-analyzer/README.md
+++ b/ai-analyzer/README.md
@@ -26,6 +26,7 @@ The analyzer performs document-type detection and structured extraction for:
 - Tax payment receipts
 - Business licenses, articles of incorporation, and EIN assignment letters
 - Financial statements (profit & loss statements and balance sheets)
+- Payroll registers and provider payroll reports (ADP, Gusto, QuickBooks Payroll, Paychex, Zenefits)
 - Project documents such as business plans, grant use statements, energy savings reports, utility bills, installer contracts, equipment specs, and invoices/quotes
 
 ```bash
@@ -59,6 +60,64 @@ eligibility engine after normalization. Common field names include:
 | `revenue_drop_2020_pct` | `55%` |
 | `annual_revenue` | `$1,200,000` |
 | `payroll_total` | `$950k` |
+
+### Payroll Register Output
+
+Payroll uploads yield per-employee detail, period metadata, and document-level totals. A truncated example:
+
+```json
+{
+  "doc_type": "Payroll_Register",
+  "fields_clean": {
+    "pay_period": {
+      "start_date": "2023-01-01",
+      "end_date": "2023-01-07",
+      "check_date": "2023-01-10",
+      "frequency": "weekly"
+    },
+    "employee_count": 12,
+    "employees": [
+      {
+        "employee": {"id": "1001", "name": "Jane Smith", "ssn_last4": "4321"},
+        "pay_components": {
+          "regular_hours": 40.0,
+          "regular_pay": 1200.0,
+          "overtime_pay": 150.0,
+          "gross_pay": 1500.0
+        },
+        "withholding": {
+          "federal_wh": 200.0,
+          "social_security": 93.0,
+          "medicare": 21.75,
+          "state_wh": 60.0
+        },
+        "net_pay": 1125.25,
+        "ytd": {"total_pay": 3000.0, "federal_wh": 400.0, "net_pay": 2200.0}
+      }
+    ],
+    "document_totals": {
+      "gross": 18540.25,
+      "withholding": 4820.13,
+      "employer_taxes": 1890.42,
+      "deductions_employee": 640.00,
+      "net": 12089.70
+    }
+  },
+  "parse_summary": {
+    "rows_parsed": 12,
+    "columns_mapped": 18,
+    "columns_missing": []
+  }
+}
+```
+
+### Payroll Export Tips
+
+- **ADP** – Reports ➜ Payroll ➜ Payroll Register ➜ export as PDF/CSV.
+- **Gusto** – Reports ➜ Payroll ➜ Payroll Journal ➜ download the pay period register.
+- **QuickBooks Payroll** – Reports ➜ Employees & Payroll ➜ Payroll Detail Review (export to CSV/XLSX).
+- **Paychex** – Reports ➜ Payroll ➜ Payroll Summary; export via Flex as XLSX.
+- **Zenefits** – Reports ➜ Payroll ➜ Payroll Register; choose CSV for structured tables.
 
 Additional aliases are documented in
 `eligibility-engine/contracts/field_map.json`.

--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -48,6 +48,8 @@ EXTRACTORS = {
     "Equipment_Specs": ("equipment_specs", "extract"),
     "Invoices_or_Quotes": ("invoices_or_quotes", "extract"),
     "Energy_Savings_Report": ("energy_savings_report", "extract"),
+    "Payroll_Register": ("payroll_register", "extract"),
+    "Payroll_Provider_Report": ("payroll_register", "extract"),
 }
 
 def identify(doc_text: str) -> dict:

--- a/ai-analyzer/src/extractors/payroll_register.py
+++ b/ai-analyzer/src/extractors/payroll_register.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import csv
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+PAY_PERIOD_RE = re.compile(
+    r"Pay\s*Period\s*[:\-]?\s*(?P<start>[^\s]+)\s*(?:to|\-|through)\s*(?P<end>[^\s]+)",
+    re.IGNORECASE,
+)
+CHECK_DATE_RE = re.compile(
+    r"Check\s*Date\s*[:\-]?\s*(?P<date>[0-9]{1,2}[\-/][0-9]{1,2}[\-/][0-9]{2,4})",
+    re.IGNORECASE,
+)
+FREQUENCY_HINTS = {
+    "weekly": "weekly",
+    "bi-weekly": "biweekly",
+    "biweekly": "biweekly",
+    "semi-monthly": "semimonthly",
+    "semimonthly": "semimonthly",
+    "monthly": "monthly",
+}
+
+VENDORS = {
+    "adp": "ADP",
+    "gusto": "Gusto",
+    "quickbooks payroll": "QuickBooks Payroll",
+    "intuit payroll": "QuickBooks Payroll",
+    "paychex": "Paychex",
+    "zenefits": "Zenefits",
+}
+
+
+def detect(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    required_hits = 0
+    if "payroll" in lowered:
+        required_hits += 1
+    if "pay period" in lowered or "check date" in lowered:
+        required_hits += 1
+    if "gross pay" in lowered or "net pay" in lowered:
+        required_hits += 1
+    if "employee name" in lowered or "emp" in lowered:
+        required_hits += 1
+    return required_hits >= 3
+
+
+def _normalize_label(label: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", label.lower()).strip()
+
+
+COLUMN_ALIASES: Dict[str, str] = {
+    "emp no": "employee.id",
+    "emp number": "employee.id",
+    "emp id": "employee.id",
+    "employee id": "employee.id",
+    "employee number": "employee.id",
+    "employee name": "employee.name",
+    "name": "employee.name",
+    "worker": "employee.name",
+    "ssn": "employee.ssn",
+    "ssn last4": "employee.ssn",
+    "social security": "employee.ssn",
+    "gross pay": "pay_components.gross_pay",
+    "total pay": "pay_components.gross_pay",
+    "total earnings": "pay_components.gross_pay",
+    "earnings": "pay_components.gross_pay",
+    "regular pay": "pay_components.regular_pay",
+    "regular hrs": "pay_components.regular_hours",
+    "regular hours": "pay_components.regular_hours",
+    "overtime pay": "pay_components.overtime_pay",
+    "overtime": "pay_components.overtime_pay",
+    "overtime hours": "pay_components.overtime_hours",
+    "ot hours": "pay_components.overtime_hours",
+    "bonus": "pay_components.bonus_pay",
+    "bonus pay": "pay_components.bonus_pay",
+    "vacation hours": "pay_components.vacation_hours",
+    "vacation pay": "pay_components.vacation_pay",
+    "sick hours": "pay_components.sick_hours",
+    "sick pay": "pay_components.sick_pay",
+    "other earnings": "pay_components.other_earnings",
+    "federal wh": "withholding.federal_wh",
+    "federal withholding": "withholding.federal_wh",
+    "fed wh": "withholding.federal_wh",
+    "oasdi": "withholding.social_security",
+    "social security tax": "withholding.social_security",
+    "fica": "withholding.social_security",
+    "medicare": "withholding.medicare",
+    "state wh": "withholding.state_wh",
+    "state withholding": "withholding.state_wh",
+    "local wh": "withholding.local_wh",
+    "local withholding": "withholding.local_wh",
+    "net pay": "net_pay",
+    "check date": "pay_period.check_date",
+    "pay period start": "pay_period.start_date",
+    "pay period end": "pay_period.end_date",
+    "period start": "pay_period.start_date",
+    "period end": "pay_period.end_date",
+    "start date": "pay_period.start_date",
+    "end date": "pay_period.end_date",
+    "ytd gross": "ytd.total_pay",
+    "ytd total": "ytd.total_pay",
+    "ytd wages": "ytd.total_pay",
+    "ytd federal": "ytd.federal_wh",
+    "ytd fed": "ytd.federal_wh",
+    "ytd oasdi": "ytd.social_security",
+    "ytd social security": "ytd.social_security",
+    "ytd medicare": "ytd.medicare",
+    "ytd state": "ytd.state_wh",
+    "ytd net": "ytd.net_pay",
+}
+
+REQUIRED_KEYS = {"employee.name", "net_pay"}
+
+
+@dataclass
+class ParsedRow:
+    index: int
+    values: List[str]
+    raw_line: str
+
+
+def _split_rows(text: str) -> List[ParsedRow]:
+    rows: List[ParsedRow] = []
+    for idx, line in enumerate(text.splitlines()):
+        raw = line.rstrip("\n")
+        cleaned = raw.strip()
+        if not cleaned or set(cleaned) <= {"-", "=", "_"}:
+            continue
+        if cleaned.lower().startswith("page "):
+            continue
+        if cleaned.lower().startswith("totals") and "," not in cleaned and "\t" not in cleaned:
+            # allow totals line to be processed later as tokens
+            pass
+        rows.append(ParsedRow(index=idx, values=_split_cells(cleaned), raw_line=raw))
+    return rows
+
+
+def _split_cells(line: str) -> List[str]:
+    if "," in line:
+        reader = csv.reader([line], skipinitialspace=True)
+        return [cell.strip() for cell in next(reader)]
+    if "\t" in line:
+        return [cell.strip() for cell in line.split("\t")]
+    parts = re.split(r"\s{2,}", line)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _map_header(cells: Iterable[str]) -> Dict[int, str]:
+    mapping: Dict[int, str] = {}
+    for idx, cell in enumerate(cells):
+        key = COLUMN_ALIASES.get(_normalize_label(cell))
+        if key:
+            mapping[idx] = key
+    return mapping
+
+
+def _parse_money(token: str) -> Optional[float]:
+    if token is None:
+        return None
+    cleaned = token.strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("$", "")
+    cleaned = cleaned.replace(",", "")
+    cleaned = cleaned.replace("O", "0").replace("o", "0")
+    cleaned = cleaned.replace("—", "-")
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        cleaned = f"-{cleaned[1:-1]}"
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    if cleaned in {"", "-", "."}:
+        return None
+    try:
+        return float(Decimal(cleaned))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_hours(token: str) -> Optional[float]:
+    value = _parse_money(token)
+    if value is None:
+        return None
+    return round(value, 4)
+
+
+def _parse_date(token: str) -> Optional[str]:
+    if not token:
+        return None
+    token_clean = token.strip()
+    for fmt in ("%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%Y/%m/%d", "%b %d, %Y", "%B %d, %Y"):
+        try:
+            return datetime.strptime(token_clean, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def _mask_ssn(value: str) -> Optional[str]:
+    digits = re.sub(r"\D", "", value or "")
+    if len(digits) >= 4:
+        return digits[-4:]
+    return None
+
+
+def _infer_frequency(start: Optional[str], end: Optional[str], text: str) -> str:
+    lowered = text.lower()
+    for token, mapped in FREQUENCY_HINTS.items():
+        if token in lowered:
+            return mapped
+    if start and end:
+        try:
+            dt_start = datetime.fromisoformat(start)
+            dt_end = datetime.fromisoformat(end)
+            delta = (dt_end - dt_start).days
+            if delta <= 7:
+                return "weekly"
+            if 10 <= delta <= 15:
+                return "biweekly"
+            if 15 <= delta <= 17:
+                return "semimonthly"
+            if delta >= 27:
+                return "monthly"
+        except ValueError:
+            pass
+    return "unknown"
+
+
+def _guess_vendor(text: str) -> Tuple[Optional[str], float]:
+    lowered = text.lower()
+    for token, name in VENDORS.items():
+        if token in lowered:
+            return name, 0.85
+    return None, 0.0
+
+
+def _ensure_employee_structure() -> Dict[str, Any]:
+    return {
+        "employee": {"id": None, "name": None, "ssn_last4": None},
+        "pay_components": {
+            "regular_hours": None,
+            "regular_pay": None,
+            "overtime_hours": None,
+            "overtime_pay": None,
+            "vacation_hours": None,
+            "vacation_pay": None,
+            "sick_hours": None,
+            "sick_pay": None,
+            "bonus_pay": None,
+            "other_earnings": [],
+            "gross_pay": None,
+        },
+        "withholding": {
+            "federal_wh": None,
+            "state_wh": None,
+            "local_wh": None,
+            "social_security": None,
+            "medicare": None,
+        },
+        "deductions_employee": [],
+        "employer_taxes_contribs": [],
+        "net_pay": None,
+        "ytd": {
+            "regular_pay": None,
+            "total_pay": None,
+            "federal_wh": None,
+            "social_security": None,
+            "medicare": None,
+            "state_wh": None,
+            "net_pay": None,
+            "other": [],
+        },
+    }
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    if not detect(text):
+        return {
+            "doc_type": None,
+            "confidence": 0.0,
+            "fields": {},
+            "fields_clean": {},
+            "field_confidence": {},
+            "field_sources": {},
+            "warnings": ["Unable to detect payroll register layout"],
+            "parse_summary": {},
+            "vendor_guess": {"name": None, "confidence": 0.0},
+            "evidence_key": evidence_key,
+        }
+
+    rows = _split_rows(text)
+    header_map: Dict[int, str] = {}
+    header_row: Optional[ParsedRow] = None
+    for row in rows:
+        mapping = _map_header(row.values)
+        if mapping and (
+            "employee.name" in mapping.values()
+            and ("net_pay" in mapping.values() or "pay_components.gross_pay" in mapping.values())
+        ):
+            header_map = mapping
+            header_row = row
+            break
+
+    warnings: List[str] = []
+    if not header_row:
+        warnings.append("Unable to identify table header")
+        header_row = ParsedRow(index=0, values=[], raw_line="")
+
+    mapped_columns = set(header_map.values())
+    missing_columns = sorted(k for k in REQUIRED_KEYS if k not in mapped_columns)
+    if missing_columns:
+        warnings.append(f"Missing expected columns: {', '.join(missing_columns)}")
+
+    pay_period_start = pay_period_end = check_date = None
+    if header_row:
+        header_text_prefix = "\n".join(
+            line for line in text.splitlines()[: header_row.index]
+        )
+    else:
+        header_text_prefix = text
+
+    if match := PAY_PERIOD_RE.search(text):
+        pay_period_start = _parse_date(match.group("start")) or pay_period_start
+        pay_period_end = _parse_date(match.group("end")) or pay_period_end
+    if match := CHECK_DATE_RE.search(text):
+        check_date = _parse_date(match.group("date")) or check_date
+
+    employees: List[Dict[str, Any]] = []
+    field_sources: Dict[str, Dict[str, Any]] = {}
+    field_confidence: Dict[str, float] = {}
+
+    rows_parsed = 0
+    rows_skipped = 0
+    totals_candidate: Optional[Dict[str, float]] = None
+
+    start_collecting = False if header_row else True
+    for row in rows:
+        if row is header_row:
+            start_collecting = True
+            continue
+        if not start_collecting:
+            continue
+        normalized_first = row.values[0].strip().lower() if row.values else ""
+        if normalized_first in {"totals", "total"}:
+            totals_candidate = {}
+            for idx, cell in enumerate(row.values):
+                key = header_map.get(idx)
+                if not key:
+                    continue
+                amount = _parse_money(cell)
+                if amount is not None:
+                    totals_candidate[key] = amount
+            continue
+
+        entry = _ensure_employee_structure()
+        row_has_value = False
+        for idx, cell in enumerate(row.values):
+            key = header_map.get(idx)
+            if not key:
+                continue
+            if key.startswith("pay_period."):
+                parsed = _parse_date(cell)
+                if key.endswith("start_date") and parsed:
+                    pay_period_start = pay_period_start or parsed
+                elif key.endswith("end_date") and parsed:
+                    pay_period_end = pay_period_end or parsed
+                elif key.endswith("check_date") and parsed:
+                    check_date = check_date or parsed
+                continue
+            if key == "employee.id":
+                entry["employee"]["id"] = cell.strip() or None
+                field_path = f"employees[{len(employees)}].employee.id"
+            elif key == "employee.name":
+                entry["employee"]["name"] = cell.strip() or None
+                field_path = f"employees[{len(employees)}].employee.name"
+            elif key == "employee.ssn":
+                entry["employee"]["ssn_last4"] = _mask_ssn(cell)
+                field_path = f"employees[{len(employees)}].employee.ssn_last4"
+            elif key.startswith("pay_components."):
+                amount_key = key.split(".", 1)[1]
+                if amount_key.endswith("hours"):
+                    value = _parse_hours(cell)
+                elif amount_key == "other_earnings":
+                    value = _parse_money(cell)
+                    if value is not None:
+                        entry["pay_components"]["other_earnings"].append(
+                            {"label": "Other", "amount": value}
+                        )
+                    field_path = f"employees[{len(employees)}].pay_components.other_earnings"
+                    field_sources.setdefault(field_path, {"line": row.index + 1, "column": idx, "raw": cell})
+                    field_confidence[field_path] = 0.6
+                    continue
+                else:
+                    value = _parse_money(cell)
+                entry["pay_components"][amount_key] = value
+                field_path = f"employees[{len(employees)}].pay_components.{amount_key}"
+            elif key.startswith("withholding."):
+                amount_key = key.split(".", 1)[1]
+                entry["withholding"][amount_key] = _parse_money(cell)
+                field_path = f"employees[{len(employees)}].withholding.{amount_key}"
+            elif key == "net_pay":
+                entry["net_pay"] = _parse_money(cell)
+                field_path = f"employees[{len(employees)}].net_pay"
+            elif key.startswith("ytd."):
+                amount_key = key.split(".", 1)[1]
+                entry["ytd"][amount_key] = _parse_money(cell)
+                field_path = f"employees[{len(employees)}].ytd.{amount_key}"
+            else:
+                continue
+            field_sources[field_path] = {
+                "line": row.index + 1,
+                "column": idx,
+                "raw": cell,
+            }
+            field_confidence[field_path] = 0.7
+            if cell.strip():
+                row_has_value = True
+
+        if not entry["employee"].get("name"):
+            rows_skipped += 1
+            continue
+
+        rows_parsed += 1
+        employees.append(entry)
+
+    totals = _aggregate_totals(employees)
+
+    if totals_candidate and totals_candidate.get("pay_components.gross_pay") is not None:
+        diff = abs(totals["gross"] - totals_candidate.get("pay_components.gross_pay", 0.0))
+        if diff > 0.05:
+            warnings.append(
+                f"Totals do not reconcile (+${diff:.2f})"
+            )
+
+    withholding_total = totals["withholding"]
+    deductions_total = totals["deductions_employee"]
+    gross_total = totals["gross"]
+    net_total = totals["net"]
+    if not math.isclose(gross_total - withholding_total - deductions_total, net_total, abs_tol=0.05):
+        warnings.append("Per-employee totals do not reconcile to net pay")
+
+    vendor_name, vendor_conf = _guess_vendor(text)
+
+    pay_period = {
+        "start_date": pay_period_start,
+        "end_date": pay_period_end,
+        "check_date": check_date,
+        "frequency": _infer_frequency(pay_period_start, pay_period_end, text),
+    }
+
+    parse_summary = {
+        "rows_parsed": rows_parsed,
+        "rows_skipped": rows_skipped,
+        "columns_mapped": len(mapped_columns),
+        "columns_missing": missing_columns,
+    }
+
+    field_confidence.update(
+        {
+            "pay_period.start_date": 0.75 if pay_period_start else 0.0,
+            "pay_period.end_date": 0.75 if pay_period_end else 0.0,
+            "pay_period.check_date": 0.7 if check_date else 0.0,
+            "pay_period.frequency": 0.6,
+        }
+    )
+
+    field_sources.update(
+        {
+            "pay_period.start_date": {"line": 1, "column": "header", "raw": pay_period_start},
+            "pay_period.end_date": {"line": 1, "column": "header", "raw": pay_period_end},
+            "pay_period.check_date": {"line": 1, "column": "header", "raw": check_date},
+            "pay_period.frequency": {"line": 0, "column": None, "raw": pay_period["frequency"]},
+        }
+    )
+
+    fields_clean = {
+        "pay_period": pay_period,
+        "employees": employees,
+        "document_totals": totals,
+        "employee_count": len(employees),
+    }
+
+    confidence = 0.6
+    if employees:
+        confidence += 0.2
+    if pay_period_start and pay_period_end:
+        confidence += 0.1
+    if totals["gross"] > 0 and totals["net"] > 0:
+        confidence += 0.05
+    confidence = min(confidence, 0.95)
+
+    result = {
+        "doc_type": "Payroll_Register",
+        "confidence": confidence,
+        "fields": {"header": header_row.values if header_row else []},
+        "fields_clean": fields_clean,
+        "field_confidence": field_confidence,
+        "field_sources": field_sources,
+        "warnings": warnings,
+        "parse_summary": parse_summary,
+        "vendor_guess": {"name": vendor_name, "confidence": vendor_conf},
+        "evidence_key": evidence_key,
+    }
+    return result
+
+
+def _aggregate_totals(employees: List[Dict[str, Any]]) -> Dict[str, float]:
+    gross_total = 0.0
+    withholding_total = 0.0
+    employer_total = 0.0
+    deductions_total = 0.0
+    net_total = 0.0
+    for entry in employees:
+        pay_comp = entry.get("pay_components", {})
+        gross = pay_comp.get("gross_pay")
+        if gross is None:
+            components = [
+                pay_comp.get("regular_pay"),
+                pay_comp.get("overtime_pay"),
+                pay_comp.get("vacation_pay"),
+                pay_comp.get("sick_pay"),
+                pay_comp.get("bonus_pay"),
+            ]
+            gross = sum(v for v in components if isinstance(v, (int, float)))
+        gross_total += gross or 0.0
+
+        withholding = entry.get("withholding", {})
+        withholding_total += sum(
+            v for v in [
+                withholding.get("federal_wh"),
+                withholding.get("state_wh"),
+                withholding.get("local_wh"),
+                withholding.get("social_security"),
+                withholding.get("medicare"),
+            ]
+            if isinstance(v, (int, float))
+        )
+
+        for item in entry.get("deductions_employee", []) or []:
+            amount = item.get("amount")
+            if isinstance(amount, (int, float)):
+                deductions_total += amount
+
+        for item in entry.get("employer_taxes_contribs", []) or []:
+            amount = item.get("amount")
+            if isinstance(amount, (int, float)):
+                employer_total += amount
+
+        net = entry.get("net_pay")
+        if isinstance(net, (int, float)):
+            net_total += net
+
+    return {
+        "gross": round(gross_total, 2),
+        "withholding": round(withholding_total, 2),
+        "employer_taxes": round(employer_total, 2),
+        "deductions_employee": round(deductions_total, 2),
+        "net": round(net_total, 2),
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/tests/fixtures/payroll_register_adp.pdf
+++ b/ai-analyzer/tests/fixtures/payroll_register_adp.pdf
@@ -1,0 +1,9 @@
+ADP Payroll Register
+Company: Demo Manufacturing LLC
+Pay Period: 01/01/2023 - 01/07/2023
+Check Date: 01/10/2023
+
+Emp. No.,Employee Name,SSN,Gross Pay,Regular Pay,Regular Hours,Overtime Pay,Overtime Hours,Federal WH,OASDI,Medicare,State WH,Net Pay,YTD Gross,YTD Federal
+1001,Jane Smith,***-**-4321,1500.00,1200.00,40,150.00,5,200.00,93.00,21.75,60.00,1125.25,3000.00,400.00
+1002,John Doe,***-**-6789,1800.00,1400.00,40,200.00,10,250.00,111.60,26.10,75.00,1337.30,3600.00,500.00
+Totals,,,,,,,,450.00,204.60,47.85,135.00,2462.55,,

--- a/ai-analyzer/tests/fixtures/payroll_register_gusto.pdf
+++ b/ai-analyzer/tests/fixtures/payroll_register_gusto.pdf
@@ -1,0 +1,8 @@
+Gusto Payroll Detail Report
+Pay Period 02/01/2023 through 02/15/2023
+Check Date 02/17/2023
+Department: Operations
+
+Employee ID,Employee Name,SSN,Regular Hours,Regular Pay,Overtime Hours,Overtime Pay,Bonus,Federal WH,State WH,Local WH,Social Security,Medicare,Net Pay,YTD Gross,YTD Net
+A-01,Chris Lee,xxx-xx-1010,80,2800.00,4,180.00,200.00,420.00,135.00,25.00,183.60,42.94,2378.46,5200.00,4200.00
+A-02,Maria Gomez,xxx-xx-2020,80,2950.00,0,0.00,0.00,450.00,140.00,30.00,182.90,42.76,2104.34,5100.00,3900.00

--- a/ai-analyzer/tests/fixtures/payroll_register_paychex.xlsx
+++ b/ai-analyzer/tests/fixtures/payroll_register_paychex.xlsx
@@ -1,0 +1,7 @@
+Paychex Flex Payroll Summary
+Pay Period: 04/01/2023 - 04/15/2023
+Check Date: 04/20/2023
+
+Emp ID\tEmployee Name\tSSN\tRegular Hours\tRegular Pay\tOvertime Hours\tOvertime Pay\tFederal WH\tState WH\tSocial Security\tMedicare\tNet Pay\tYTD Gross\tYTD Net
+PX-01\tJordan Miles\t***-**-5050\t80\t3100.00\t2\t120.00\t480.00\t160.00\t192.20\t44.95\t2242.85\t6400.00\t5000.00
+PX-02\tTaylor Reed\t***-**-6060\t80\t3000.00\t0\t0.00\t470.00\t150.00\t186.00\t43.50\t2150.50\t6300.00\t4900.00

--- a/ai-analyzer/tests/fixtures/payroll_register_qb.csv
+++ b/ai-analyzer/tests/fixtures/payroll_register_qb.csv
@@ -1,0 +1,6 @@
+"QuickBooks Payroll Register"
+"Pay Period","03/01/2023","-","03/07/2023"
+"Check Date","03/09/2023"
+"Employee Name","Employee ID","SSN","Gross Pay","Regular Pay","Federal WH","Medicare","Social Security","State WH","Net Pay","YTD Gross","YTD Federal"
+"Alex Parker","QB-100","***-**-3030","2100.00","1800.00","320.00","30.45","130.20","80.00","1539.35","6000.00","750.00"
+"Jamie Wong","QB-200","***-**-4040","1950.00","1700.00","300.00","28.28","121.14","70.00","1430.58","5800.00","690.00"

--- a/ai-analyzer/tests/test_payroll_register.py
+++ b/ai-analyzer/tests/test_payroll_register.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.detectors import identify
+from src.extractors.payroll_register import detect as detect_payroll, extract as extract_payroll
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "payroll_register_adp.pdf",
+        "payroll_register_gusto.pdf",
+        "payroll_register_qb.csv",
+        "payroll_register_paychex.xlsx",
+    ],
+)
+def test_payroll_register_detection_variants(fixture_name: str) -> None:
+    sample = _read(fixture_name)
+    assert detect_payroll(sample) is True
+    det = identify(sample)
+    assert det
+    assert det["type_key"] in {"Payroll_Register", "Payroll_Provider_Report"}
+    assert det["confidence"] >= 0.5
+
+
+def test_payroll_register_extraction_parses_employees() -> None:
+    sample = _read("payroll_register_adp.pdf")
+    result = extract_payroll(sample, evidence_key="uploads/adp.pdf")
+    clean = result["fields_clean"]
+    assert result["doc_type"] == "Payroll_Register"
+    assert clean["employee_count"] == 2
+    assert clean["pay_period"]["start_date"] == "2023-01-01"
+    assert clean["pay_period"]["end_date"] == "2023-01-07"
+    assert clean["pay_period"]["check_date"] == "2023-01-10"
+    assert clean["pay_period"]["frequency"] in {"weekly", "biweekly", "semimonthly", "monthly", "unknown"}
+
+    employees = clean["employees"]
+    assert employees[0]["employee"]["name"] == "Jane Smith"
+    assert employees[0]["employee"]["ssn_last4"] == "4321"
+    assert employees[0]["pay_components"]["regular_pay"] == pytest.approx(1200.0)
+    assert employees[0]["withholding"]["federal_wh"] == pytest.approx(200.0)
+    assert employees[0]["net_pay"] == pytest.approx(1125.25)
+    assert employees[0]["ytd"]["total_pay"] == pytest.approx(3000.0)
+
+    totals = clean["document_totals"]
+    assert totals["gross"] == pytest.approx(3300.0)
+    assert totals["withholding"] == pytest.approx(837.45, rel=1e-3)
+    assert totals["net"] == pytest.approx(2462.55, rel=1e-3)
+
+    assert result["parse_summary"]["rows_parsed"] == 2
+    assert result["vendor_guess"]["name"] == "ADP"
+    assert result["field_sources"]["employees[0].employee.name"]["line"] > 0
+    assert result["field_confidence"]["employees[0].employee.name"] >= 0.7
+    assert isinstance(result["warnings"], list)
+
+
+def test_payroll_register_gusto_frequency_and_totals() -> None:
+    sample = _read("payroll_register_gusto.pdf")
+    result = extract_payroll(sample)
+    period = result["fields_clean"]["pay_period"]
+    assert period["start_date"] == "2023-02-01"
+    assert period["end_date"] == "2023-02-15"
+    assert period["frequency"] == "biweekly"
+    totals = result["fields_clean"]["document_totals"]
+    assert totals["gross"] == pytest.approx(6130.0)
+    assert totals["net"] == pytest.approx(4482.8, rel=1e-3)
+
+
+def test_payroll_register_csv_detection_prefers_catalog_entry() -> None:
+    sample = _read("payroll_register_qb.csv")
+    det = identify(sample)
+    assert det["type_key"] in {"Payroll_Register", "Payroll_Provider_Report"}
+    out = extract_payroll(sample)
+    assert out["fields_clean"]["employee_count"] == 2
+    assert out["fields_clean"]["employees"][1]["employee"]["name"] == "Jamie Wong"
+
+
+def test_payroll_register_missing_columns_warns() -> None:
+    text = """Payroll Register\nEmployee Name,Gross Pay\nTotals,1000"""
+    out = extract_payroll(text)
+    assert any("Missing expected columns" in msg for msg in out["warnings"])
+    assert out["parse_summary"]["columns_missing"]

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -470,5 +470,30 @@
     "box18_local_wages": { "aliases": ["box18", "local_wages"], "type": "currency" },
     "box19_local_income_tax": { "aliases": ["box19", "local_income_tax"], "type": "currency" },
     "box20_locality_name": { "aliases": ["box20", "locality_name"], "type": "string" }
+  },
+  "payroll_period_total_gross": {
+    "aliases": ["payroll.period.total_gross", "payroll_total_gross"],
+    "target": "payroll_period_total_gross",
+    "type": "currency"
+  },
+  "payroll_period_total_withholding": {
+    "aliases": ["payroll.period.total_withholding"],
+    "target": "payroll_period_total_withholding",
+    "type": "currency"
+  },
+  "payroll_period_total_employer_taxes": {
+    "aliases": ["payroll.period.total_employer_taxes"],
+    "target": "payroll_period_total_employer_taxes",
+    "type": "currency"
+  },
+  "payroll_period_total_net": {
+    "aliases": ["payroll.period.total_net"],
+    "target": "payroll_period_total_net",
+    "type": "currency"
+  },
+  "payroll_period_employee_count": {
+    "aliases": ["payroll.period.employee_count"],
+    "target": "payroll_period_employee_count",
+    "type": "int"
   }
 }

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -169,6 +169,54 @@
         "P&L statement showing revenues, expenses and net income"
       ]
     },
+    "Payroll_Register": {
+      "display_name": "Payroll Register",
+      "identify": {
+        "keywords_any": [
+          "Payroll Register",
+          "Payroll Journal",
+          "Payroll Summary",
+          "Payroll Detail",
+          "Pay Period",
+          "Check Date"
+        ],
+        "regex_any": [
+          "(?i)\\bEmp\\.?\\s*(?:No|ID)\\b",
+          "(?i)\\bGross\\s+Pay\\b",
+          "(?i)\\bNet\\s+Pay\\b"
+        ],
+        "score_bonus": 0.2
+      },
+      "fields": {
+        "pay_period": "object",
+        "employees": "array",
+        "document_totals": "object"
+      }
+    },
+    "Payroll_Provider_Report": {
+      "display_name": "Payroll Provider Report",
+      "identify": {
+        "keywords_any": [
+          "ADP",
+          "Gusto",
+          "QuickBooks Payroll",
+          "Intuit Payroll",
+          "Paychex",
+          "Zenefits"
+        ],
+        "regex_any": [
+          "(?i)Payroll\\s+(?:Register|Detail|Summary)",
+          "(?i)Check\\s+Date",
+          "(?i)Employee\\s+Name"
+        ],
+        "score_bonus": 0.1
+      },
+      "fields": {
+        "pay_period": "object",
+        "employees": "array",
+        "document_totals": "object"
+      }
+    },
     "Balance_Sheet": {
       "extractor": "balance_sheet",
       "detector": {


### PR DESCRIPTION
## Summary
- extend the document catalog and detector routing to recognise payroll register/provider uploads and expose eligibility aliases
- implement a payroll register extractor that parses tabular payroll data, normalises values, and surfaces totals/metadata for downstream use
- add fixtures, tests, and README guidance covering payroll report support across major vendors

## Testing
- pytest ai-analyzer/tests/test_payroll_register.py

------
https://chatgpt.com/codex/tasks/task_b_68d072f2aad883278b3f879e40daa8c0