### PR TITLE
Add veteran certification analysis and eligibility

### DIFF
--- a/ai-analyzer/src/detectors.py
+++ b/ai-analyzer/src/detectors.py
@@ -57,6 +57,10 @@ EXTRACTORS = {
     "Payroll_Register": ("payroll_register", "extract"),
     "Payroll_Provider_Report": ("payroll_register", "extract"),
     "DBE_ACDBE_Uniform_Application": ("dbe_acdbe_uniform_application", "extract"),
+    "VOSB_SDVOSB_Application": ("veteran_cert_application", "extract"),
+    "VOSB_Certificate": ("veteran_cert_proof", "extract"),
+    "SDVOSB_Certificate": ("veteran_cert_proof", "extract"),
+    "VOSB_SDVOSB_Approval_Letter": ("veteran_cert_proof", "extract"),
 }
 
 
@@ -96,10 +100,101 @@ def _score_1099_summary(text: str) -> float:
     return min(score, 1.1)
 
 
-CUSTOM_DETECTORS: Dict[str, Callable[[str], float]] = {
+def _score_veteran_documents(text: str) -> Dict[str, float | str]:
+    lowered = text.lower()
+    if not lowered:
+        return {"score": 0.0}
+
+    issuer_terms = [
+        "veteran small business certification",
+        "vetcert",
+        "vosb",
+        "sdvosb",
+        "u.s. small business administration",
+        "small business administration",
+        "department of veterans affairs",
+        "osdbu",
+        "cve",
+    ]
+    application_terms = [
+        "certification application",
+        "application packet",
+        "ownership and control",
+        "dd-214",
+        "service-connected disability",
+        "eligibility questionnaire",
+    ]
+    certificate_terms = [
+        "this certifies that",
+        "has been verified",
+        "certification valid through",
+        "certificate id",
+        "verified",
+        "certificate number",
+    ]
+    letter_terms = [
+        "approval letter",
+        "verification letter",
+        "approval notice",
+        "under review",
+        "pending",
+    ]
+
+    negative_terms = [
+        "form w-2",
+        "wage and tax statement",
+        "form 1099",
+        "nonemployee compensation",
+        "form 941-x",
+        "disadvantaged business enterprise",
+        "uniform certification application",
+    ]
+
+    score = 0.0
+    issuer_hits = sum(1 for term in issuer_terms if term in lowered)
+    score += min(issuer_hits * 0.2, 0.6)
+
+    has_application = any(term in lowered for term in application_terms)
+    has_certificate = any(term in lowered for term in certificate_terms)
+    has_letter = any(term in lowered for term in letter_terms)
+
+    if has_application:
+        score += 0.35
+    if has_certificate:
+        score += 0.4
+    if has_letter:
+        score += 0.25
+
+    if "service-disabled" in lowered or "service disabled" in lowered:
+        score += 0.1
+
+    if any(term in lowered for term in negative_terms):
+        score -= 0.5
+
+    score = max(score, 0.0)
+
+    doc_type = None
+    if has_letter:
+        doc_type = "VOSB_SDVOSB_Approval_Letter"
+    elif has_certificate:
+        if "service-disabled" in lowered or "service disabled" in lowered:
+            doc_type = "SDVOSB_Certificate"
+        else:
+            doc_type = "VOSB_Certificate"
+    elif has_application and score >= 0.5:
+        doc_type = "VOSB_SDVOSB_Application"
+
+    return {"score": score, "type_key": doc_type} if doc_type else {"score": score}
+
+
+CUSTOM_DETECTORS: Dict[str, Callable[[str], float | Dict[str, float | str]]] = {
     "1099_NEC": _score_1099_nec,
     "Form1099_Summary": _score_1099_summary,
     "Vendor_1099_Report": _score_1099_summary,
+    "VOSB_SDVOSB_Application": _score_veteran_documents,
+    "VOSB_Certificate": _score_veteran_documents,
+    "SDVOSB_Certificate": _score_veteran_documents,
+    "VOSB_SDVOSB_Approval_Letter": _score_veteran_documents,
 }
 
 
@@ -117,12 +212,19 @@ def identify(doc_text: str) -> dict:
         if any(re.search(r, text) for r in rx):
             score += 0.5
         custom = CUSTOM_DETECTORS.get(key)
+        override_key = None
         if custom:
-            score = max(score, custom(text))
+            custom_res = custom(text)
+            if isinstance(custom_res, dict):
+                score = max(score, float(custom_res.get("score", 0.0)))
+                override_key = custom_res.get("type_key")
+            else:
+                score = max(score, float(custom_res))
         if score > 0:
             score += spec["identify"].get("score_bonus", 0)
+        candidate_key = override_key or key
         if score > 0 and (not best or score > best["confidence"]):
-            best = {"type_key": key, "confidence": float(score)}
+            best = {"type_key": candidate_key, "confidence": float(score)}
     return best or {}
 
 
@@ -136,5 +238,8 @@ def detect(text: str) -> dict:
     if mod_name:
         mod = __import__(f"src.extractors.{mod_name}", fromlist=[func_name])
         func = getattr(mod, func_name)
-        extracted = func(text)
+        try:
+            extracted = func(text, key)
+        except TypeError:
+            extracted = func(text)
     return {"type": {"key": key, "confidence": det.get("confidence", 0)}, "extracted": extracted}

--- a/ai-analyzer/src/extractors/veteran_cert_application.py
+++ b/ai-analyzer/src/extractors/veteran_cert_application.py
@@ -1,0 +1,491 @@
+"""Parser for Veteran Small Business certification applications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from ai_analyzer.nlp_parser import extract_ein, normalize_country, normalize_state
+
+
+def _make_field(value: Any = None, confidence: float = 0.0, source: Optional[str] = None) -> Dict[str, Any]:
+    return {"value": value, "confidence": round(confidence, 2), "source": source}
+
+
+def _normalize_phone(value: str) -> Optional[str]:
+    digits = re.sub(r"\D", "", value or "")
+    if not digits:
+        return None
+    if digits.startswith("1") and len(digits) == 11:
+        digits = digits[1:]
+    if len(digits) == 10:
+        return f"+1{digits}"
+    if len(digits) > 10 and digits.startswith("01"):
+        digits = digits[2:]
+        if len(digits) == 10:
+            return f"+1{digits}"
+    if len(digits) >= 11 and digits.startswith("+"):
+        return digits
+    return f"+{digits}" if digits else None
+
+
+def _normalize_date(value: str) -> Optional[str]:
+    raw = value.strip()
+    if not raw:
+        return None
+    cleaned = (
+        raw.replace("\u2013", "-")
+        .replace("\u2014", "-")
+        .replace("st", "")
+        .replace("nd", "")
+        .replace("rd", "")
+        .replace("th", "")
+    )
+    candidates = [cleaned]
+    if " – " in cleaned:
+        candidates.extend(part.strip() for part in cleaned.split(" – "))
+    for candidate in candidates:
+        for fmt in ("%m/%d/%Y", "%m-%d-%Y", "%B %d %Y", "%b %d %Y", "%Y-%m-%d", "%m/%d/%y", "%m-%d-%y"):
+            try:
+                return datetime.strptime(candidate, fmt).date().isoformat()
+            except ValueError:
+                continue
+    match = re.search(r"(\d{1,2})/(\d{1,2})/(\d{2,4})", cleaned)
+    if match:
+        month, day, year = match.groups()
+        if len(year) == 2:
+            year = "20" + year if int(year) < 50 else "19" + year
+        try:
+            return datetime(int(year), int(month), int(day)).date().isoformat()
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_currency_to_cents(value: str) -> Optional[int]:
+    if not value:
+        return None
+    cleaned = value.strip().lower().replace(",", "").replace("$", "")
+    cleaned = cleaned.replace("(", "-").replace(")", "")
+    multiplier = 1
+    if cleaned.endswith("m"):
+        multiplier = 1_000_000
+        cleaned = cleaned[:-1]
+    elif cleaned.endswith("k"):
+        multiplier = 1_000
+        cleaned = cleaned[:-1]
+    try:
+        amount = float(cleaned)
+    except ValueError:
+        match = re.search(r"-?\d+(?:\.\d+)?", cleaned)
+        if not match:
+            return None
+        amount = float(match.group())
+    cents = int(round(amount * multiplier * 100))
+    return cents
+
+
+def _parse_percent(value: str) -> Optional[float]:
+    if not value:
+        return None
+    cleaned = value.strip().lower().replace("%", "").replace(",", "")
+    try:
+        pct = float(cleaned)
+        if pct <= 1:
+            pct *= 100
+        return pct
+    except ValueError:
+        match = re.search(r"\d+(?:\.\d+)?", cleaned)
+        if not match:
+            return None
+        pct = float(match.group())
+        if pct <= 1:
+            pct *= 100
+        return pct
+
+
+def _issuer_from_text(text: str) -> str:
+    lowered = text.lower()
+    if "small business administration" in lowered or "sba" in lowered:
+        return "SBA"
+    if "department of veterans affairs" in lowered or "va" in lowered:
+        return "VA"
+    return "STATE"
+
+
+def _program_from_text(text: str) -> str:
+    lowered = text.lower()
+    if "vetcert" in lowered or "veteran small business certification" in lowered:
+        return "VetCert"
+    return "Legacy"
+
+
+def _extract_label(lines: List[str], label: str) -> Optional[str]:
+    pattern = re.compile(rf"^{re.escape(label)}\s*[:\-]?\s*(.*)$", re.IGNORECASE)
+    for line in lines:
+        match = pattern.match(line.strip())
+        if match:
+            value = match.group(1).strip()
+            if value:
+                return value
+    return None
+
+
+def _extract_version(text: str) -> Optional[str]:
+    match = re.search(r"(?:version|rev\.?|application)[^\n]*(20\d{2}|19\d{2})", text, re.IGNORECASE)
+    if match:
+        return match.group(0).strip()
+    match = re.search(r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+20\d{2}", text)
+    if match:
+        return match.group(0)
+    return None
+
+
+def _collect_lines(text: str) -> List[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _extract_address(lines: List[str]) -> Dict[str, Dict[str, Any]]:
+    street = _extract_label(lines, "Street Address") or _extract_label(lines, "Business Address")
+    city = _extract_label(lines, "City")
+    state = _extract_label(lines, "State")
+    zip_code = _extract_label(lines, "Zip") or _extract_label(lines, "Postal Code")
+    country = _extract_label(lines, "Country")
+    return {
+        "street": _make_field(street, 0.9 if street else 0.0, "Street Address" if street else None),
+        "city": _make_field(city, 0.85 if city else 0.0, "City" if city else None),
+        "state": _make_field(normalize_state(state) if state else None, 0.85 if state else 0.0, "State" if state else None),
+        "zip": _make_field(zip_code, 0.8 if zip_code else 0.0, "Zip" if zip_code else None),
+        "country": _make_field(normalize_country(country) if country else None, 0.6 if country else 0.0, "Country" if country else None),
+    }
+
+
+def _extract_naics(text: str) -> List[Dict[str, Any]]:
+    matches = re.findall(r"\b(\d{2}\d{4})\b", text)
+    seen: List[str] = []
+    results: List[Dict[str, Any]] = []
+    for code in matches:
+        if len(code) == 6 and code not in seen:
+            seen.append(code)
+            results.append(_make_field(code, 0.85, "NAICS"))
+    if not results:
+        alt = re.search(r"NAICS[^\d]*(\d{5,6})", text, re.IGNORECASE)
+        if alt:
+            digits = alt.group(1)[:6]
+            if len(digits) == 6:
+                results.append(_make_field(digits, 0.75, "NAICS"))
+    return results
+
+
+def _detect_requested_type(text: str) -> Optional[str]:
+    lowered = text.lower()
+    if "sdvosb" in lowered or "service-disabled" in lowered:
+        return "SDVOSB"
+    if "vosb" in lowered or "veteran-owned" in lowered:
+        return "VOSB"
+    return None
+
+
+@dataclass
+class OwnerField:
+    index: str
+    name: Optional[str] = None
+    pct: Optional[float] = None
+    veteran: Optional[bool] = None
+    sdv: Optional[bool] = None
+    role: Optional[str] = None
+    notes: Optional[str] = None
+    acquired: Optional[str] = None
+    cash: Optional[int] = None
+    equipment: Optional[int] = None
+    other: Optional[str] = None
+
+
+def _extract_owners(lines: List[str]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    owners: Dict[str, OwnerField] = {}
+    for line in lines:
+        m = re.match(r"owner\s*(\d+)\s+name\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).name = m.group(2).strip()
+            continue
+        m = re.match(r"owner\s*(\d+)\s+ownership\s+percentage\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).pct = _parse_percent(m.group(2))
+            continue
+        m = re.match(r"owner\s*(\d+)\s+veteran\s+status\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            value = m.group(2).strip().lower()
+            owners.setdefault(idx, OwnerField(index=idx)).veteran = value.startswith("y")
+            continue
+        m = re.match(r"owner\s*(\d+)\s+service[-\s]*disabled\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            value = m.group(2).strip().lower()
+            owners.setdefault(idx, OwnerField(index=idx)).sdv = value.startswith("y")
+            continue
+        m = re.match(r"owner\s*(\d+)\s+role.*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).role = m.group(2).strip()
+            continue
+        m = re.match(r"owner\s*(\d+)\s+control\s+notes\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).notes = m.group(2).strip()
+            continue
+        m = re.match(r"owner\s*(\d+)\s+acquired\s+on\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).acquired = _normalize_date(m.group(2))
+            continue
+        m = re.match(r"owner\s*(\d+)\s+investment\s+cash\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).cash = _parse_currency_to_cents(m.group(2))
+            continue
+        m = re.match(r"owner\s*(\d+)\s+investment\s+equipment\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).equipment = _parse_currency_to_cents(m.group(2))
+            continue
+        m = re.match(r"owner\s*(\d+)\s+investment\s+other\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            idx = m.group(1)
+            owners.setdefault(idx, OwnerField(index=idx)).other = m.group(2).strip()
+            continue
+
+    owner_fields: List[Dict[str, Any]] = []
+    owner_simple: List[Dict[str, Any]] = []
+    for idx in sorted(owners):
+        data = owners[idx]
+        owner_fields.append(
+            {
+                "fullName": _make_field(data.name, 0.9 if data.name else 0.0, f"Owner {idx} Name" if data.name else None),
+                "ownershipPct": _make_field(data.pct, 0.9 if data.pct is not None else 0.0, f"Owner {idx} Ownership" if data.pct is not None else None),
+                "isVeteran": _make_field(data.veteran, 0.8 if data.veteran is not None else 0.0, f"Owner {idx} Veteran" if data.veteran is not None else None),
+                "isServiceDisabledVeteran": _make_field(data.sdv, 0.8 if data.sdv is not None else 0.0, f"Owner {idx} Service-Disabled" if data.sdv is not None else None),
+                "roleTitle": _make_field(data.role, 0.7 if data.role else 0.0, f"Owner {idx} Role" if data.role else None),
+                "controlNotes": _make_field(data.notes, 0.6 if data.notes else 0.0, f"Owner {idx} Control" if data.notes else None),
+                "dateAcquired": _make_field(data.acquired, 0.7 if data.acquired else 0.0, f"Owner {idx} Acquired" if data.acquired else None),
+                "investment": {
+                    "cash": _make_field(data.cash, 0.7 if data.cash is not None else 0.0, f"Owner {idx} Investment Cash" if data.cash is not None else None),
+                    "equipment": _make_field(data.equipment, 0.7 if data.equipment is not None else 0.0, f"Owner {idx} Investment Equipment" if data.equipment is not None else None),
+                    "other": _make_field(data.other, 0.6 if data.other else 0.0, f"Owner {idx} Investment Other" if data.other else None),
+                },
+            }
+        )
+        owner_simple.append(
+            {
+                "name": data.name,
+                "percent": data.pct,
+                "isVeteran": data.veteran,
+                "isSDV": data.sdv,
+            }
+        )
+    return owner_fields, owner_simple
+
+
+def _extract_loans(lines: List[str]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    loan_map: Dict[str, Dict[str, Any]] = {}
+    for line in lines:
+        m = re.match(r"loan\s*(\d+)\s+lender\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            loan_map.setdefault(m.group(1), {})["lender"] = m.group(2).strip()
+            continue
+        m = re.match(r"loan\s*(\d+)\s+purpose\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            loan_map.setdefault(m.group(1), {})["purpose"] = m.group(2).strip()
+            continue
+        m = re.match(r"loan\s*(\d+)\s+original\s+amount\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            loan_map.setdefault(m.group(1), {})["originalAmount"] = _parse_currency_to_cents(m.group(2))
+            continue
+        m = re.match(r"loan\s*(\d+)\s+current\s+balance\s*[:\-]?\s*(.*)$", line, re.IGNORECASE)
+        if m:
+            loan_map.setdefault(m.group(1), {})["currentBalance"] = _parse_currency_to_cents(m.group(2))
+            continue
+
+    loans_detail: List[Dict[str, Any]] = []
+    loans_simple: List[Dict[str, Any]] = []
+    for idx in sorted(loan_map):
+        data = loan_map[idx]
+        loans_detail.append(
+            {
+                "lender": _make_field(data.get("lender"), 0.8 if data.get("lender") else 0.0, f"Loan {idx} Lender" if data.get("lender") else None),
+                "purpose": _make_field(data.get("purpose"), 0.7 if data.get("purpose") else 0.0, f"Loan {idx} Purpose" if data.get("purpose") else None),
+                "originalAmount": _make_field(data.get("originalAmount"), 0.75 if data.get("originalAmount") is not None else 0.0, f"Loan {idx} Original Amount" if data.get("originalAmount") is not None else None),
+                "currentBalance": _make_field(data.get("currentBalance"), 0.7 if data.get("currentBalance") is not None else 0.0, f"Loan {idx} Current Balance" if data.get("currentBalance") is not None else None),
+            }
+        )
+        loans_simple.append(
+            {
+                "lender": data.get("lender"),
+                "purpose": data.get("purpose"),
+                "originalAmount": data.get("originalAmount"),
+                "currentBalance": data.get("currentBalance"),
+            }
+        )
+    return loans_detail, loans_simple
+
+
+def extract(text: str, _: Optional[str] = None) -> Dict[str, Any]:
+    lines = _collect_lines(text)
+
+    doc_info = {
+        "type": "VOSB_SDVOSB_Application",
+        "issuer": _issuer_from_text(text),
+        "program": _program_from_text(text),
+        "version": _extract_version(text),
+    }
+
+    legal_name = _extract_label(lines, "Legal Business Name")
+    dba = _extract_label(lines, "DBA") or _extract_label(lines, "Doing Business As")
+    ein_value, _, _, _ = extract_ein(text)
+    entity_type = _extract_label(lines, "Entity Type")
+    inc_state = normalize_state(_extract_label(lines, "State of Incorporation") or "")
+    established = _normalize_date(_extract_label(lines, "Date Established") or "")
+    phone = _normalize_phone(_extract_label(lines, "Business Phone") or "")
+    email = _extract_label(lines, "Business Email") or _extract_label(lines, "Email")
+    website = _extract_label(lines, "Website")
+
+    business_fields = {
+        "legalName": _make_field(legal_name, 0.95 if legal_name else 0.0, "Legal Business Name" if legal_name else None),
+        "dba": _make_field(dba, 0.85 if dba else 0.0, "DBA" if dba else None),
+        "ein": _make_field(ein_value, 0.9 if ein_value else 0.0, "EIN" if ein_value else None),
+        "entityType": _make_field(entity_type, 0.8 if entity_type else 0.0, "Entity Type" if entity_type else None),
+        "stateOfIncorp": _make_field(inc_state, 0.8 if inc_state else 0.0, "State of Incorporation" if inc_state else None),
+        "dateEstablished": _make_field(established, 0.75 if established else 0.0, "Date Established" if established else None),
+        "address": _extract_address(lines),
+        "phone": _make_field(phone, 0.8 if phone else 0.0, "Business Phone" if phone else None),
+        "email": _make_field(email, 0.8 if email else 0.0, "Business Email" if email else None),
+        "website": _make_field(website, 0.6 if website else 0.0, "Website" if website else None),
+        "naics": _extract_naics(text),
+    }
+
+    owners_detail, owners_simple = _extract_owners(lines)
+
+    branch = _extract_label(lines, "Branch of Service")
+    discharge = _extract_label(lines, "Discharge Type")
+    dd214 = _extract_label(lines, "DD-214 Included") or _extract_label(lines, "DD214 Provided")
+    va_letter = _extract_label(lines, "VA Disability Letter Included") or _extract_label(lines, "VA Disability Rating Letter")
+    disability_pct = _parse_percent(_extract_label(lines, "Disability Rating Percent") or "")
+
+    veteran_block = {
+        "branchOfService": _make_field(branch, 0.7 if branch else 0.0, "Branch of Service" if branch else None),
+        "dischargeType": _make_field(discharge, 0.7 if discharge else 0.0, "Discharge Type" if discharge else None),
+        "dd214Present": _make_field(dd214.lower().startswith("y") if dd214 else None, 0.8 if dd214 else 0.0, "DD-214 Included" if dd214 else None),
+        "vaDisabilityLetterPresent": _make_field(va_letter.lower().startswith("y") if va_letter else None, 0.8 if va_letter else 0.0, "VA Disability Letter" if va_letter else None),
+        "disabilityRatingPercent": _make_field(disability_pct, 0.75 if disability_pct is not None else 0.0, "Disability Rating Percent" if disability_pct is not None else None),
+    }
+
+    ctrl_signs = _extract_label(lines, "Control - Signs Checks")
+    ctrl_hires = _extract_label(lines, "Control - Hires/Fires")
+    ctrl_executes = _extract_label(lines, "Control - Executes Contracts")
+    ctrl_purchases = _extract_label(lines, "Control - Major Purchases")
+    control = {
+        "signsChecks": _make_field((ctrl_signs or "").lower().startswith("y"), 0.75 if ctrl_signs else 0.0, "Control - Signs Checks" if ctrl_signs else None),
+        "hiresFires": _make_field((ctrl_hires or "").lower().startswith("y"), 0.75 if ctrl_hires else 0.0, "Control - Hires/Fires" if ctrl_hires else None),
+        "executesContracts": _make_field((ctrl_executes or "").lower().startswith("y"), 0.75 if ctrl_executes else 0.0, "Control - Executes Contracts" if ctrl_executes else None),
+        "majorPurchases": _make_field((ctrl_purchases or "").lower().startswith("y"), 0.75 if ctrl_purchases else 0.0, "Control - Major Purchases" if ctrl_purchases else None),
+    }
+
+    bank_name = _extract_label(lines, "Bank Name")
+    signer_present = _extract_label(lines, "Authorized Signer Attached")
+    banking = {
+        "bankName": _make_field(bank_name, 0.7 if bank_name else 0.0, "Bank Name" if bank_name else None),
+        "authorizedSignerPresent": _make_field(signer_present.lower().startswith("y") if signer_present else None, 0.7 if signer_present else 0.0, "Authorized Signer Attached" if signer_present else None),
+    }
+
+    loans_detail, loans_simple = _extract_loans(lines)
+
+    affidavit_present = _extract_label(lines, "Affidavit Present") or _extract_label(lines, "Affidavit Included")
+    affidavit_signer = _extract_label(lines, "Affidavit Signer") or _extract_label(lines, "Affidavit Signer Name")
+    affidavit_date = _normalize_date(_extract_label(lines, "Affidavit Date") or "")
+    affidavit = {
+        "present": _make_field(affidavit_present.lower().startswith("y") if affidavit_present else None, 0.75 if affidavit_present else 0.0, "Affidavit Present" if affidavit_present else None),
+        "signerName": _make_field(affidavit_signer, 0.7 if affidavit_signer else 0.0, "Affidavit Signer" if affidavit_signer else None),
+        "signDate": _make_field(affidavit_date, 0.7 if affidavit_date else 0.0, "Affidavit Date" if affidavit_date else None),
+    }
+
+    requested_type = _detect_requested_type(text)
+
+    warnings: List[str] = []
+    veteran_owner_pct = max((owner.get("percent") or 0 for owner in owners_simple if owner.get("isVeteran")), default=0)
+    if veteran_owner_pct < 51:
+        warnings.append("ownership_below_51")
+    dd214_bool = veteran_block["dd214Present"]["value"]
+    if dd214_bool is False or dd214_bool is None:
+        warnings.append("missing_dd214")
+    va_bool = veteran_block["vaDisabilityLetterPresent"]["value"]
+    if requested_type == "SDVOSB" and not va_bool:
+        warnings.append("missing_va_disability_letter")
+    if not affidavit["present"]["value"]:
+        warnings.append("missing_affidavit")
+    if not (control["signsChecks"]["value"] and control["executesContracts"]["value"]):
+        warnings.append("control_not_demonstrated")
+
+    application_payload = {
+        "doc": doc_info,
+        "business": business_fields,
+        "owners": owners_detail,
+        "veteran": veteran_block,
+        "control": control,
+        "banking": banking,
+        "loans": loans_detail,
+        "affidavit": affidavit,
+        "requestedType": _make_field(requested_type, 0.7 if requested_type else 0.0, "Requested Certification" if requested_type else None),
+        "warnings": warnings,
+    }
+
+    fields_clean = {
+        "veteranCert": {"application": application_payload},
+        "business.legalName": legal_name,
+        "business.dba": dba,
+        "business.ein": ein_value,
+        "business.entityType": entity_type,
+        "business.stateOfIncorp": inc_state,
+        "business.dateEstablished": established,
+        "business.address.street": business_fields["address"]["street"]["value"],
+        "business.address.city": business_fields["address"]["city"]["value"],
+        "business.address.state": business_fields["address"]["state"]["value"],
+        "business.address.zip": business_fields["address"]["zip"]["value"],
+        "business.address.country": business_fields["address"]["country"]["value"],
+        "business.phone": phone,
+        "business.email": email,
+        "business.website": website,
+        "business.naics": [code["value"] for code in business_fields["naics"] if code["value"]],
+        "owners": owners_simple,
+        "veteran.dd214Present": dd214_bool,
+        "veteran.vaDisabilityLetterPresent": va_bool,
+        "veteran.disabilityRatingPercent": disability_pct,
+        "control.signsChecks": control["signsChecks"]["value"],
+        "control.executesContracts": control["executesContracts"]["value"],
+        "control.hiresFires": control["hiresFires"]["value"],
+        "control.majorPurchases": control["majorPurchases"]["value"],
+        "banking.bankName": bank_name,
+        "banking.authorizedSignerPresent": banking["authorizedSignerPresent"]["value"],
+        "loans": loans_simple,
+        "affidavit.present": affidavit["present"]["value"],
+        "affidavit.signerName": affidavit["signerName"]["value"],
+        "affidavit.signDate": affidavit["signDate"]["value"],
+        "requestedType": requested_type,
+        "veteranCert.application.warnings": warnings,
+    }
+
+    fields = {
+        "veteranCert": {"application": application_payload},
+    }
+
+    return {
+        "doc_type": "VOSB_SDVOSB_Application",
+        "confidence": 0.92,
+        "fields": fields,
+        "fields_clean": fields_clean,
+        "warnings": warnings,
+    }
+

--- a/ai-analyzer/src/extractors/veteran_cert_proof.py
+++ b/ai-analyzer/src/extractors/veteran_cert_proof.py
@@ -1,0 +1,162 @@
+"""Extractor for veteran certification proof documents (certificates & letters)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import re
+from typing import Any, Dict, List, Optional
+
+
+def _make_field(value: Any = None, confidence: float = 0.0, source: Optional[str] = None) -> Dict[str, Any]:
+    return {"value": value, "confidence": round(confidence, 2), "source": source}
+
+
+def _normalize_date(value: str) -> Optional[str]:
+    if not value:
+        return None
+    cleaned = value.strip().replace("\u2013", "-").replace("\u2014", "-")
+    cleaned = re.sub(r"(st|nd|rd|th)", "", cleaned, flags=re.IGNORECASE)
+    for fmt in ("%B %d %Y", "%B %d, %Y", "%b %d %Y", "%b %d, %Y", "%m/%d/%Y", "%m-%d-%Y", "%Y-%m-%d", "%m/%d/%y", "%m-%d-%y"):
+        try:
+            return datetime.strptime(cleaned, fmt).date().isoformat()
+        except ValueError:
+            continue
+    match = re.search(r"(\d{1,2})/(\d{1,2})/(\d{2,4})", cleaned)
+    if match:
+        month, day, year = match.groups()
+        if len(year) == 2:
+            year = "20" + year if int(year) < 50 else "19" + year
+        try:
+            return datetime(int(year), int(month), int(day)).date().isoformat()
+        except ValueError:
+            return None
+    return None
+
+
+def _issuer_from_text(text: str) -> str:
+    lowered = text.lower()
+    if "small business administration" in lowered or "sba" in lowered:
+        return "SBA"
+    if "department of veterans affairs" in lowered or "va" in lowered:
+        return "VA"
+    return "STATE"
+
+
+def _program_from_text(text: str) -> str:
+    lowered = text.lower()
+    if "vetcert" in lowered or "veteran small business certification" in lowered:
+        return "VetCert"
+    return "Legacy"
+
+
+def _extract_naics(text: str) -> List[Dict[str, Any]]:
+    fields: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        if "naics" not in line.lower():
+            continue
+        for code in re.findall(r"(\d{6})", line):
+            if code not in seen:
+                seen.add(code)
+                fields.append(_make_field(code, 0.85, "NAICS"))
+    return fields
+
+
+def _status_from_dates(issue: Optional[str], valid: Optional[str], text: str) -> str:
+    lowered = text.lower()
+    today = datetime.now(UTC).date()
+    if valid:
+        try:
+            valid_date = datetime.strptime(valid, "%Y-%m-%d").date()
+            if valid_date < today:
+                return "expired"
+        except ValueError:
+            pass
+    if "pending" in lowered or "under review" in lowered:
+        return "pending"
+    if "revoked" in lowered or "inactive" in lowered:
+        return "revoked"
+    if issue:
+        return "active"
+    return "pending"
+
+
+def _certified_type(text: str) -> str:
+    lowered = text.lower()
+    if "service-disabled" in lowered or "service disabled" in lowered or "sdvosb" in lowered:
+        return "SDVOSB"
+    return "VOSB"
+
+
+def _detect_doc_type(text: str, hint: Optional[str]) -> str:
+    if hint in {"VOSB_Certificate", "SDVOSB_Certificate", "VOSB_SDVOSB_Approval_Letter"}:
+        return hint
+    lowered = text.lower()
+    if "approval letter" in lowered or "verification letter" in lowered or "under review" in lowered:
+        return "VOSB_SDVOSB_Approval_Letter"
+    if "service-disabled" in lowered or "sdvosb" in lowered:
+        return "SDVOSB_Certificate"
+    return "VOSB_Certificate"
+
+
+def extract(text: str, doc_hint: Optional[str] = None) -> Dict[str, Any]:
+    doc_type = _detect_doc_type(text, doc_hint)
+    issuer = _issuer_from_text(text)
+    program = _program_from_text(text)
+
+    business_name_match = re.search(
+        r"(?:certifies that|awards to|confirms that)\s+([A-Za-z0-9&',.\- ]+?)\s+(?:has\s+been|is)\b",
+        text,
+        re.IGNORECASE,
+    )
+    if not business_name_match:
+        business_name_match = re.search(r"Re:\s*([A-Za-z0-9&',.\- ]+)", text, re.IGNORECASE)
+    business_name = business_name_match.group(1).strip(" .-\n") if business_name_match else None
+
+    certificate_id_match = re.search(r"Certificate\s*(?:ID|No\.?|Number)\s*[:#]?\s*([A-Z0-9-]+)", text, re.IGNORECASE)
+    certificate_id = certificate_id_match.group(1).strip() if certificate_id_match else None
+
+    issue_match = re.search(r"(?:issue date|issued on|certified on)\s*[:\-]?\s*([A-Za-z0-9 ,/\-]+)", text, re.IGNORECASE)
+    valid_match = re.search(r"(?:valid through|expires on|expiration date)\s*[:\-]?\s*([A-Za-z0-9 ,/\-]+)", text, re.IGNORECASE)
+
+    issue_date = _normalize_date(issue_match.group(1)) if issue_match else None
+    valid_through = _normalize_date(valid_match.group(1)) if valid_match else None
+
+    certified_as = _certified_type(text)
+    status = _status_from_dates(issue_date, valid_through, text)
+
+    naics = _extract_naics(text)
+
+    proof_block = {
+        "businessName": _make_field(business_name, 0.9 if business_name else 0.0, "Business Name" if business_name else None),
+        "certificateId": _make_field(certificate_id, 0.8 if certificate_id else 0.0, "Certificate ID" if certificate_id else None),
+        "certifiedAs": _make_field(certified_as, 0.85, "Certified As"),
+        "issueDate": _make_field(issue_date, 0.8 if issue_date else 0.0, "Issue Date" if issue_date else None),
+        "validThrough": _make_field(valid_through, 0.8 if valid_through else 0.0, "Valid Through" if valid_through else None),
+        "status": _make_field(status, 0.85, "Derived Status"),
+        "naics": naics,
+    }
+
+    fields_clean = {
+        "veteranCert": {"doc": {"type": doc_type, "issuer": issuer, "program": program}, "proof": proof_block},
+        "proof.type": doc_type,
+        "proof.issuer": issuer,
+        "proof.program": program,
+        "proof.businessName": business_name,
+        "proof.certificateId": certificate_id,
+        "proof.certifiedAs": certified_as,
+        "proof.issueDate": issue_date,
+        "proof.validThrough": valid_through,
+        "proof.status": status,
+        "proof.naics": [entry["value"] for entry in naics if entry["value"]],
+    }
+
+    fields = {"veteranCert": {"doc": {"type": doc_type, "issuer": issuer, "program": program}, "proof": proof_block}}
+
+    return {
+        "doc_type": doc_type,
+        "confidence": 0.93,
+        "fields": fields,
+        "fields_clean": fields_clean,
+    }
+

--- a/ai-analyzer/tests/fixtures/veteran/application_aug2023.pdf
+++ b/ai-analyzer/tests/fixtures/veteran/application_aug2023.pdf
@@ -1,0 +1,58 @@
+Veteran Small Business Certification Program (VetCert)
+SDVOSB Certification Application – Aug 2023
+U.S. Small Business Administration Office of Veterans Business Development
+Legal Business Name: Valor Tech Industries LLC
+DBA: Valor Tech
+EIN: 12-3456789
+Entity Type: LLC
+State of Incorporation: CO
+Date Established: 03/14/2016
+Street Address: 123 Liberty Road
+City: Denver
+State: CO
+Zip: 80205
+Country: United States
+Business Phone: (303) 555-0199
+Business Email: info@valortech.com
+Website: https://valortech.com
+NAICS: 541330, 541512
+Ownership and Control Questionnaire
+Requested Certification: SDVOSB
+Owner 1 Name: Jordan Carter
+Owner 1 Ownership Percentage: 60%
+Owner 1 Veteran Status: Yes
+Owner 1 Service-Disabled: Yes
+Owner 1 Role / Title: Chief Executive Officer
+Owner 1 Control Notes: Signs contracts, leads daily operations
+Owner 1 Acquired On: 05/01/2016
+Owner 1 Investment Cash: $50,000
+Owner 1 Investment Equipment: $20,000
+Owner 1 Investment Other: Sweat equity
+Owner 2 Name: Avery Smith
+Owner 2 Ownership Percentage: 40%
+Owner 2 Veteran Status: No
+Owner 2 Service-Disabled: No
+Owner 2 Role / Title: Chief Operating Officer
+Owner 2 Control Notes: Manages production
+Owner 2 Acquired On: 07/15/2018
+Owner 2 Investment Cash: $20,000
+Owner 2 Investment Equipment: $5,000
+Owner 2 Investment Other: None
+Branch of Service: Army
+Discharge Type: Honorable
+DD-214 Included: Yes
+VA Disability Letter Included: No
+Disability Rating Percent: 70%
+Control - Signs Checks: Yes
+Control - Hires/Fires: Yes
+Control - Executes Contracts: Yes
+Control - Major Purchases: Yes
+Bank Name: Freedom Bank
+Authorized Signer Attached: Yes
+Loan 1 Lender: First Capital Bank
+Loan 1 Purpose: Equipment Purchase
+Loan 1 Original Amount: $125,000
+Loan 1 Current Balance: $85,000
+Affidavit Present: Yes
+Affidavit Signer: Jordan Carter
+Affidavit Date: 08/15/2023

--- a/ai-analyzer/tests/fixtures/veteran/approval_letter.pdf
+++ b/ai-analyzer/tests/fixtures/veteran/approval_letter.pdf
@@ -1,0 +1,13 @@
+Department of Veterans Affairs
+Center for Verification and Evaluation
+VetCert Verification Letter
+September 5, 2023
+
+Re: Valor Tech Industries LLC
+
+Thank you for submitting your Veteran Small Business Certification application. This letter confirms that your firm has been approved pending issuance of the final certificate.
+
+The verification remains pending until the signed certificate is generated. Please maintain your DD-214 documentation and submit any additional NAICS updates (541330).
+
+Sincerely,
+OSDBU VetCert Team

--- a/ai-analyzer/tests/fixtures/veteran/certificate_sba.pdf
+++ b/ai-analyzer/tests/fixtures/veteran/certificate_sba.pdf
@@ -1,0 +1,8 @@
+Veteran Small Business Certification
+U.S. Small Business Administration VetCert Program
+This certifies that Valor Tech Industries LLC has been verified as a Service-Disabled Veteran-Owned Small Business.
+Certificate ID: SBA-VC-123456
+Issue Date: September 12, 2023
+Certification valid through: September 12, 2026
+NAICS Codes: 541330, 541512
+Verified by: Office of Veterans Business Development

--- a/ai-analyzer/tests/fixtures/veteran/negative/random_tax_form.pdf
+++ b/ai-analyzer/tests/fixtures/veteran/negative/random_tax_form.pdf
@@ -1,0 +1,4 @@
+Form W-2 Wage and Tax Statement
+Box 1 Wages: 42,000
+Employer identification number (EIN) 00-0000000
+This is not related to veteran certification.

--- a/ai-analyzer/tests/test_veteran_application_extractor.py
+++ b/ai-analyzer/tests/test_veteran_application_extractor.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from src.extractors.veteran_cert_application import extract
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "veteran" / "application_aug2023.pdf"
+
+
+def test_application_extractor_parses_core_fields():
+    text = FIXTURE.read_text(encoding="utf-8")
+    result = extract(text)
+
+    app = result["fields_clean"]["veteranCert"]["application"]
+    doc = app["doc"]
+    assert doc["type"] == "VOSB_SDVOSB_Application"
+    assert doc["issuer"] == "SBA"
+    assert doc["program"] == "VetCert"
+
+    business = app["business"]
+    assert business["legalName"]["value"] == "Valor Tech Industries LLC"
+    assert result["fields_clean"]["business.ein"] == "12-3456789"
+    assert result["fields_clean"]["business.phone"] == "+13035550199"
+    assert set(result["fields_clean"]["business.naics"]) == {"541330", "541512"}
+
+    owners = app["owners"]
+    assert owners[0]["ownershipPct"]["value"] == 60.0
+    assert owners[0]["isVeteran"]["value"] is True
+    assert owners[0]["isServiceDisabledVeteran"]["value"] is True
+    assert result["fields_clean"]["owners"][0]["percent"] == 60.0
+
+    control = app["control"]
+    assert control["signsChecks"]["value"] is True
+    assert control["executesContracts"]["value"] is True
+
+    loans = result["fields_clean"]["loans"]
+    assert loans[0]["originalAmount"] == 12_500_000
+    assert loans[0]["currentBalance"] == 8_500_000
+
+    affidavit = app["affidavit"]
+    assert affidavit["present"]["value"] is True
+    assert affidavit["signerName"]["value"] == "Jordan Carter"
+    assert affidavit["signDate"]["value"] == "2023-08-15"
+
+    veteran = app["veteran"]
+    assert veteran["dd214Present"]["value"] is True
+    assert veteran["vaDisabilityLetterPresent"]["value"] is False
+    assert result["fields_clean"]["requestedType"] == "SDVOSB"
+
+    warnings = result["warnings"]
+    assert "missing_va_disability_letter" in warnings
+    assert "ownership_below_51" not in warnings

--- a/ai-analyzer/tests/test_veteran_detection.py
+++ b/ai-analyzer/tests/test_veteran_detection.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from src.detectors import identify
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "veteran"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_detects_veteran_application():
+    text = _read("application_aug2023.pdf")
+    det = identify(text)
+    assert det["type_key"] == "VOSB_SDVOSB_Application"
+    assert det["confidence"] >= 0.7
+
+
+def test_detects_sba_certificate():
+    text = _read("certificate_sba.pdf")
+    det = identify(text)
+    assert det["type_key"] == "SDVOSB_Certificate"
+    assert det["confidence"] >= 0.7
+
+
+def test_detects_approval_letter():
+    text = _read("approval_letter.pdf")
+    det = identify(text)
+    assert det["type_key"] == "VOSB_SDVOSB_Approval_Letter"
+    assert det["confidence"] >= 0.6
+
+
+def test_negative_tax_document_not_veteran_cert():
+    text = _read("negative/random_tax_form.pdf")
+    det = identify(text)
+    assert det == {} or det.get("type_key") not in {
+        "VOSB_SDVOSB_Application",
+        "VOSB_Certificate",
+        "SDVOSB_Certificate",
+        "VOSB_SDVOSB_Approval_Letter",
+    }

--- a/ai-analyzer/tests/test_veteran_proof_extractor.py
+++ b/ai-analyzer/tests/test_veteran_proof_extractor.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from src.extractors.veteran_cert_proof import extract
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "veteran"
+
+
+def _read(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_certificate_proof_fields():
+    text = _read("certificate_sba.pdf")
+    result = extract(text, "SDVOSB_Certificate")
+
+    doc = result["fields_clean"]["veteranCert"]["doc"]
+    proof = result["fields_clean"]["veteranCert"]["proof"]
+
+    assert result["doc_type"] == "SDVOSB_Certificate"
+    assert doc == {"type": "SDVOSB_Certificate", "issuer": "SBA", "program": "VetCert"}
+    assert proof["businessName"]["value"] == "Valor Tech Industries LLC"
+    assert proof["certificateId"]["value"] == "SBA-VC-123456"
+    assert proof["issueDate"]["value"] == "2023-09-12"
+    assert proof["validThrough"]["value"] == "2026-09-12"
+    assert proof["certifiedAs"]["value"] == "SDVOSB"
+    assert result["fields_clean"]["proof.status"] == "active"
+    assert set(result["fields_clean"]["proof.naics"]) == {"541330", "541512"}
+
+
+def test_approval_letter_status_pending():
+    text = _read("approval_letter.pdf")
+    result = extract(text, "VOSB_SDVOSB_Approval_Letter")
+    assert result["doc_type"] == "VOSB_SDVOSB_Approval_Letter"
+    assert result["fields_clean"]["proof.status"] == "pending"
+    proof = result["fields_clean"]["veteranCert"]["proof"]
+    assert proof["certifiedAs"]["value"] == "VOSB"

--- a/eligibility-engine/README.md
+++ b/eligibility-engine/README.md
@@ -111,6 +111,29 @@ See `test_payload.json` for a sample business profile. Running the engine with t
 
 Each grant is assigned a percentage score based on how many rules passed. Missing data results in `eligible: null` and a score of 0. The `reasoning` and `debug` fields explain exactly why a grant did or did not qualify.
 
+## Veteran Certification Eligibility Checks
+
+The engine ships lightweight helpers for Veteran-owned programs. Analyzer
+payloads normalize veteran certification documents under `veteranCert` and the
+field map aliases them to simple keys such as `owners_list`,
+`control.signsChecks`, `veteran.proofs.dd214Present`, `veteran.proofs.vaLetterPresent`,
+and `veteran.cert.status`.
+
+- **`evaluate_vosb(payload)`** – deems a business eligible when a veteran owner
+  controls ≥51% equity, control indicators show the veteran signs checks and
+  executes contracts, and either an active certificate exists or a DD-214 proof
+  is on file. Missing certificates degrade to `conditional` with a
+  `submit_active_certificate` next step; expired/revoked certificates lead to
+  `ineligible`.
+- **`evaluate_sdv(payload)`** – extends the above with a ≥51% service-disabled
+  owner requirement plus VA disability proof (letter or rating > 0). Active
+  certificates return `eligible`; otherwise complete applications with DD-214
+  and VA disability evidence return `conditional`, while expired or revoked
+  proofs yield `ineligible`.
+
+Both functions return `{"decision": "eligible|conditional|ineligible", "reasons": [...], "missing": [...]}` to feed downstream
+workflows or UI messaging. See `tests/test_veteran_rules.py` for usage examples.
+
 ## Testing
 
 ```bash

--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -2,7 +2,8 @@
   "employer_identification_number": {
     "aliases": [
       "ein",
-      "tin"
+      "tin",
+      "business.ein"
     ],
     "target": "employer_identification_number",
     "type": "ein",
@@ -1159,7 +1160,7 @@
     "type": "currency"
   },
   "company_name": {
-    "aliases": ["company.name"],
+    "aliases": ["company.name", "business.legalName"],
     "target": "company_name",
     "type": "string"
   },
@@ -1174,7 +1175,7 @@
     "type": "object"
   },
   "company_naics": {
-    "aliases": ["company.naics"],
+    "aliases": ["company.naics", "business.naics"],
     "target": "company_naics",
     "type": "array"
   },
@@ -1192,6 +1193,46 @@
     "aliases": ["licenses"],
     "target": "licenses_list",
     "type": "array"
+  },
+  "veteran.proofs.dd214Present": {
+    "aliases": ["veteran.dd214Present"],
+    "target": "veteran.proofs.dd214Present",
+    "type": "bool"
+  },
+  "veteran.proofs.vaLetterPresent": {
+    "aliases": ["veteran.vaDisabilityLetterPresent"],
+    "target": "veteran.proofs.vaLetterPresent",
+    "type": "bool"
+  },
+  "veteran.disabilityPercent": {
+    "aliases": ["veteran.disabilityRatingPercent"],
+    "target": "veteran.disabilityPercent",
+    "type": "percent"
+  },
+  "veteran.cert.type": {
+    "aliases": ["proof.type"],
+    "target": "veteran.cert.type",
+    "type": "string"
+  },
+  "veteran.cert.issuer": {
+    "aliases": ["proof.issuer"],
+    "target": "veteran.cert.issuer",
+    "type": "string"
+  },
+  "veteran.cert.validThrough": {
+    "aliases": ["proof.validThrough"],
+    "target": "veteran.cert.validThrough",
+    "type": "date"
+  },
+  "veteran.cert.status": {
+    "aliases": ["proof.status"],
+    "target": "veteran.cert.status",
+    "type": "string"
+  },
+  "veteran.cert.certifiedAs": {
+    "aliases": ["proof.certifiedAs"],
+    "target": "veteran.cert.certifiedAs",
+    "type": "string"
   },
   "revenue_history": {
     "aliases": ["revenue.history"],

--- a/eligibility-engine/tests/test_veteran_rules.py
+++ b/eligibility-engine/tests/test_veteran_rules.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from veteran_rules import evaluate_sdv, evaluate_vosb
+
+
+def _base_payload():
+    return {
+        "owners_list": [
+            {"name": "Jordan", "percent": 60, "isVeteran": True, "isSDV": True},
+            {"name": "Avery", "percent": 40, "isVeteran": False, "isSDV": False},
+        ],
+        "control.signsChecks": True,
+        "control.executesContracts": True,
+        "veteran.proofs.dd214Present": True,
+        "veteran.proofs.vaLetterPresent": True,
+        "veteran.disabilityPercent": 70,
+        "veteran.cert.status": "active",
+    }
+
+
+def test_vosb_eligible_with_active_certificate():
+    payload = _base_payload()
+    result = evaluate_vosb(payload)
+    assert result["decision"] == "eligible"
+    assert "veteran_ownership_met" in result["reasons"]
+    assert result["missing"] == []
+
+
+def test_sdv_eligible_with_letter():
+    payload = _base_payload()
+    result = evaluate_sdv(payload)
+    assert result["decision"] == "eligible"
+    assert "sdv_ownership_met" in result["reasons"]
+    assert "certificate_active" in result["reasons"]
+
+
+def test_sdv_conditional_without_va_letter():
+    payload = _base_payload()
+    payload["veteran.proofs.vaLetterPresent"] = False
+    payload["veteran.disabilityPercent"] = 0
+    payload["veteran.cert.status"] = "pending"
+    result = evaluate_sdv(payload)
+    assert result["decision"] == "conditional"
+    assert "need_va_disability_letter" in result["reasons"]
+    assert "need_va_disability_letter" in result["missing"]
+
+
+def test_ineligible_when_ownership_below_threshold():
+    payload = _base_payload()
+    payload["owners_list"][0]["percent"] = 50
+    payload["veteran.cert.status"] = "expired"
+    result_vosb = evaluate_vosb(payload)
+    assert result_vosb["decision"] == "ineligible"
+    assert "ownership_below_51" in result_vosb["reasons"]
+    result_sdv = evaluate_sdv(payload)
+    assert result_sdv["decision"] == "ineligible"
+    assert "sdv_ownership_below_51" in result_sdv["reasons"]
+    assert "certificate_expired" in result_sdv["reasons"]

--- a/eligibility-engine/veteran_rules.py
+++ b/eligibility-engine/veteran_rules.py
@@ -1,0 +1,154 @@
+"""Eligibility helpers for Veteran certification programs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def _to_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"", "unknown", "na", "n/a"}:
+            return None
+        if lowered in {"true", "yes", "y", "1"}:
+            return True
+        if lowered in {"false", "no", "n", "0"}:
+            return False
+    return bool(value)
+
+
+def _to_float(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        cleaned = value.strip().replace("%", "")
+        try:
+            return float(cleaned)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _collect_context(data: Dict[str, Any]) -> Dict[str, Any]:
+    owners = data.get("owners_list") or data.get("owners") or []
+    max_veteran_pct = 0.0
+    max_sdv_pct = 0.0
+    for owner in owners:
+        pct = _to_float(owner.get("percent") or owner.get("ownershipPct"))
+        if _to_bool(owner.get("isVeteran")):
+            max_veteran_pct = max(max_veteran_pct, pct)
+        if _to_bool(owner.get("isSDV")) or _to_bool(owner.get("isServiceDisabledVeteran")):
+            max_sdv_pct = max(max_sdv_pct, pct)
+    control_signs = _to_bool(data.get("control.signsChecks"))
+    control_executes = _to_bool(data.get("control.executesContracts"))
+    dd214 = _to_bool(data.get("veteran.proofs.dd214Present"))
+    va_letter = _to_bool(data.get("veteran.proofs.vaLetterPresent"))
+    disability_percent = _to_float(data.get("veteran.disabilityPercent"))
+    proof_status = (data.get("veteran.cert.status") or "").strip().lower() or None
+    return {
+        "owners": owners,
+        "max_veteran_pct": max_veteran_pct,
+        "max_sdv_pct": max_sdv_pct,
+        "control_signs": control_signs,
+        "control_executes": control_executes,
+        "dd214": dd214,
+        "va_letter": va_letter,
+        "disability_percent": disability_percent,
+        "proof_status": proof_status,
+    }
+
+
+def evaluate_vosb(data: Dict[str, Any]) -> Dict[str, Any]:
+    ctx = _collect_context(data)
+    reasons: List[str] = []
+    missing: List[str] = []
+    decision = "eligible"
+
+    if ctx["max_veteran_pct"] >= 51:
+        reasons.append("veteran_ownership_met")
+    else:
+        decision = "ineligible"
+        reasons.append("ownership_below_51")
+
+    if not (ctx["control_signs"] and ctx["control_executes"]):
+        decision = "ineligible"
+        reasons.append("control_not_demonstrated")
+
+    status = ctx["proof_status"]
+    if status in {"expired", "revoked"}:
+        decision = "ineligible"
+        reasons.append(f"certificate_{status}")
+    elif status == "active" and decision == "eligible":
+        reasons.append("certificate_active")
+    else:
+        if ctx["dd214"]:
+            if decision == "eligible":
+                decision = "conditional"
+            reasons.append("dd214_present_pending_certificate")
+            missing.append("submit_active_certificate")
+        else:
+            if decision == "eligible":
+                decision = "conditional"
+            reasons.append("missing_service_proof")
+            missing.append("provide_dd214_or_certificate")
+
+    return {"decision": decision, "reasons": reasons, "missing": sorted(set(missing))}
+
+
+def evaluate_sdv(data: Dict[str, Any]) -> Dict[str, Any]:
+    ctx = _collect_context(data)
+    reasons: List[str] = []
+    missing: List[str] = []
+    decision = "eligible"
+
+    if ctx["max_sdv_pct"] >= 51:
+        reasons.append("sdv_ownership_met")
+    else:
+        decision = "ineligible"
+        reasons.append("sdv_ownership_below_51")
+
+    if not (ctx["control_signs"] and ctx["control_executes"]):
+        decision = "ineligible"
+        reasons.append("control_not_demonstrated")
+
+    letter_ok = ctx["va_letter"] or ctx["disability_percent"] > 0
+    if not letter_ok:
+        if decision == "eligible":
+            decision = "conditional"
+        reasons.append("need_va_disability_letter")
+        missing.append("need_va_disability_letter")
+
+    status = ctx["proof_status"]
+    if status in {"expired", "revoked"}:
+        decision = "ineligible"
+        reasons.append(f"certificate_{status}")
+    elif status == "active" and decision == "eligible":
+        reasons.append("certificate_active")
+    else:
+        if ctx["dd214"] and letter_ok:
+            if decision == "eligible":
+                decision = "conditional"
+            reasons.append("awaiting_active_certificate")
+            missing.append("submit_active_certificate")
+        elif ctx["dd214"]:
+            if decision == "eligible":
+                decision = "conditional"
+            reasons.append("dd214_present_pending_certificate")
+            if "need_va_disability_letter" not in missing:
+                missing.append("need_va_disability_letter")
+        else:
+            if decision == "eligible":
+                decision = "conditional"
+            reasons.append("missing_service_proof")
+            missing.append("provide_dd214")
+
+    return {"decision": decision, "reasons": reasons, "missing": sorted(set(missing))}
+

--- a/shared/document_types/catalog.json
+++ b/shared/document_types/catalog.json
@@ -572,6 +572,136 @@
         "acdbe.concessionSpaces": "array",
         "affidavit": "object"
       }
+    },
+    "VOSB_SDVOSB_Application": {
+      "display_name": "Veteran-Owned Small Business Certification Application",
+      "identify": {
+        "keywords_any": [
+          "Veteran Small Business Certification",
+          "SDVOSB Certification Application",
+          "VOSB Certification Application",
+          "VetCert Application",
+          "Ownership and Control",
+          "Service-connected disability",
+          "DD-214"
+        ],
+        "regex_any": [
+          "(?i)Veteran\\s+Small\\s+Business\\s+Certification",
+          "(?i)SDVOSB\\s+Certification\\s+Application",
+          "(?i)VOSB\\s+Certification\\s+Application"
+        ],
+        "score_bonus": 0.35,
+        "check_pages": [
+          1,
+          2
+        ]
+      },
+      "extractor": "veteran_cert_application",
+      "fields": {
+        "veteranCert": "object",
+        "business.legalName": "string",
+        "business.ein": "string",
+        "business.naics": "array",
+        "owners": "array",
+        "veteran.dd214Present": "bool",
+        "veteran.vaDisabilityLetterPresent": "bool",
+        "veteran.disabilityRatingPercent": "number",
+        "control.signsChecks": "bool",
+        "control.executesContracts": "bool",
+        "control.hiresFires": "bool",
+        "control.majorPurchases": "bool",
+        "affidavit.present": "bool",
+        "requestedType": "string"
+      }
+    },
+    "VOSB_Certificate": {
+      "display_name": "Veteran-Owned Small Business Certificate",
+      "identify": {
+        "keywords_any": [
+          "Veteran Small Business Certification",
+          "VOSB Certificate",
+          "This certifies that",
+          "Certification valid through",
+          "Certificate ID",
+          "Verified"
+        ],
+        "regex_any": [
+          "(?i)Veteran[-\\s]+Owned",
+          "(?i)has\\s+been\\s+verified",
+          "(?i)Certification\\s+valid\\s+through"
+        ],
+        "score_bonus": 0.3,
+        "check_pages": [
+          1
+        ]
+      },
+      "extractor": "veteran_cert_proof",
+      "fields": {
+        "veteranCert": "object",
+        "proof.certifiedAs": "string",
+        "proof.status": "string",
+        "proof.validThrough": "date",
+        "proof.issueDate": "date"
+      }
+    },
+    "SDVOSB_Certificate": {
+      "display_name": "Service-Disabled Veteran-Owned Small Business Certificate",
+      "identify": {
+        "keywords_any": [
+          "Service-Disabled Veteran-Owned Small Business",
+          "SDVOSB Certificate",
+          "This certifies that",
+          "Certification valid through",
+          "Certificate ID",
+          "Service-disabled"
+        ],
+        "regex_any": [
+          "(?i)Service[-\\s]+Disabled",
+          "(?i)has\\s+been\\s+verified",
+          "(?i)Certification\\s+valid\\s+through"
+        ],
+        "score_bonus": 0.35,
+        "check_pages": [
+          1
+        ]
+      },
+      "extractor": "veteran_cert_proof",
+      "fields": {
+        "veteranCert": "object",
+        "proof.certifiedAs": "string",
+        "proof.status": "string",
+        "proof.validThrough": "date",
+        "proof.issueDate": "date"
+      }
+    },
+    "VOSB_SDVOSB_Approval_Letter": {
+      "display_name": "Veteran Certification Approval Letter",
+      "identify": {
+        "keywords_any": [
+          "Veteran Small Business Certification",
+          "Approval Letter",
+          "Verification Letter",
+          "VetCert",
+          "has been approved"
+        ],
+        "regex_any": [
+          "(?i)approval\\s+letter",
+          "(?i)verification\\s+letter",
+          "(?i)under\\s+review",
+          "(?i)pending"
+        ],
+        "score_bonus": 0.25,
+        "check_pages": [
+          1
+        ]
+      },
+      "extractor": "veteran_cert_proof",
+      "fields": {
+        "veteranCert": "object",
+        "proof.status": "string",
+        "proof.certifiedAs": "string",
+        "proof.validThrough": "date"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add veteran certification document types with analyzer routing, extractors, and fixtures
- map normalized veteran data to eligibility fields and implement VOSB/SDVOSB rule helpers
- document the new veteran support and add focused unit tests

## Testing
- pytest ai-analyzer/tests/test_veteran_detection.py ai-analyzer/tests/test_veteran_application_extractor.py
- pytest ai-analyzer/tests/test_veteran_proof_extractor.py
- pytest eligibility-engine/tests/test_veteran_rules.py

------
https://chatgpt.com/codex/tasks/task_b_68d99bbfc4e08327b31a2518e521bcaa