### PR TITLE
Add IRS 1099 NEC and summary report support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,62 @@ To extend the library:
    `shared/document_library/` (e.g. `grants_v2.json`).
 3. Update services to reference the new version if needed.
 
+### Supported Documents
+
+- IRS Form 1099-NEC (Nonemployee Compensation)
+- 1099 Summary / Vendor 1099 Reports (QuickBooks, Gusto, ADP, Paychex)
+
+Example 1099-NEC extraction:
+
+```json
+{
+  "doc_type": "1099_NEC",
+  "fields_clean": {
+    "payer_name": "Acme Services LLC",
+    "payer_tin": "123456789",
+    "payer_tin_masked": "***-**-6789",
+    "recipient_name": "Jamie Contractor",
+    "recipient_tin_masked": "***-**-4321",
+    "box1_nonemployee_comp": 5500.0,
+    "box4_federal_income_tax_wh": 500.0,
+    "tax_year": "2023"
+  },
+  "warnings": []
+}
+```
+
+### 1099 Summaries
+
+The analyzer now parses 1099 rollup reports exported from accounting platforms. Supported exports include QuickBooks CSV downloads, Gusto PDFs, ADP text and Paychex spreadsheets. Ensure the header row contains contractor names, TIN/EIN columns and Box 1 totals.
+
+```json
+{
+  "doc_type": "Form1099_Summary",
+  "fields_clean": {
+    "tax_year": "2023",
+    "vendor_guess": {"name": "QuickBooks", "confidence": 0.8},
+    "contractors": [
+      {
+        "contractor": {"name": "Jamie Contractor", "tin_last4": "6789"},
+        "amounts": {"box1_nonemployee_comp": 5500.0, "federal_wh": 500.0},
+        "metadata": {"account_number": "AC123"}
+      }
+    ],
+    "totals": {
+      "contractors_count": 2,
+      "sum_box1": 9700.5,
+      "sum_state_wh": 150.0
+    }
+  }
+}
+```
+
+Export tips:
+
+- **QuickBooks Online** – use the 1099 detail CSV export.
+- **Gusto** – download the 1099 contractor PDF summary.
+- **ADP / Paychex** – export the vendor 1099 worksheet (CSV/XLSX).
+
 Example: to support IRS Form 941-X uploads, add a `shared/document_types/IRS_941X.json`
 with detector keywords and required fields (`employer_identification_number`,
 `quarter`, `calendar_year`), register it in `catalog.json`, and list the

--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json, re
+from typing import Callable, Dict
 
 CATALOG_DIR = Path(__file__).resolve().parents[2] / "shared" / "document_types"
 CATALOG_PATH = CATALOG_DIR / "catalog.json"
@@ -39,6 +40,9 @@ EXTRACTORS = {
     "EIN_Letter": ("ein_letter", "extract"),
     "W9_Form": ("w9_form", "extract"),
     "W2_Form": ("w2_form", "extract"),
+    "1099_NEC": ("irs_1099_nec", "extract"),
+    "Form1099_Summary": ("irs_1099_summary", "extract_form1099_summary"),
+    "Vendor_1099_Report": ("irs_1099_summary", "extract_vendor_1099_report"),
     "Profit_And_Loss_Statement": ("p_and_l_statement", "extract"),
     "Balance_Sheet": ("balance_sheet", "extract"),
     "Business_Plan": ("business_plan", "extract"),
@@ -52,22 +56,70 @@ EXTRACTORS = {
     "Payroll_Provider_Report": ("payroll_register", "extract"),
 }
 
+
+def _score_1099_nec(text: str) -> float:
+    if not text:
+        return 0.0
+    lowered = text.lower()
+    score = 0.0
+    if "form 1099-nec" in lowered or "form 1099 nec" in lowered:
+        score += 0.6
+    if "nonemployee compensation" in lowered:
+        score += 0.3
+    if "omb no. 1545-0116" in lowered or "omb no 1545-0116" in lowered:
+        score += 0.15
+    if "copy a" in lowered or "copy b" in lowered:
+        score += 0.1
+    if "irs.gov/form1099nec" in lowered:
+        score += 0.1
+    if len(re.findall(r"(?im)^\s*[1-7]\s+", text)) >= 3:
+        score += 0.1
+    return min(score, 1.2)
+
+
+def _score_1099_summary(text: str) -> float:
+    if not text:
+        return 0.0
+    lowered = text.lower()
+    score = 0.0
+    if "1099 summary" in lowered or "vendor 1099" in lowered:
+        score += 0.7
+    if "nonemployee compensation" in lowered or "box 1" in lowered:
+        score += 0.3
+    if any(term in lowered for term in ("tin", "tax id", "ein")):
+        score += 0.2
+    if any(vendor in lowered for vendor in ("quickbooks", "gusto", "adp", "paychex", "intuit")):
+        score += 0.2
+    return min(score, 1.1)
+
+
+CUSTOM_DETECTORS: Dict[str, Callable[[str], float]] = {
+    "1099_NEC": _score_1099_nec,
+    "Form1099_Summary": _score_1099_summary,
+    "Vendor_1099_Report": _score_1099_summary,
+}
+
+
 def identify(doc_text: str) -> dict:
     """Return {'type_key': str, 'confidence': float} or {}"""
     text = doc_text[:20000]  # cap for speed
     best = None
+    lowered = text.lower()
     for key, spec in DOC_TYPES.items():
         kw = spec["identify"].get("keywords_any", [])
         rx = spec["identify"].get("regex_any", [])
-        score = 0
-        if any(k.lower() in text.lower() for k in kw):
+        score = 0.0
+        if any(k.lower() in lowered for k in kw):
             score += 0.5
         if any(re.search(r, text) for r in rx):
             score += 0.5
+        custom = CUSTOM_DETECTORS.get(key)
+        if custom:
+            score = max(score, custom(text))
         if score > 0:
             score += spec["identify"].get("score_bonus", 0)
         if score > 0 and (not best or score > best["confidence"]):
-            best = {"type_key": key, "confidence": score}
+            best = {"type_key": key, "confidence": float(score)}
     return best or {}
 
 

--- a/ai-analyzer/src/extractors/irs_1099_nec.py
+++ b/ai-analyzer/src/extractors/irs_1099_nec.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import logging
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+FORM_RE = re.compile(r"form\s+1099[-\u2011]?nec", re.IGNORECASE)
+TITLE_RE = re.compile(r"nonemployee\s+comp(?:ensation)?", re.IGNORECASE)
+OMB_RE = re.compile(r"OMB\s+No\.?\s*1545-0116", re.IGNORECASE)
+COPY_RE = re.compile(r"copy\s+(?:a|b|1|2)\b", re.IGNORECASE)
+URL_RE = re.compile(r"irs\.gov/\s*form1099nec", re.IGNORECASE)
+BOX_LABEL_RE = re.compile(
+    r"(?im)^\s*([1-7])\s+(Nonemployee|Payer made direct sales|Excess golden parachute|Federal income tax withheld|State tax withheld|State/Payer's state no\.?|State income)"
+)
+CHECK_TRUE_RE = re.compile(r"(☑|☒|✅|✔|\[\s*[xX]\s*\]|\(\s*[xX]\s*\)|\b[Xx]\b)")
+CHECK_FALSE_RE = re.compile(r"(☐|\[\s*\])")
+
+TAX_YEAR_RE = re.compile(r"For\s+calendar\s+year\s+(20\d{2})", re.IGNORECASE)
+PHONE_RE = re.compile(r"Phone\s*[:\-]?\s*([\d()\-\s\.]+)", re.IGNORECASE)
+ACCOUNT_RE = re.compile(r"Account\s+number\s*[:\-]?\s*(.+)$", re.IGNORECASE)
+STATE_SPLIT_RE = re.compile(r"[,/]|\s{2,}")
+
+BOX_PATTERNS = {
+    "box1_nonemployee_comp": re.compile(
+        r"(?im)^\s*1\s+Nonemployee\s+comp(?:ensation)?[^0-9\n]*([\$0-9,()\.-]+)"
+    ),
+    "box3_excess_golden_parachute": re.compile(
+        r"(?im)^\s*3\s+Excess\s+golden\s+parachute[^0-9\n]*([\$0-9,()\.-]+)"
+    ),
+    "box4_federal_income_tax_wh": re.compile(
+        r"(?im)^\s*4\s+Federal\s+income\s+tax\s+withheld[^0-9\n]*([\$0-9,()\.-]+)"
+    ),
+    "box5_state_tax_wh": re.compile(
+        r"(?im)^\s*5\s+State\s+tax\s+withheld[^0-9\n]*([\$0-9,()\.-]+(?:\s+[\$0-9,()\.-]+)*)"
+    ),
+    "box7_state_income": re.compile(
+        r"(?im)^\s*7\s+State\s+income[^0-9\n]*([\$0-9,()\.-]+(?:\s+[\$0-9,()\.-]+)*)"
+    ),
+}
+
+MULTI_VALUE_BOXES = {"box5_state_tax_wh", "box7_state_income"}
+
+
+def detect(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    score = 0.0
+    if FORM_RE.search(lowered):
+        score += 0.4
+    if TITLE_RE.search(lowered):
+        score += 0.25
+    if OMB_RE.search(text):
+        score += 0.1
+    if COPY_RE.search(text):
+        score += 0.1
+    if URL_RE.search(lowered):
+        score += 0.1
+    if len(BOX_LABEL_RE.findall(text)) >= 3:
+        score += 0.15
+    return score >= 0.6
+
+
+def _parse_money(token: str) -> Optional[float]:
+    cleaned = (token or "").strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("$", "").replace(",", "")
+    cleaned = cleaned.replace("O", "0").replace("o", "0")
+    cleaned = cleaned.replace("—", "-")
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        cleaned = f"-{cleaned[1:-1]}"
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    if cleaned in {"", "-", "."}:
+        return None
+    try:
+        return float(Decimal(cleaned))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _normalize_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def _normalize_tin(value: Optional[str]) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    if not value:
+        return None, None, None
+    digits = re.sub(r"\D", "", value)
+    masked = None
+    last4 = digits[-4:] if len(digits) >= 4 else None
+    if last4:
+        masked = f"***-**-{last4}"
+    if len(digits) == 9:
+        return digits, masked, last4
+    return None, masked, last4
+
+
+def _checkbox_value(line: str, label: Optional[str] = None) -> Optional[bool]:
+    if not line:
+        return None
+    snippet = line
+    if label:
+        match = re.search(rf"{label}[^\n]*", line, re.IGNORECASE)
+        if match:
+            snippet = match.group(0)
+    true = CHECK_TRUE_RE.search(snippet)
+    false = CHECK_FALSE_RE.search(snippet)
+    if true and not false:
+        return True
+    if false and not true:
+        return False
+    lowered = snippet.lower()
+    if "yes" in lowered:
+        return True
+    if "no" in lowered:
+        return False
+    return None
+
+
+def _extract_labeled(
+    lines: List[str], patterns: List[re.Pattern[str]], *, join_next: int = 0
+) -> Tuple[Optional[str], Optional[int]]:
+    for idx, line in enumerate(lines):
+        for pat in patterns:
+            match = pat.search(line)
+            if match:
+                tail = line[match.end() :].strip(" :\t-·")
+                parts = [tail] if tail else []
+                for offset in range(1, join_next + 1):
+                    if idx + offset >= len(lines):
+                        break
+                    nxt = lines[idx + offset].strip()
+                    if not nxt:
+                        break
+                    parts.append(nxt)
+                value = _normalize_whitespace(" ".join(filter(None, parts)))
+                return value or None, idx
+    return None, None
+
+
+def _extract_box_values(
+    pattern: re.Pattern[str], text: str, allow_multi: bool = False
+) -> Tuple[List[str], List[float]]:
+    match = pattern.search(text)
+    if not match:
+        return [], []
+    raw = match.group(1).strip()
+    if allow_multi:
+        tokens = [tok.strip() for tok in re.findall(r"\(?[\$0-9,\.\-]+\)?", raw) if tok.strip()]
+    else:
+        tokens = [raw]
+    raw_values: List[str] = []
+    clean_values: List[float] = []
+    for token in tokens:
+        value = token.strip()
+        if not value:
+            continue
+        if allow_multi and value.isdigit() and len(value) <= 2:
+            continue
+        if value.endswith(')') and '(' not in value:
+            numeric_candidate = re.sub(r'[^0-9.]', '', value)
+            if numeric_candidate:
+                value = f'({value}'
+        raw_values.append(value)
+        parsed = _parse_money(value)
+        if parsed is not None:
+            clean_values.append(parsed)
+    if not raw_values and raw:
+        raw_values.append(raw)
+        parsed = _parse_money(raw)
+        if parsed is not None:
+            clean_values.append(parsed)
+    return raw_values, clean_values
+
+
+def extract(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    lines = [line.rstrip("\n") for line in text.splitlines()]
+    stripped_lines = [line.strip() for line in lines]
+
+    fields: Dict[str, Any] = {}
+    fields_clean: Dict[str, Any] = {}
+    field_sources: Dict[str, Dict[str, Any]] = {}
+    field_confidence: Dict[str, float] = {}
+    warnings: List[str] = []
+
+    payer_name, payer_name_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Payer'?s\s+name[:\-]?", re.IGNORECASE)],
+        join_next=0,
+    )
+    if payer_name:
+        fields["payer_name"] = payer_name
+        fields_clean["payer_name"] = payer_name
+        field_sources["payer_name"] = {"page": 1, "line": (payer_name_idx or 0) + 1, "raw": payer_name}
+        field_confidence["payer_name"] = 0.9
+
+    payer_address, payer_address_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Street\s+address[:\-]?", re.IGNORECASE)],
+        join_next=1,
+    )
+    if payer_address:
+        fields["payer_address"] = payer_address
+        fields_clean["payer_address"] = payer_address
+        field_sources["payer_address"] = {
+            "page": 1,
+            "line": (payer_address_idx or 0) + 1,
+            "raw": payer_address,
+        }
+        field_confidence["payer_address"] = 0.85
+
+    payer_phone = None
+    payer_phone_idx = None
+    for idx, line in enumerate(stripped_lines):
+        match = PHONE_RE.search(line)
+        if match:
+            payer_phone = _normalize_whitespace(match.group(1))
+            payer_phone_idx = idx
+            break
+    if payer_phone:
+        fields["payer_phone"] = payer_phone
+        fields_clean["payer_phone"] = payer_phone
+        field_sources["payer_phone"] = {
+            "page": 1,
+            "line": (payer_phone_idx or 0) + 1,
+            "raw": payer_phone,
+        }
+        field_confidence["payer_phone"] = 0.6
+
+    payer_tin_value, payer_tin_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Payer'?s\s+TIN[:\-]?", re.IGNORECASE)],
+        join_next=0,
+    )
+    if payer_tin_value:
+        clean_tin, masked_tin, last4 = _normalize_tin(payer_tin_value)
+        if clean_tin:
+            fields_clean["payer_tin"] = clean_tin
+            fields["payer_tin"] = clean_tin
+            field_confidence["payer_tin"] = 0.9
+        else:
+            warnings.append("invalid_payer_tin")
+        if masked_tin:
+            fields_clean["payer_tin_masked"] = masked_tin
+            field_confidence["payer_tin_masked"] = 0.9
+        if last4:
+            fields_clean["payer_tin_last4"] = last4
+            field_confidence["payer_tin_last4"] = 0.9
+        field_sources["payer_tin"] = {
+            "page": 1,
+            "line": (payer_tin_idx or 0) + 1,
+            "raw": payer_tin_value,
+        }
+        field_sources["payer_tin_masked"] = field_sources["payer_tin"]
+        field_sources["payer_tin_last4"] = field_sources["payer_tin"]
+
+    recipient_name, recipient_name_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Recipient'?s\s+name[:\-]?", re.IGNORECASE)],
+        join_next=0,
+    )
+    if recipient_name:
+        fields["recipient_name"] = recipient_name
+        fields_clean["recipient_name"] = recipient_name
+        field_sources["recipient_name"] = {
+            "page": 1,
+            "line": (recipient_name_idx or 0) + 1,
+            "raw": recipient_name,
+        }
+        field_confidence["recipient_name"] = 0.9
+
+    recipient_address, recipient_addr_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Street\s+address\s*\(including\s+apt\.?", re.IGNORECASE)],
+        join_next=1,
+    )
+    if recipient_address:
+        fields["recipient_address"] = recipient_address
+        fields_clean["recipient_address"] = recipient_address
+        field_sources["recipient_address"] = {
+            "page": 1,
+            "line": (recipient_addr_idx or 0) + 1,
+            "raw": recipient_address,
+        }
+        field_confidence["recipient_address"] = 0.85
+
+    recipient_tin_value, recipient_tin_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"Recipient'?s\s+TIN[:\-]?", re.IGNORECASE)],
+        join_next=0,
+    )
+    if recipient_tin_value:
+        clean_tin, masked_tin, last4 = _normalize_tin(recipient_tin_value)
+        if clean_tin:
+            fields_clean["recipient_tin"] = clean_tin
+            fields["recipient_tin"] = clean_tin
+            field_confidence["recipient_tin"] = 0.9
+        else:
+            warnings.append("invalid_recipient_tin")
+        if masked_tin:
+            fields_clean["recipient_tin_masked"] = masked_tin
+            field_confidence["recipient_tin_masked"] = 0.9
+        if last4:
+            fields_clean["recipient_tin_last4"] = last4
+            field_confidence["recipient_tin_last4"] = 0.9
+        field_sources["recipient_tin"] = {
+            "page": 1,
+            "line": (recipient_tin_idx or 0) + 1,
+            "raw": recipient_tin_value,
+        }
+        field_sources["recipient_tin_masked"] = field_sources["recipient_tin"]
+        field_sources["recipient_tin_last4"] = field_sources["recipient_tin"]
+
+    account_number = None
+    account_idx = None
+    for idx, line in enumerate(stripped_lines):
+        match = ACCOUNT_RE.search(line)
+        if match:
+            account_number = _normalize_whitespace(match.group(1))
+            account_idx = idx
+            break
+    if account_number:
+        fields["account_number"] = account_number
+        fields_clean["account_number"] = account_number
+        field_sources["account_number"] = {
+            "page": 1,
+            "line": (account_idx or 0) + 1,
+            "raw": account_number,
+        }
+        field_confidence["account_number"] = 0.6
+
+    tax_year_match = TAX_YEAR_RE.search(text)
+    if tax_year_match:
+        tax_year = tax_year_match.group(1)
+        fields_clean["tax_year"] = tax_year
+        field_confidence["tax_year"] = 0.8
+        field_sources["tax_year"] = {"page": 1, "line": 1, "raw": tax_year_match.group(0)}
+
+    void_value = None
+    corrected_value = None
+    for idx, line in enumerate(stripped_lines[:5]):
+        if "void" in line.lower():
+            void_value = _checkbox_value(line, label="void")
+            field_sources["void"] = {
+                "page": 1,
+                "line": idx + 1,
+                "raw": stripped_lines[idx],
+            }
+        if "corrected" in line.lower():
+            corrected_value = _checkbox_value(line, label="corrected")
+            field_sources["corrected"] = {
+                "page": 1,
+                "line": idx + 1,
+                "raw": stripped_lines[idx],
+            }
+    if void_value is not None:
+        fields_clean["void"] = bool(void_value)
+        field_confidence["void"] = 0.6
+    if corrected_value is not None:
+        fields_clean["corrected"] = bool(corrected_value)
+        field_confidence["corrected"] = 0.6
+
+    box2_value = None
+    for idx, line in enumerate(stripped_lines):
+        if line.lower().startswith("2 payer"):
+            box2_value = _checkbox_value(line, label="payer")
+            field_sources["box2_direct_sales_over_5000"] = {
+                "page": 1,
+                "line": idx + 1,
+                "raw": stripped_lines[idx],
+            }
+            break
+    if box2_value is not None:
+        fields_clean["box2_direct_sales_over_5000"] = bool(box2_value)
+        field_confidence["box2_direct_sales_over_5000"] = 0.75
+
+    for key, pattern in BOX_PATTERNS.items():
+        raw_values, parsed_values = _extract_box_values(
+            pattern, text, allow_multi=key in MULTI_VALUE_BOXES
+        )
+        if not raw_values and not parsed_values:
+            continue
+        if key in MULTI_VALUE_BOXES and len(parsed_values) > 1:
+            fields_clean[key] = parsed_values
+            fields[key] = raw_values
+        else:
+            value_clean = parsed_values[0] if parsed_values else None
+            value_raw = raw_values[0] if raw_values else None
+            fields_clean[key] = value_clean
+            fields[key] = value_raw
+        field_confidence[key] = 0.85
+        field_sources[key] = {
+            "page": 1,
+            "line": next(
+                (idx + 1 for idx, line in enumerate(stripped_lines) if pattern.search(line)),
+                1,
+            ),
+            "raw": raw_values if len(raw_values) > 1 else (raw_values[0] if raw_values else ""),
+        }
+
+    state_raw, state_idx = _extract_labeled(
+        stripped_lines,
+        [re.compile(r"State/Payer'?s\s+state\s+no\.", re.IGNORECASE)],
+        join_next=0,
+    )
+    if state_raw:
+        tokens = [tok.strip() for tok in STATE_SPLIT_RE.split(state_raw) if tok.strip()]
+        value: Any = tokens if len(tokens) > 1 else (tokens[0] if tokens else state_raw)
+        fields_clean["box6_state_payer_state_no"] = value
+        fields["box6_state_payer_state_no"] = value
+        field_confidence["box6_state_payer_state_no"] = 0.8
+        field_sources["box6_state_payer_state_no"] = {
+            "page": 1,
+            "line": (state_idx or 0) + 1,
+            "raw": state_raw,
+        }
+
+    if fields_clean.get("box1_nonemployee_comp") in (None, [], ""):
+        warnings.append("missing_box1")
+
+    state_lengths = []
+    for key in ("box5_state_tax_wh", "box6_state_payer_state_no", "box7_state_income"):
+        value = fields_clean.get(key)
+        if isinstance(value, list):
+            state_lengths.append(len(value))
+        elif value is not None:
+            state_lengths.append(1)
+    if state_lengths and len(set(state_lengths)) > 1:
+        warnings.append("state_box_length_mismatch")
+
+    doc_conf = 0.55
+    if FORM_RE.search(text):
+        doc_conf += 0.15
+    if TITLE_RE.search(text):
+        doc_conf += 0.1
+    if fields_clean.get("box1_nonemployee_comp"):
+        doc_conf += 0.1
+    if fields_clean.get("payer_tin") and fields_clean.get("recipient_tin"):
+        doc_conf += 0.1
+    if fields_clean.get("box4_federal_income_tax_wh") is not None:
+        doc_conf += 0.05
+    doc_conf = min(doc_conf, 0.95)
+    if warnings:
+        doc_conf = max(0.35, doc_conf - 0.1 * len(warnings))
+
+    logger.info(
+        "irs_1099_nec.extract",
+        extra={
+            "found": sorted(fields_clean.keys()),
+            "warnings": warnings,
+            "evidence_key": evidence_key,
+        },
+    )
+
+    return {
+        "doc_type": "1099_NEC",
+        "confidence": doc_conf,
+        "fields": fields,
+        "fields_clean": fields_clean,
+        "field_confidence": field_confidence,
+        "field_sources": field_sources,
+        "warnings": warnings,
+        "evidence_key": evidence_key,
+    }
+
+
+__all__ = ["detect", "extract"]

--- a/ai-analyzer/src/extractors/irs_1099_summary.py
+++ b/ai-analyzer/src/extractors/irs_1099_summary.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import csv
+import io
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+TITLE_HINTS = [
+    "1099 summary",
+    "vendor 1099 summary",
+    "1099 nec summary",
+    "1099 report",
+    "vendor 1099 report",
+]
+COLUMN_ALIASES: Dict[str, str] = {
+    "vendor": "contractor.name",
+    "vendor payee": "contractor.name",
+    "payee": "contractor.name",
+    "contractor": "contractor.name",
+    "recipient": "contractor.name",
+    "name": "contractor.name",
+    "vendor name": "contractor.name",
+    "tin": "contractor.tin",
+    "tax id": "contractor.tin",
+    "tax identification number": "contractor.tin",
+    "ein": "contractor.tin",
+    "ein ssn": "contractor.tin",
+    "ein/ssn": "contractor.tin",
+    "ssn": "contractor.tin",
+    "nonemployee compensation": "amounts.box1_nonemployee_comp",
+    "box 1": "amounts.box1_nonemployee_comp",
+    "box1": "amounts.box1_nonemployee_comp",
+    "total 1099 amount": "amounts.box1_nonemployee_comp",
+    "1099 amount": "amounts.box1_nonemployee_comp",
+    "nec": "amounts.box1_nonemployee_comp",
+    "federal wh": "amounts.federal_wh",
+    "federal withholding": "amounts.federal_wh",
+    "federal tax withheld": "amounts.federal_wh",
+    "backup wh": "amounts.federal_wh",
+    "backup withholding": "amounts.federal_wh",
+    "state wh": "amounts.state_wh",
+    "state tax withheld": "amounts.state_wh",
+    "state withholding": "amounts.state_wh",
+    "state income": "amounts.state_income",
+    "state taxable": "amounts.state_income",
+    "total state income": "amounts.state_income",
+    "account #": "metadata.account_number",
+    "account number": "metadata.account_number",
+    "acct #": "metadata.account_number",
+}
+
+TOTAL_KEY_MAP = {
+    "box1_nonemployee_comp": "sum_box1",
+    "federal_wh": "sum_federal_wh",
+    "state_wh": "sum_state_wh",
+    "state_income": "sum_state_income",
+}
+
+VENDOR_KEYWORDS = {
+    "quickbooks": "QuickBooks",
+    "intuit": "QuickBooks",
+    "gusto": "Gusto",
+    "adp": "ADP",
+    "paychex": "Paychex",
+}
+
+
+def detect(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    hits = 0.0
+    if any(hint in lowered for hint in TITLE_HINTS):
+        hits += 1
+    header_hits = sum(
+        1 for alias in ("vendor", "contractor", "nonemployee compensation", "box 1") if alias in lowered
+    )
+    if header_hits >= 2:
+        hits += 0.5
+    if "tin" in lowered or "tax id" in lowered:
+        hits += 0.5
+    if "1099" in lowered and "summary" in lowered:
+        hits += 0.5
+    return hits >= 1.5
+
+
+def _normalize_label(label: str) -> str:
+    cleaned = re.sub(r"[\s\-/]+", " ", label.lower()).strip()
+    cleaned = re.sub(r"[^a-z0-9# ]", "", cleaned)
+    return cleaned
+
+
+def _parse_money(token: str) -> Optional[float]:
+    if token is None:
+        return None
+    cleaned = token.strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("$", "").replace(",", "")
+    cleaned = cleaned.replace("O", "0").replace("o", "0")
+    cleaned = cleaned.replace("—", "-")
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        cleaned = f"-{cleaned[1:-1]}"
+    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    if cleaned in {"", "-", "."}:
+        return None
+    try:
+        return float(Decimal(cleaned))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _coerce_row_cells(row: Iterable[str]) -> List[str]:
+    cells: List[str] = []
+    for cell in row:
+        if cell is None:
+            cells.append("")
+        else:
+            cells.append(str(cell).strip())
+    return cells
+
+
+def _map_header(cells: Iterable[str]) -> Dict[int, str]:
+    mapping: Dict[int, str] = {}
+    for idx, cell in enumerate(cells):
+        key = COLUMN_ALIASES.get(_normalize_label(cell))
+        if key:
+            mapping[idx] = key
+    return mapping
+
+
+def _guess_vendor(text: str) -> Tuple[str, float]:
+    lowered = text.lower()
+    for needle, vendor in VENDOR_KEYWORDS.items():
+        if needle in lowered:
+            return vendor, 0.8
+    return "Unknown", 0.3
+
+
+def _extract_tax_year(text: str) -> Optional[str]:
+    match = re.search(r"(?:tax|report)\s+year\s*[:\-]?\s*(20\d{2})", text, flags=re.IGNORECASE)
+    if match:
+        return match.group(1)
+    match = re.search(r"\b20\d{2}\b", text)
+    if match:
+        return match.group(0)
+    return None
+
+
+def _iter_rows(text: str) -> List[List[str]]:
+    stripped = text.strip()
+    if "," in stripped and "\n" in stripped:
+        reader = csv.reader(io.StringIO(stripped))
+        rows = [_coerce_row_cells(row) for row in reader if any(cell.strip() for cell in row)]
+        if rows:
+            return rows
+    rows: List[List[str]] = []
+    for line in text.splitlines():
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        if "\t" in cleaned:
+            cells = [cell.strip() for cell in cleaned.split("\t")]
+        elif "|" in cleaned:
+            cells = [cell.strip() for cell in cleaned.split("|")]
+        else:
+            cells = [cell.strip() for cell in re.split(r"\s{2,}", cleaned) if cell.strip()]
+        rows.append(cells)
+    return rows
+
+
+def _is_totals_row(cells: List[str]) -> bool:
+    if not cells:
+        return False
+    first = cells[0].lower()
+    return first.startswith("total") or first.startswith("grand total")
+
+
+def _accumulate(numbers: List[Optional[float]]) -> Optional[float]:
+    clean = [n for n in numbers if isinstance(n, (int, float))]
+    if not clean:
+        return None
+    return round(sum(clean), 2)
+
+
+def _extract(
+    text: str,
+    *,
+    doc_type: str,
+    evidence_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    rows = _iter_rows(text)
+    header_row: Optional[List[str]] = None
+    header_map: Dict[int, str] = {}
+    start_index = 0
+    for idx, row in enumerate(rows):
+        mapping = _map_header(row)
+        if mapping:
+            header_row = row
+            header_map = mapping
+            start_index = idx + 1
+            break
+    warnings: List[str] = []
+    if "amounts.box1_nonemployee_comp" not in header_map.values():
+        warnings.append("missing_box1_column")
+
+    contractors: List[Dict[str, Any]] = []
+    field_sources: Dict[str, Dict[str, Any]] = {}
+    field_confidence: Dict[str, float] = {}
+    totals_row_values: Dict[str, float] = {}
+    invalid_tins = False
+
+    for row_idx, row in enumerate(rows[start_index:], start=start_index):
+        cells = row
+        if not cells or (len(cells) == 1 and not cells[0]):
+            continue
+        if _is_totals_row(cells):
+            for col_idx, cell in enumerate(cells):
+                key = header_map.get(col_idx)
+                if key and key.startswith("amounts."):
+                    parsed = _parse_money(cell)
+                    if parsed is not None:
+                        totals_row_values[key.split(".")[1]] = parsed
+            continue
+        entry: Dict[str, Any] = {
+            "contractor": {"name": None, "tin_last4": None},
+            "amounts": {
+                "box1_nonemployee_comp": None,
+                "federal_wh": None,
+                "state_wh": None,
+                "state_income": None,
+            },
+            "metadata": {"account_number": None},
+        }
+        seen_values = False
+        for col_idx, cell in enumerate(cells):
+            key = header_map.get(col_idx)
+            if not key:
+                continue
+            value = cell.strip()
+            if not value:
+                continue
+            seen_values = True
+            base_source = {
+                "page": 1,
+                "row": row_idx + 1,
+                "column": col_idx,
+                "raw": value,
+            }
+            contractor_idx = len(contractors)
+            source_key = f"contractors[{contractor_idx}].{key}"
+            if key == "contractor.name":
+                entry["contractor"]["name"] = value
+                field_sources[source_key] = base_source
+                field_confidence[source_key] = 0.85
+            elif key == "contractor.tin":
+                digits = re.sub(r"\D", "", value)
+                if digits:
+                    if len(digits) not in {4, 9}:
+                        invalid_tins = True
+                    entry["contractor"]["tin_last4"] = digits[-4:]
+                field_sources[source_key] = base_source
+                field_confidence[source_key] = 0.8
+            elif key.startswith("amounts."):
+                amount_key = key.split(".")[1]
+                entry["amounts"][amount_key] = _parse_money(value)
+                field_sources[source_key] = base_source
+                field_confidence[source_key] = 0.8
+            elif key == "metadata.account_number":
+                entry["metadata"]["account_number"] = value
+                field_sources[source_key] = base_source
+                field_confidence[source_key] = 0.6
+        if seen_values and entry["contractor"]["name"]:
+            contractors.append(entry)
+
+    if invalid_tins:
+        warnings.append("invalid_tin_value")
+
+    box1_values = [c["amounts"].get("box1_nonemployee_comp") for c in contractors]
+    federal_values = [c["amounts"].get("federal_wh") for c in contractors]
+    state_wh_values = [c["amounts"].get("state_wh") for c in contractors]
+    state_income_values = [c["amounts"].get("state_income") for c in contractors]
+
+    totals_clean: Dict[str, Optional[float]] = {
+        "contractors_count": len(contractors),
+        "sum_box1": _accumulate(box1_values) or 0.0,
+        "sum_federal_wh": _accumulate(federal_values),
+        "sum_state_wh": _accumulate(state_wh_values),
+    }
+    state_income_total = _accumulate(state_income_values)
+    if state_income_total is not None:
+        totals_clean["sum_state_income"] = state_income_total
+
+    if totals_row_values:
+        mismatch = False
+        for key, reported in totals_row_values.items():
+            target_key = TOTAL_KEY_MAP.get(key)
+            if not target_key:
+                continue
+            actual = totals_clean.get(target_key)
+            if actual is not None and abs(actual - reported) > 1.0:
+                mismatch = True
+                break
+        if mismatch:
+            warnings.append("totals_mismatch")
+
+    tax_year = _extract_tax_year(text)
+    if tax_year:
+        field_sources["tax_year"] = {"page": 1, "row": 1, "column": 0, "raw": tax_year}
+        field_confidence["tax_year"] = 0.75
+
+    vendor_name, vendor_conf = _guess_vendor(text)
+    field_sources["vendor_guess.name"] = {"page": 1, "row": 1, "column": 0, "raw": vendor_name}
+    field_confidence["vendor_guess.name"] = vendor_conf
+
+    for total_key, value in totals_clean.items():
+        field_sources[f"totals.{total_key}"] = {"page": 1, "row": 0, "column": 0, "raw": value}
+        field_confidence[f"totals.{total_key}"] = 0.7
+
+    fields_clean: Dict[str, Any] = {
+        "contractors": contractors,
+        "totals": totals_clean,
+        "vendor_guess": {"name": vendor_name, "confidence": vendor_conf},
+    }
+    if tax_year:
+        fields_clean["tax_year"] = tax_year
+
+    confidence = 0.55
+    if contractors:
+        confidence += 0.2
+    if any(c["amounts"].get("box1_nonemployee_comp") for c in contractors):
+        confidence += 0.15
+    if vendor_name != "Unknown":
+        confidence += 0.05
+    if tax_year:
+        confidence += 0.05
+    confidence = min(confidence, 0.95)
+    if "missing_box1_column" in warnings:
+        confidence = max(0.3, confidence - 0.1)
+
+    logger.info(
+        "irs_1099_summary.extract",
+        extra={
+            "doc_type": doc_type,
+            "rows": len(contractors),
+            "warnings": warnings,
+            "evidence_key": evidence_key,
+        },
+    )
+
+    return {
+        "doc_type": doc_type,
+        "confidence": confidence,
+        "fields": {"header": header_row or []},
+        "fields_clean": fields_clean,
+        "field_confidence": field_confidence,
+        "field_sources": field_sources,
+        "warnings": warnings,
+        "evidence_key": evidence_key,
+    }
+
+
+def extract_form1099_summary(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    return _extract(text, doc_type="Form1099_Summary", evidence_key=evidence_key)
+
+
+def extract_vendor_1099_report(text: str, evidence_key: Optional[str] = None) -> Dict[str, Any]:
+    return _extract(text, doc_type="Vendor_1099_Report", evidence_key=evidence_key)
+
+
+__all__ = [
+    "detect",
+    "extract_form1099_summary",
+    "extract_vendor_1099_report",
+]

--- a/ai-analyzer/tests/fixtures/1099_summary_adp.xlsx
+++ b/ai-analyzer/tests/fixtures/1099_summary_adp.xlsx
@@ -1,0 +1,6 @@
+ADP Vendor 1099 Report
+Tax Year: 2023
+Contractor  EIN/SSN  Box 1  State Tax Withheld  Federal WH
+Morgan Lee  999887777  4100.00  300.00  100.00
+Jordan Poe  444556666  2500.00  100.00  75.00
+Totals  6600.00  400.00  175.00

--- a/ai-analyzer/tests/fixtures/1099_summary_gusto.pdf
+++ b/ai-analyzer/tests/fixtures/1099_summary_gusto.pdf
@@ -1,0 +1,6 @@
+Gusto 1099 Summary Report
+Tax Year 2022
+Vendor  TIN  Nonemployee Compensation  Federal WH  State WH  State Income  Account #
+Taylor Fields  ***-**-1234  3500.00  0.00  120.00  3500.00  GUS-100
+Riley Chan  111223333  2800.00  50.00  0.00  2800.00  GUS-200
+Total  Contractors  6300.00  50.00  120.00  6300.00

--- a/ai-analyzer/tests/fixtures/1099_summary_qb.csv
+++ b/ai-analyzer/tests/fixtures/1099_summary_qb.csv
@@ -1,0 +1,6 @@
+"QuickBooks 1099 Summary Report"
+"Tax Year",2023
+Vendor/Payee,TIN,Nonemployee Compensation,Federal WH,State Tax Withheld,State Income,Account #
+Jamie Contractor,12-3456789,"$5,500.00","$500.00","$150.00","$5,500.00",AC123
+Alex Builder,98-7654321,"$4,200.50","$0.00","$0.00","$4,200.50",AC987
+Totals,,9700.50,500.00,150.00,9700.50,

--- a/ai-analyzer/tests/fixtures/irs_1099_nec_copyB.pdf
+++ b/ai-analyzer/tests/fixtures/irs_1099_nec_copyB.pdf
@@ -1,0 +1,27 @@
+Form 1099-NEC
+Nonemployee Compensation
+OMB No. 1545-0116
+For calendar year 2023
+VOID ☐    CORRECTED ☑
+Copy B
+irs.gov/Form1099NEC
+
+Payer's name: Acme Services LLC
+Street address: 123 Market Street
+City or town, state or province, country, and ZIP or foreign postal code: Springfield, IL 62704
+Payer's TIN: 12-3456789
+Phone: (312) 555-0199
+
+Recipient's TIN: 98-7654321
+Recipient's name: Jamie Contractor
+Street address (including apt. no.): 55 Elm Street Apt 2B
+City or town, state or province, country, and ZIP or foreign postal code: Springfield, IL 62705
+
+Account number: ACCT-99
+1 Nonemployee compensation $5,500.00
+2 Payer made direct sales totaling $5,000 or more of consumer products to recipient for resale ☑
+3 Excess golden parachute 0.00
+4 Federal income tax withheld $500.00
+5 State tax withheld $150.00
+6 State/Payer's state no. IL-123456
+7 State income $5,500.00

--- a/ai-analyzer/tests/fixtures/irs_1099_nec_ocr.txt
+++ b/ai-analyzer/tests/fixtures/irs_1099_nec_ocr.txt
@@ -1,0 +1,27 @@
+FORM 1099 NEC
+Nonemployee Comp
+OMB No 1545-0116
+FOR CALENDAR YEAR 2022
+VOID [ ]  CORRECTED [X]
+Copy A
+
+PAYER'S NAME: Westfield Consulting Inc.
+STREET ADDRESS: 777 Harbor Blvd
+City or town, state or province, country, and ZIP or foreign postal code: San Diego CA 92101
+PAYER'S TIN: 98 7654321
+Phone 858-555-1212
+
+Recipient's TIN: 123-45-6789
+Recipient's name: Morgan Allen
+Street address (including apt. no.): 900 Ocean Ave Suite 200
+City or town, state or province, country, and ZIP or foreign postal code: San Diego CA 92101
+
+Account number 445500
+1 Nonemployee compensation $12,345.67
+2 Payer made direct sales totaling $5,000 or more of consumer products to recipient for resale ☐
+3 Excess golden parachute (150.00)
+4 Federal income tax withheld 0.00
+5 State tax withheld 250.00
+6 State/Payer's state no. CA-998877
+7 State income 12,345.67
+irs.gov/Form1099NEC

--- a/ai-analyzer/tests/test_irs_1099_nec.py
+++ b/ai-analyzer/tests/test_irs_1099_nec.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.detectors import identify
+from src.extractors.irs_1099_nec import detect as detect_1099_nec, extract
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+PDF_SAMPLE = (FIXTURES / "irs_1099_nec_copyB.pdf").read_text()
+OCR_SAMPLE = (FIXTURES / "irs_1099_nec_ocr.txt").read_text()
+
+
+def test_detects_1099_nec_variants() -> None:
+    assert detect_1099_nec(PDF_SAMPLE) is True
+    det = identify(PDF_SAMPLE)
+    assert det["type_key"] == "1099_NEC"
+    assert det["confidence"] >= 0.8
+
+    det_ocr = identify(OCR_SAMPLE)
+    assert det_ocr["type_key"] == "1099_NEC"
+    assert det_ocr["confidence"] >= 0.7
+
+
+def test_extracts_core_fields_with_masking() -> None:
+    result = extract(PDF_SAMPLE, evidence_key="uploads/nec.pdf")
+    clean = result["fields_clean"]
+    assert result["doc_type"] == "1099_NEC"
+    assert clean["payer_name"] == "Acme Services LLC"
+    assert clean["payer_address"].startswith("123 Market Street")
+    assert clean["payer_phone"] == "(312) 555-0199"
+    assert clean["payer_tin"] == "123456789"
+    assert clean["payer_tin_masked"] == "***-**-6789"
+    assert clean["payer_tin_last4"] == "6789"
+    assert clean["recipient_name"] == "Jamie Contractor"
+    assert clean["recipient_tin"] == "987654321"
+    assert clean["recipient_tin_masked"] == "***-**-4321"
+    assert clean["recipient_tin_last4"] == "4321"
+    assert clean["box1_nonemployee_comp"] == pytest.approx(5500.0)
+    assert clean["box2_direct_sales_over_5000"] is True
+    assert clean["box4_federal_income_tax_wh"] == pytest.approx(500.0)
+    assert clean["box5_state_tax_wh"] == pytest.approx(150.0)
+    assert clean["box6_state_payer_state_no"] == "IL-123456"
+    assert clean["box7_state_income"] == pytest.approx(5500.0)
+    assert clean["account_number"] == "ACCT-99"
+    assert clean["corrected"] is True
+    assert clean.get("void") in {False, None}
+    assert clean["tax_year"] == "2023"
+
+    assert result["field_sources"]["payer_tin"]["raw"].startswith("12-345")
+    assert result["field_confidence"]["box1_nonemployee_comp"] >= 0.8
+    assert not result["warnings"]
+
+
+def test_ocr_variant_handles_parentheses_and_warnings() -> None:
+    result = extract(OCR_SAMPLE)
+    clean = result["fields_clean"]
+    assert clean["tax_year"] == "2022"
+    assert clean["payer_tin_masked"].endswith("4321")
+    assert clean["recipient_tin_last4"] == "6789"
+    assert clean["box3_excess_golden_parachute"] == pytest.approx(-150.0)
+    assert clean["box2_direct_sales_over_5000"] is False
+    assert clean["box5_state_tax_wh"] == pytest.approx(250.0)
+    assert clean["box7_state_income"] == pytest.approx(12345.67)
+    assert "missing_box1" not in result["warnings"]
+
+
+def test_missing_box1_adds_warning() -> None:
+    text = PDF_SAMPLE.replace("1 Nonemployee compensation $5,500.00\n", "1 Nonemployee compensation \n")
+    result = extract(text)
+    assert "missing_box1" in result["warnings"]

--- a/ai-analyzer/tests/test_irs_1099_summary.py
+++ b/ai-analyzer/tests/test_irs_1099_summary.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.detectors import identify
+from src.extractors.irs_1099_summary import (
+    detect as detect_summary,
+    extract_form1099_summary,
+    extract_vendor_1099_report,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "1099_summary_qb.csv",
+        "1099_summary_gusto.pdf",
+        "1099_summary_adp.xlsx",
+    ],
+)
+def test_detects_summary_variants(fixture_name: str) -> None:
+    sample = _read(fixture_name)
+    assert detect_summary(sample) is True
+    det = identify(sample)
+    assert det["type_key"] in {"Form1099_Summary", "Vendor_1099_Report"}
+    assert det["confidence"] >= 0.7
+
+
+def test_extracts_quickbooks_csv() -> None:
+    sample = _read("1099_summary_qb.csv")
+    result = extract_form1099_summary(sample, evidence_key="uploads/qb.csv")
+    clean = result["fields_clean"]
+    contractors = clean["contractors"]
+    assert len(contractors) == 2
+    first = contractors[0]
+    assert first["contractor"]["name"] == "Jamie Contractor"
+    assert first["contractor"]["tin_last4"] == "6789"
+    assert first["amounts"]["box1_nonemployee_comp"] == pytest.approx(5500.0)
+    assert first["amounts"]["federal_wh"] == pytest.approx(500.0)
+    totals = clean["totals"]
+    assert totals["contractors_count"] == 2
+    assert totals["sum_box1"] == pytest.approx(9700.5)
+    assert totals["sum_federal_wh"] == pytest.approx(500.0)
+    assert totals["sum_state_wh"] == pytest.approx(150.0)
+    assert clean["vendor_guess"]["name"] == "QuickBooks"
+    assert clean["tax_year"] == "2023"
+    assert result["field_sources"]["contractors[0].contractor.name"]["raw"] == "Jamie Contractor"
+    assert result["warnings"] == []
+
+
+def test_extracts_gusto_pdf_totals() -> None:
+    sample = _read("1099_summary_gusto.pdf")
+    result = extract_vendor_1099_report(sample)
+    clean = result["fields_clean"]
+    assert clean["vendor_guess"]["name"] == "Gusto"
+    contractors = clean["contractors"]
+    assert contractors[1]["contractor"]["tin_last4"] == "3333"
+    assert contractors[1]["amounts"]["federal_wh"] == pytest.approx(50.0)
+    assert clean["totals"]["sum_box1"] == pytest.approx(6300.0)
+    assert clean["totals"]["sum_state_wh"] == pytest.approx(120.0)
+    assert clean["tax_year"] == "2022"
+
+
+def test_missing_columns_and_invalid_tin_warn() -> None:
+    sample = "Vendor,Name\nNo totals here"
+    result = extract_form1099_summary(sample)
+    assert "missing_box1_column" in result["warnings"]
+
+    bad_tin = _read("1099_summary_qb.csv").replace("12-3456789", "12-3")
+    result_bad = extract_form1099_summary(bad_tin)
+    assert "invalid_tin_value" in result_bad["warnings"]

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -1,6 +1,9 @@
 {
   "employer_identification_number": {
-    "aliases": ["ein", "tin"],
+    "aliases": [
+      "ein",
+      "tin"
+    ],
     "target": "employer_identification_number",
     "type": "ein",
     "normalize": {
@@ -8,7 +11,11 @@
     }
   },
   "w2_employee_count": {
-    "aliases": ["employees", "w-2 employees", "w2 employees"],
+    "aliases": [
+      "employees",
+      "w-2 employees",
+      "w2 employees"
+    ],
     "target": "w2_employee_count",
     "type": "int",
     "normalize": {
@@ -16,32 +23,46 @@
     }
   },
   "business_location_country": {
-    "aliases": ["country", "location_country"],
+    "aliases": [
+      "country",
+      "location_country"
+    ],
     "target": "business_location_country",
     "type": "string"
   },
   "business_location_state": {
-    "aliases": ["state", "location_state"],
+    "aliases": [
+      "state",
+      "location_state"
+    ],
     "target": "business_location_state",
     "type": "string"
   },
   "revenue_drop_2020_percent": {
-    "aliases": ["revenue_drop_2020_pct"],
+    "aliases": [
+      "revenue_drop_2020_pct"
+    ],
     "target": "revenue_drop_2020_percent",
     "type": "percent"
   },
   "revenue_drop_2021_percent": {
-    "aliases": ["revenue_drop_2021_pct"],
+    "aliases": [
+      "revenue_drop_2021_pct"
+    ],
     "target": "revenue_drop_2021_percent",
     "type": "percent"
   },
   "government_shutdown_2020": {
-    "aliases": ["shutdown_2020"],
+    "aliases": [
+      "shutdown_2020"
+    ],
     "target": "government_shutdown_2020",
     "type": "bool"
   },
   "government_shutdown_2021": {
-    "aliases": ["shutdown_2021"],
+    "aliases": [
+      "shutdown_2021"
+    ],
     "target": "government_shutdown_2021",
     "type": "bool"
   },
@@ -56,17 +77,24 @@
     "type": "currency"
   },
   "ppp_wages_double_dip": {
-    "aliases": ["ppp_double_dip"],
+    "aliases": [
+      "ppp_double_dip"
+    ],
     "target": "ppp_wages_double_dip",
     "type": "bool"
   },
   "owner_veteran": {
-    "aliases": ["owner_is_veteran", "veteran_owned"],
+    "aliases": [
+      "owner_is_veteran",
+      "veteran_owned"
+    ],
     "target": "owner_veteran",
     "type": "bool"
   },
   "owner_spouse": {
-    "aliases": ["owner_is_spouse"],
+    "aliases": [
+      "owner_is_spouse"
+    ],
     "target": "owner_spouse",
     "type": "bool"
   },
@@ -76,12 +104,16 @@
     "type": "bool"
   },
   "ownership_percentage": {
-    "aliases": ["ownership_pct"],
+    "aliases": [
+      "ownership_pct"
+    ],
     "target": "ownership_percentage",
     "type": "percent"
   },
   "number_of_employees": {
-    "aliases": ["employee_count"],
+    "aliases": [
+      "employee_count"
+    ],
     "target": "number_of_employees",
     "type": "int"
   },
@@ -91,12 +123,16 @@
     "type": "currency"
   },
   "economically_vulnerable_area": {
-    "aliases": ["economically_vulnerable"],
+    "aliases": [
+      "economically_vulnerable"
+    ],
     "target": "economically_vulnerable_area",
     "type": "bool"
   },
   "business_type": {
-    "aliases": ["biz_type"],
+    "aliases": [
+      "biz_type"
+    ],
     "target": "business_type",
     "type": "string"
   },
@@ -209,57 +245,92 @@
     "type": "bool"
   },
   "period_start": {
-    "aliases": ["periodStart"],
+    "aliases": [
+      "periodStart"
+    ],
     "target": "period_start",
     "type": "date"
   },
   "period_end": {
-    "aliases": ["periodEnd"],
+    "aliases": [
+      "periodEnd"
+    ],
     "target": "period_end",
     "type": "date"
   },
   "total_revenue": {
-    "aliases": ["revenue", "totalRevenue"],
+    "aliases": [
+      "revenue",
+      "totalRevenue"
+    ],
     "target": "total_revenue",
     "type": "currency"
   },
   "cogs": {
-    "aliases": ["cost_of_goods_sold", "costOfGoodsSold"],
+    "aliases": [
+      "cost_of_goods_sold",
+      "costOfGoodsSold"
+    ],
     "target": "cogs",
     "type": "currency"
   },
   "gross_profit": {
-    "aliases": ["grossProfit"],
+    "aliases": [
+      "grossProfit"
+    ],
     "target": "gross_profit",
     "type": "currency"
   },
   "total_expenses": {
-    "aliases": ["expensesTotal", "totalExpenses"],
+    "aliases": [
+      "expensesTotal",
+      "totalExpenses"
+    ],
     "target": "total_expenses",
     "type": "currency"
   },
   "net_income": {
-    "aliases": ["netIncome", "net_profit", "netProfit", "loss"],
+    "aliases": [
+      "netIncome",
+      "net_profit",
+      "netProfit",
+      "loss"
+    ],
     "target": "net_income",
     "type": "currency"
   },
   "as_of_date": {
-    "aliases": ["asOf", "as_of", "asOfDate"],
+    "aliases": [
+      "asOf",
+      "as_of",
+      "asOfDate"
+    ],
     "target": "as_of_date",
     "type": "date"
   },
   "total_assets": {
-    "aliases": ["assetsTotal", "totalAssets"],
+    "aliases": [
+      "assetsTotal",
+      "totalAssets"
+    ],
     "target": "total_assets",
     "type": "currency"
   },
   "total_liabilities": {
-    "aliases": ["liabilitiesTotal", "totalLiabilities"],
+    "aliases": [
+      "liabilitiesTotal",
+      "totalLiabilities"
+    ],
     "target": "total_liabilities",
     "type": "currency"
   },
   "total_equity": {
-    "aliases": ["equityTotal", "totalEquity", "shareholders_equity", "shareholdersEquity"],
+    "aliases": [
+      "equityTotal",
+      "totalEquity",
+      "shareholders_equity",
+      "shareholdersEquity"
+    ],
     "target": "total_equity",
     "type": "currency"
   },
@@ -269,72 +340,141 @@
     "type": "string"
   },
   "business_name": {
-    "aliases": ["business_name", "legal_name"],
+    "aliases": [
+      "business_name",
+      "legal_name"
+    ],
     "target": "business_name",
     "type": "string"
   },
   "executive_summary": {
-    "aliases": ["executive_summary"],
+    "aliases": [
+      "executive_summary"
+    ],
     "target": "executive_summary",
     "type": "string"
   },
   "funding_request_amount": {
-    "aliases": ["funding_request_amount", "grant_amount"],
+    "aliases": [
+      "funding_request_amount",
+      "grant_amount"
+    ],
     "target": "funding_request_amount",
     "type": "currency"
   },
   "period_years": {
-    "aliases": ["period_years", "projection_years"],
+    "aliases": [
+      "period_years",
+      "projection_years"
+    ],
     "target": "period_years",
     "type": "int"
   },
   "last_updated": {
-    "aliases": ["last_updated"],
+    "aliases": [
+      "last_updated"
+    ],
     "target": "last_updated",
     "type": "date"
   },
   "intended_categories": {
-    "aliases": ["intended_categories"],
+    "aliases": [
+      "intended_categories"
+    ],
     "target": "intended_categories",
     "type": "array"
   },
   "justification": {
-    "aliases": ["justification"],
+    "aliases": [
+      "justification"
+    ],
     "target": "justification",
     "type": "string"
   },
   "date_signed": {
-    "aliases": ["date_signed", "signature_date"],
+    "aliases": [
+      "date_signed",
+      "signature_date"
+    ],
     "target": "date_signed",
     "type": "date"
   },
   "utility_bill": {
-    "utility_provider": { "aliases": ["utility_provider"], "type": "string" },
-    "service_address": { "aliases": ["service_address"], "type": "string" },
-    "billing_period_start": { "aliases": ["billing_period_start"], "type": "date" },
-    "billing_period_end": { "aliases": ["billing_period_end"], "type": "date" },
-    "total_kwh": { "aliases": ["total_kwh", "kwh_total"], "type": "number" },
+    "utility_provider": {
+      "aliases": [
+        "utility_provider"
+      ],
+      "type": "string"
+    },
+    "service_address": {
+      "aliases": [
+        "service_address"
+      ],
+      "type": "string"
+    },
+    "billing_period_start": {
+      "aliases": [
+        "billing_period_start"
+      ],
+      "type": "date"
+    },
+    "billing_period_end": {
+      "aliases": [
+        "billing_period_end"
+      ],
+      "type": "date"
+    },
+    "total_kwh": {
+      "aliases": [
+        "total_kwh",
+        "kwh_total"
+      ],
+      "type": "number"
+    },
     "total_amount_due": {
-      "aliases": ["total_amount_due", "amount_due", "total_amount"],
+      "aliases": [
+        "total_amount_due",
+        "amount_due",
+        "total_amount"
+      ],
       "type": "number"
     },
     "account_number": {
-      "aliases": ["account_number", "customer_account"],
+      "aliases": [
+        "account_number",
+        "customer_account"
+      ],
       "type": "string"
     },
-    "statement_date": { "aliases": ["statement_date", "bill_date"], "type": "date" }
+    "statement_date": {
+      "aliases": [
+        "statement_date",
+        "bill_date"
+      ],
+      "type": "date"
+    }
   },
   "installer_contract": {
     "provider_name": {
-      "aliases": ["provider_name", "contractor_name", "installer_name"],
+      "aliases": [
+        "provider_name",
+        "contractor_name",
+        "installer_name"
+      ],
       "type": "string"
     },
     "client_name": {
-      "aliases": ["client_name", "customer_name"],
+      "aliases": [
+        "client_name",
+        "customer_name"
+      ],
       "type": "string"
     },
     "service_description": {
-      "aliases": ["service_description", "scope_of_work"],
+      "aliases": [
+        "service_description",
+        "scope_of_work"
+      ],
       "type": "string"
     },
     "contract_start_date": {
@@ -347,153 +487,675 @@
       "type": "date"
     },
     "contract_end_date": {
-      "aliases": ["contract_end_date", "end_date", "terminate_date"],
+      "aliases": [
+        "contract_end_date",
+        "end_date",
+        "terminate_date"
+      ],
       "type": "date"
     },
     "total_amount": {
-      "aliases": ["total_amount", "contract_value", "payment_amount"],
+      "aliases": [
+        "total_amount",
+        "contract_value",
+        "payment_amount"
+      ],
       "type": "number"
     },
     "contract_number": {
-      "aliases": ["contract_number", "agreement_number"],
+      "aliases": [
+        "contract_number",
+        "agreement_number"
+      ],
       "type": "string"
     },
-    "signature_dates": { "aliases": ["signature_dates"], "type": "array" }
+    "signature_dates": {
+      "aliases": [
+        "signature_dates"
+      ],
+      "type": "array"
+    }
   },
   "equipment_specs": {
     "equipment_name": {
-      "aliases": ["equipment_name", "product_name"],
+      "aliases": [
+        "equipment_name",
+        "product_name"
+      ],
       "type": "string"
     },
     "model_number": {
-      "aliases": ["model_number", "type"],
+      "aliases": [
+        "model_number",
+        "type"
+      ],
       "type": "string"
     },
     "capacity_kw": {
-      "aliases": ["capacity_kw", "power_output_kw"],
+      "aliases": [
+        "capacity_kw",
+        "power_output_kw"
+      ],
       "type": "number"
     },
     "efficiency_percent": {
-      "aliases": ["efficiency_percent", "efficiency"],
+      "aliases": [
+        "efficiency_percent",
+        "efficiency"
+      ],
       "type": "number"
     },
     "certifications": {
-      "aliases": ["certifications", "standards"],
+      "aliases": [
+        "certifications",
+        "standards"
+      ],
       "type": "array"
     },
     "manufacturer": {
-      "aliases": ["manufacturer", "vendor"],
+      "aliases": [
+        "manufacturer",
+        "vendor"
+      ],
       "type": "string"
     },
     "issue_date": {
-      "aliases": ["issue_date", "date"],
+      "aliases": [
+        "issue_date",
+        "date"
+      ],
       "type": "date"
     }
-    },
-    "invoices_or_quotes": {
-    "doc_variant":       { "aliases": ["doc_variant"], "type": "string" },
-    "vendor_name":       { "aliases": ["vendor_name","supplier_name"], "type": "string" },
-    "vendor_tax_id":     { "aliases": ["vendor_tax_id","supplier_tax_id","ein","tin","vat"], "type": "string" },
-    "customer_name":     { "aliases": ["customer_name","bill_to_name"], "type": "string" },
-    "customer_address":  { "aliases": ["customer_address","bill_to_address"], "type": "string" },
-    "invoice_number":    { "aliases": ["invoice_number"], "type": "string" },
-    "quote_number":      { "aliases": ["quote_number"], "type": "string" },
-    "issue_date":        { "aliases": ["issue_date","invoice_date","quote_date"], "type": "date" },
-    "due_date":          { "aliases": ["due_date"], "type": "date" },
-    "quote_valid_until": { "aliases": ["quote_valid_until","valid_until"], "type": "date" },
-    "item_description":  { "aliases": ["item_description","line_item_desc"], "type": "string" },
-    "quantity":          { "aliases": ["quantity","qty"], "type": "number" },
-    "unit_price":        { "aliases": ["unit_price","price_per_unit"], "type": "number" },
-    "subtotal_amount":   { "aliases": ["subtotal_amount","subtotal"], "type": "number" },
-    "tax_amount":        { "aliases": ["tax_amount","tax"], "type": "number" },
-    "total_amount":      { "aliases": ["total_amount","amount_due","grand_total"], "type": "number" },
-    "currency":          { "aliases": ["currency"], "type": "string" }
   },
-  "energy_savings_report": {
-    "report_date":            { "aliases": ["report_date","date"], "type": "date" },
-    "business_name":          { "aliases": ["business_name","customer_name"], "type": "string" },
-    "site_address":           { "aliases": ["site_address","facility_address"], "type": "string" },
-    "measure_type":           { "aliases": ["measure_type","project_type"], "type": "string" },
-    "baseline_kwh_annual":    { "aliases": ["baseline_kwh_annual","baseline_kwh"], "type": "number" },
-    "post_kwh_annual":        { "aliases": ["post_kwh_annual","post_kwh"], "type": "number" },
-    "kwh_saved_annual":       { "aliases": ["kwh_saved_annual","annual_kwh_saved","kwh_savings"], "type": "number" },
-    "demand_reduction_kw":    { "aliases": ["demand_reduction_kw","kw_reduction"], "type": "number" },
-    "tariff_rate_usd_per_kwh":{ "aliases": ["tariff_rate_usd_per_kwh","rate_usd_per_kwh"], "type": "number" },
-    "annual_savings_usd":     { "aliases": ["annual_savings_usd","annual_savings"], "type": "number" },
-    "capex_usd":              { "aliases": ["capex_usd","capex"], "type": "number" },
-    "opex_usd":               { "aliases": ["opex_usd","opex"], "type": "number" },
-    "payback_years":          { "aliases": ["payback_years","payback"], "type": "number" },
-    "npv_usd":                { "aliases": ["npv_usd","npv"], "type": "number" },
-    "irr_percent":            { "aliases": ["irr_percent","irr"], "type": "number" },
-    "standards_refs":         { "aliases": ["standards_refs","standards"], "type": "array" },
-    "prepared_by_name":       { "aliases": ["prepared_by_name","engineer_name"], "type": "string" },
-    "prepared_by_license":    { "aliases": ["prepared_by_license","engineer_license"], "type": "string" }
-  },
-  "w2_form": {
-    "ein": { "aliases": ["ein", "employer_ein"], "type": "ein" },
-    "employer_name": { "aliases": ["employer_name"], "type": "string" },
-    "employer_address": { "aliases": ["employer_address"], "type": "string" },
-    "employer_zip": { "aliases": ["employer_zip", "employer_postal_code"], "type": "string" },
-    "employee_ssn": { "aliases": ["employee_ssn", "ssn"], "type": "string" },
-    "employee_ssn_masked": { "aliases": ["employee_ssn_masked"], "type": "string" },
-    "employee_name": { "aliases": ["employee_name"], "type": "string" },
-    "employee_address": { "aliases": ["employee_address"], "type": "string" },
-    "employee_zip": { "aliases": ["employee_zip", "employee_postal_code"], "type": "string" },
-    "box1_wages": { "aliases": ["box1", "wages", "wages_box1"], "type": "currency" },
-    "box2_federal_income_tax_withheld": {
-      "aliases": ["box2", "federal_withholding", "federal_income_tax_withheld"],
-      "type": "currency"
-    },
-    "box3_social_security_wages": { "aliases": ["box3", "social_security_wages"], "type": "currency" },
-    "box4_social_security_tax_withheld": {
-      "aliases": ["box4", "social_security_tax", "social_security_tax_withheld"],
-      "type": "currency"
-    },
-    "box5_medicare_wages_and_tips": { "aliases": ["box5", "medicare_wages"], "type": "currency" },
-    "box6_medicare_tax_withheld": { "aliases": ["box6", "medicare_tax"], "type": "currency" },
-    "box7_social_security_tips": { "aliases": ["box7", "social_security_tips"], "type": "currency" },
-    "box8_allocated_tips": { "aliases": ["box8", "allocated_tips"], "type": "currency" },
-    "box10_dependent_care_benefits": { "aliases": ["box10", "dependent_care_benefits"], "type": "currency" },
-    "box11_nonqualified_plans": { "aliases": ["box11", "nonqualified_plans"], "type": "currency" },
-    "box12": { "aliases": ["box12", "box12_entries"], "type": "array" },
-    "box13_statutory_employee": { "aliases": ["statutory_employee"], "type": "bool" },
-    "box13_retirement_plan": { "aliases": ["retirement_plan"], "type": "bool" },
-    "box13_third_party_sick_pay": { "aliases": ["third_party_sick_pay"], "type": "bool" },
-    "box14_other": { "aliases": ["box14", "box14_other"], "type": "array" },
-    "box15_state": { "aliases": ["box15_state", "state"], "type": "string" },
-    "box15_employer_state_id": {
-      "aliases": ["box15_employer_state_id", "employer_state_id"],
+  "invoices_or_quotes": {
+    "doc_variant": {
+      "aliases": [
+        "doc_variant"
+      ],
       "type": "string"
     },
-    "box16_state_wages": { "aliases": ["box16", "state_wages"], "type": "currency" },
-    "box17_state_income_tax": { "aliases": ["box17", "state_income_tax"], "type": "currency" },
-    "box18_local_wages": { "aliases": ["box18", "local_wages"], "type": "currency" },
-    "box19_local_income_tax": { "aliases": ["box19", "local_income_tax"], "type": "currency" },
-    "box20_locality_name": { "aliases": ["box20", "locality_name"], "type": "string" }
+    "vendor_name": {
+      "aliases": [
+        "vendor_name",
+        "supplier_name"
+      ],
+      "type": "string"
+    },
+    "vendor_tax_id": {
+      "aliases": [
+        "vendor_tax_id",
+        "supplier_tax_id",
+        "ein",
+        "tin",
+        "vat"
+      ],
+      "type": "string"
+    },
+    "customer_name": {
+      "aliases": [
+        "customer_name",
+        "bill_to_name"
+      ],
+      "type": "string"
+    },
+    "customer_address": {
+      "aliases": [
+        "customer_address",
+        "bill_to_address"
+      ],
+      "type": "string"
+    },
+    "invoice_number": {
+      "aliases": [
+        "invoice_number"
+      ],
+      "type": "string"
+    },
+    "quote_number": {
+      "aliases": [
+        "quote_number"
+      ],
+      "type": "string"
+    },
+    "issue_date": {
+      "aliases": [
+        "issue_date",
+        "invoice_date",
+        "quote_date"
+      ],
+      "type": "date"
+    },
+    "due_date": {
+      "aliases": [
+        "due_date"
+      ],
+      "type": "date"
+    },
+    "quote_valid_until": {
+      "aliases": [
+        "quote_valid_until",
+        "valid_until"
+      ],
+      "type": "date"
+    },
+    "item_description": {
+      "aliases": [
+        "item_description",
+        "line_item_desc"
+      ],
+      "type": "string"
+    },
+    "quantity": {
+      "aliases": [
+        "quantity",
+        "qty"
+      ],
+      "type": "number"
+    },
+    "unit_price": {
+      "aliases": [
+        "unit_price",
+        "price_per_unit"
+      ],
+      "type": "number"
+    },
+    "subtotal_amount": {
+      "aliases": [
+        "subtotal_amount",
+        "subtotal"
+      ],
+      "type": "number"
+    },
+    "tax_amount": {
+      "aliases": [
+        "tax_amount",
+        "tax"
+      ],
+      "type": "number"
+    },
+    "total_amount": {
+      "aliases": [
+        "total_amount",
+        "amount_due",
+        "grand_total"
+      ],
+      "type": "number"
+    },
+    "currency": {
+      "aliases": [
+        "currency"
+      ],
+      "type": "string"
+    }
+  },
+  "energy_savings_report": {
+    "report_date": {
+      "aliases": [
+        "report_date",
+        "date"
+      ],
+      "type": "date"
+    },
+    "business_name": {
+      "aliases": [
+        "business_name",
+        "customer_name"
+      ],
+      "type": "string"
+    },
+    "site_address": {
+      "aliases": [
+        "site_address",
+        "facility_address"
+      ],
+      "type": "string"
+    },
+    "measure_type": {
+      "aliases": [
+        "measure_type",
+        "project_type"
+      ],
+      "type": "string"
+    },
+    "baseline_kwh_annual": {
+      "aliases": [
+        "baseline_kwh_annual",
+        "baseline_kwh"
+      ],
+      "type": "number"
+    },
+    "post_kwh_annual": {
+      "aliases": [
+        "post_kwh_annual",
+        "post_kwh"
+      ],
+      "type": "number"
+    },
+    "kwh_saved_annual": {
+      "aliases": [
+        "kwh_saved_annual",
+        "annual_kwh_saved",
+        "kwh_savings"
+      ],
+      "type": "number"
+    },
+    "demand_reduction_kw": {
+      "aliases": [
+        "demand_reduction_kw",
+        "kw_reduction"
+      ],
+      "type": "number"
+    },
+    "tariff_rate_usd_per_kwh": {
+      "aliases": [
+        "tariff_rate_usd_per_kwh",
+        "rate_usd_per_kwh"
+      ],
+      "type": "number"
+    },
+    "annual_savings_usd": {
+      "aliases": [
+        "annual_savings_usd",
+        "annual_savings"
+      ],
+      "type": "number"
+    },
+    "capex_usd": {
+      "aliases": [
+        "capex_usd",
+        "capex"
+      ],
+      "type": "number"
+    },
+    "opex_usd": {
+      "aliases": [
+        "opex_usd",
+        "opex"
+      ],
+      "type": "number"
+    },
+    "payback_years": {
+      "aliases": [
+        "payback_years",
+        "payback"
+      ],
+      "type": "number"
+    },
+    "npv_usd": {
+      "aliases": [
+        "npv_usd",
+        "npv"
+      ],
+      "type": "number"
+    },
+    "irr_percent": {
+      "aliases": [
+        "irr_percent",
+        "irr"
+      ],
+      "type": "number"
+    },
+    "standards_refs": {
+      "aliases": [
+        "standards_refs",
+        "standards"
+      ],
+      "type": "array"
+    },
+    "prepared_by_name": {
+      "aliases": [
+        "prepared_by_name",
+        "engineer_name"
+      ],
+      "type": "string"
+    },
+    "prepared_by_license": {
+      "aliases": [
+        "prepared_by_license",
+        "engineer_license"
+      ],
+      "type": "string"
+    }
+  },
+  "w2_form": {
+    "ein": {
+      "aliases": [
+        "ein",
+        "employer_ein"
+      ],
+      "type": "ein"
+    },
+    "employer_name": {
+      "aliases": [
+        "employer_name"
+      ],
+      "type": "string"
+    },
+    "employer_address": {
+      "aliases": [
+        "employer_address"
+      ],
+      "type": "string"
+    },
+    "employer_zip": {
+      "aliases": [
+        "employer_zip",
+        "employer_postal_code"
+      ],
+      "type": "string"
+    },
+    "employee_ssn": {
+      "aliases": [
+        "employee_ssn",
+        "ssn"
+      ],
+      "type": "string"
+    },
+    "employee_ssn_masked": {
+      "aliases": [
+        "employee_ssn_masked"
+      ],
+      "type": "string"
+    },
+    "employee_name": {
+      "aliases": [
+        "employee_name"
+      ],
+      "type": "string"
+    },
+    "employee_address": {
+      "aliases": [
+        "employee_address"
+      ],
+      "type": "string"
+    },
+    "employee_zip": {
+      "aliases": [
+        "employee_zip",
+        "employee_postal_code"
+      ],
+      "type": "string"
+    },
+    "box1_wages": {
+      "aliases": [
+        "box1",
+        "wages",
+        "wages_box1"
+      ],
+      "type": "currency"
+    },
+    "box2_federal_income_tax_withheld": {
+      "aliases": [
+        "box2",
+        "federal_withholding",
+        "federal_income_tax_withheld"
+      ],
+      "type": "currency"
+    },
+    "box3_social_security_wages": {
+      "aliases": [
+        "box3",
+        "social_security_wages"
+      ],
+      "type": "currency"
+    },
+    "box4_social_security_tax_withheld": {
+      "aliases": [
+        "box4",
+        "social_security_tax",
+        "social_security_tax_withheld"
+      ],
+      "type": "currency"
+    },
+    "box5_medicare_wages_and_tips": {
+      "aliases": [
+        "box5",
+        "medicare_wages"
+      ],
+      "type": "currency"
+    },
+    "box6_medicare_tax_withheld": {
+      "aliases": [
+        "box6",
+        "medicare_tax"
+      ],
+      "type": "currency"
+    },
+    "box7_social_security_tips": {
+      "aliases": [
+        "box7",
+        "social_security_tips"
+      ],
+      "type": "currency"
+    },
+    "box8_allocated_tips": {
+      "aliases": [
+        "box8",
+        "allocated_tips"
+      ],
+      "type": "currency"
+    },
+    "box10_dependent_care_benefits": {
+      "aliases": [
+        "box10",
+        "dependent_care_benefits"
+      ],
+      "type": "currency"
+    },
+    "box11_nonqualified_plans": {
+      "aliases": [
+        "box11",
+        "nonqualified_plans"
+      ],
+      "type": "currency"
+    },
+    "box12": {
+      "aliases": [
+        "box12",
+        "box12_entries"
+      ],
+      "type": "array"
+    },
+    "box13_statutory_employee": {
+      "aliases": [
+        "statutory_employee"
+      ],
+      "type": "bool"
+    },
+    "box13_retirement_plan": {
+      "aliases": [
+        "retirement_plan"
+      ],
+      "type": "bool"
+    },
+    "box13_third_party_sick_pay": {
+      "aliases": [
+        "third_party_sick_pay"
+      ],
+      "type": "bool"
+    },
+    "box14_other": {
+      "aliases": [
+        "box14",
+        "box14_other"
+      ],
+      "type": "array"
+    },
+    "box15_state": {
+      "aliases": [
+        "box15_state",
+        "state"
+      ],
+      "type": "string"
+    },
+    "box15_employer_state_id": {
+      "aliases": [
+        "box15_employer_state_id",
+        "employer_state_id"
+      ],
+      "type": "string"
+    },
+    "box16_state_wages": {
+      "aliases": [
+        "box16",
+        "state_wages"
+      ],
+      "type": "currency"
+    },
+    "box17_state_income_tax": {
+      "aliases": [
+        "box17",
+        "state_income_tax"
+      ],
+      "type": "currency"
+    },
+    "box18_local_wages": {
+      "aliases": [
+        "box18",
+        "local_wages"
+      ],
+      "type": "currency"
+    },
+    "box19_local_income_tax": {
+      "aliases": [
+        "box19",
+        "local_income_tax"
+      ],
+      "type": "currency"
+    },
+    "box20_locality_name": {
+      "aliases": [
+        "box20",
+        "locality_name"
+      ],
+      "type": "string"
+    }
   },
   "payroll_period_total_gross": {
-    "aliases": ["payroll.period.total_gross", "payroll_total_gross"],
+    "aliases": [
+      "payroll.period.total_gross",
+      "payroll_total_gross"
+    ],
     "target": "payroll_period_total_gross",
     "type": "currency"
   },
   "payroll_period_total_withholding": {
-    "aliases": ["payroll.period.total_withholding"],
+    "aliases": [
+      "payroll.period.total_withholding"
+    ],
     "target": "payroll_period_total_withholding",
     "type": "currency"
   },
   "payroll_period_total_employer_taxes": {
-    "aliases": ["payroll.period.total_employer_taxes"],
+    "aliases": [
+      "payroll.period.total_employer_taxes"
+    ],
     "target": "payroll_period_total_employer_taxes",
     "type": "currency"
   },
   "payroll_period_total_net": {
-    "aliases": ["payroll.period.total_net"],
+    "aliases": [
+      "payroll.period.total_net"
+    ],
     "target": "payroll_period_total_net",
     "type": "currency"
   },
   "payroll_period_employee_count": {
-    "aliases": ["payroll.period.employee_count"],
+    "aliases": [
+      "payroll.period.employee_count"
+    ],
     "target": "payroll_period_employee_count",
     "type": "int"
+  },
+  "nonemployee_compensation.amount": {
+    "aliases": [
+      "box1_nonemployee_comp"
+    ],
+    "target": "nonemployee_compensation.amount",
+    "type": "currency"
+  },
+  "withholding.federal.backup": {
+    "aliases": [
+      "box4_federal_income_tax_wh"
+    ],
+    "target": "withholding.federal.backup",
+    "type": "currency"
+  },
+  "state.withholding": {
+    "aliases": [
+      "box5_state_tax_wh"
+    ],
+    "target": "state.withholding",
+    "type": "currency"
+  },
+  "state.payer_state_no": {
+    "aliases": [
+      "box6_state_payer_state_no"
+    ],
+    "target": "state.payer_state_no",
+    "type": "string"
+  },
+  "state.income": {
+    "aliases": [
+      "box7_state_income"
+    ],
+    "target": "state.income",
+    "type": "currency"
+  },
+  "tax_year": {
+    "aliases": [
+      "tax_year"
+    ],
+    "target": "tax_year",
+    "type": "int"
+  },
+  "recipient.tin_last4": {
+    "aliases": [
+      "recipient_tin_last4"
+    ],
+    "target": "recipient.tin_last4",
+    "type": "string"
+  },
+  "payer.tin_last4": {
+    "aliases": [
+      "payer_tin_last4"
+    ],
+    "target": "payer.tin_last4",
+    "type": "string"
+  },
+  "nonemployee_compensation.total_1099_box1": {
+    "aliases": [
+      "totals.sum_box1"
+    ],
+    "target": "nonemployee_compensation.total_1099_box1",
+    "type": "currency"
+  },
+  "nonemployee_compensation.contractors_count": {
+    "aliases": [
+      "totals.contractors_count"
+    ],
+    "target": "nonemployee_compensation.contractors_count",
+    "type": "int"
+  },
+  "nonemployee_compensation.contractors": {
+    "aliases": [
+      "contractors"
+    ],
+    "target": "nonemployee_compensation.contractors",
+    "type": "array"
+  },
+  "state.withholding_total": {
+    "aliases": [
+      "totals.sum_state_wh"
+    ],
+    "target": "state.withholding_total",
+    "type": "currency"
+  },
+  "withholding.federal.total": {
+    "aliases": [
+      "totals.sum_federal_wh"
+    ],
+    "target": "withholding.federal.total",
+    "type": "currency"
   }
 }

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -5,16 +5,30 @@
     "Form_1120X": {
       "display_name": "IRS Form 1120X (Amended U.S. Corporation Income Tax Return)",
       "identify": {
-        "keywords_any": ["Form 1120X", "Amended U.S. Corporation Income Tax Return"],
-        "regex_any": ["(?i)\\bForm\\s+1120X\\b"],
-        "check_pages": [1, 2]
+        "keywords_any": [
+          "Form 1120X",
+          "Amended U.S. Corporation Income Tax Return"
+        ],
+        "regex_any": [
+          "(?i)\\bForm\\s+1120X\\b"
+        ],
+        "check_pages": [
+          1,
+          2
+        ]
       },
       "extract_fields": [
-        "ein", "company_name", "tax_year_ending",
-        "address_line", "city_state_zip",
-        "total_income_c", "total_deductions_c",
-        "taxable_income_c", "total_tax_c",
-        "overpayment", "tax_due"
+        "ein",
+        "company_name",
+        "tax_year_ending",
+        "address_line",
+        "city_state_zip",
+        "total_income_c",
+        "total_deductions_c",
+        "taxable_income_c",
+        "total_tax_c",
+        "overpayment",
+        "tax_due"
       ],
       "normalize": {
         "tax_year_ending": "date",
@@ -117,7 +131,9 @@
         "address": "string",
         "date_signed": "date"
       },
-      "examples": ["IRS Form W-9"]
+      "examples": [
+        "IRS Form W-9"
+      ]
     },
     "W2_Form": {
       "display_name": "IRS Form W-2 (Wage and Tax Statement)",
@@ -133,7 +149,9 @@
           "(?i)Copy\\s+(?:A|B|C|D|1|2)"
         ],
         "score_bonus": 0.2,
-        "check_pages": [1]
+        "check_pages": [
+          1
+        ]
       },
       "extract_fields": [
         "ein",
@@ -269,7 +287,9 @@
           "Statement of Intended Use",
           "Funding Request"
         ],
-        "regex": ["(?i)use of funds"]
+        "regex": [
+          "(?i)use of funds"
+        ]
       },
       "fields": {
         "business_name": "string",
@@ -315,7 +335,9 @@
           "HVAC INSTALLATION CONTRACT",
           "Installation Agreement"
         ],
-        "regex": ["(?i)Contract Number"]
+        "regex": [
+          "(?i)Contract Number"
+        ]
       },
       "fields": {
         "provider_name": "string",
@@ -339,7 +361,9 @@
           "Manufacturer Datasheet",
           "Model Specifications"
         ],
-        "regex": ["(?i)Equipment\\s+Specifications"]
+        "regex": [
+          "(?i)Equipment\\s+Specifications"
+        ]
       },
       "fields": {
         "equipment_name": "string",
@@ -350,14 +374,19 @@
         "manufacturer": "string",
         "issue_date": "date"
       },
-      "description": "Manufacturer’s technical datasheet for equipment, including power rating, efficiency, certifications, and model details."
+      "description": "Manufacturer\u2019s technical datasheet for equipment, including power rating, efficiency, certifications, and model details."
     },
     "Invoices_or_Quotes": {
       "extractor": "invoices_or_quotes",
       "detector": {
         "keywords": [
-          "Invoice", "Tax Invoice", "Commercial Invoice",
-          "Quote", "Quotation", "Estimate", "Proposal"
+          "Invoice",
+          "Tax Invoice",
+          "Commercial Invoice",
+          "Quote",
+          "Quotation",
+          "Estimate",
+          "Proposal"
         ]
       },
       "fields": {
@@ -398,7 +427,9 @@
           "ASHRAE",
           "IPMVP"
         ],
-        "regex": ["(?i)energy savings report"]
+        "regex": [
+          "(?i)energy savings report"
+        ]
       },
       "fields": {
         "report_date": "date",
@@ -429,6 +460,86 @@
         "Balance_Sheet"
       ],
       "description": "Complete financial statements (P&L and Balance Sheet)"
+    },
+    "1099_NEC": {
+      "display_name": "IRS Form 1099-NEC (Nonemployee Compensation)",
+      "identify": {
+        "keywords_any": [
+          "Form 1099-NEC",
+          "Nonemployee Compensation",
+          "OMB No. 1545-0116",
+          "Copy A",
+          "Copy B",
+          "Copy 1",
+          "Copy 2",
+          "For calendar year",
+          "irs.gov/Form1099NEC"
+        ],
+        "regex_any": [
+          "(?i)Form\\s+1099[-\\u2011]?NEC",
+          "(?i)Nonemployee\\s+Comp(?:ensation)?",
+          "(?i)irs\\.gov/Form1099NEC"
+        ],
+        "score_bonus": 0.2,
+        "check_pages": [
+          1
+        ]
+      },
+      "extract_fields": [
+        "payer_name",
+        "payer_tin",
+        "recipient_name",
+        "recipient_tin",
+        "box1_nonemployee_comp"
+      ]
+    },
+    "Form1099_Summary": {
+      "display_name": "1099 Summary Report",
+      "identify": {
+        "keywords_any": [
+          "1099 Summary",
+          "Vendor 1099 Summary",
+          "1099 NEC Summary",
+          "1099 Report",
+          "Total 1099 Amount",
+          "Nonemployee compensation"
+        ],
+        "regex_any": [
+          "(?i)1099\\s+(?:NEC\\s+)?Summary",
+          "(?i)1099\\s+Report",
+          "(?i)Vendor\\s+1099"
+        ],
+        "score_bonus": 0.1
+      },
+      "extract_fields": [
+        "tax_year",
+        "contractors",
+        "totals"
+      ]
+    },
+    "Vendor_1099_Report": {
+      "display_name": "Vendor 1099 Report",
+      "identify": {
+        "keywords_any": [
+          "1099 Summary",
+          "Vendor 1099 Summary",
+          "1099 NEC Summary",
+          "1099 Report",
+          "Total 1099 Amount",
+          "Nonemployee compensation"
+        ],
+        "regex_any": [
+          "(?i)1099\\s+(?:NEC\\s+)?Summary",
+          "(?i)1099\\s+Report",
+          "(?i)Vendor\\s+1099"
+        ],
+        "score_bonus": 0.1
+      },
+      "extract_fields": [
+        "tax_year",
+        "contractors",
+        "totals"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add catalog entries and detector logic for IRS Form 1099-NEC and 1099 summary/vendor reports
- implement structured extractors with masking, normalization, and metadata for 1099-NEC forms and 1099 rollup reports
- wire eligibility field mappings, fixtures, and documentation for the new document types

## Testing
- pytest ai-analyzer/tests/test_irs_1099_nec.py
- pytest ai-analyzer/tests/test_irs_1099_summary.py

------
https://chatgpt.com/codex/tasks/task_b_68d08458c8c483279b33de6cac16e929