### PR TITLE
Integrate NAICS industry catalog into eligibility flow

### DIFF
--- a/eligibility-engine/contracts/field_map.json
+++ b/eligibility-engine/contracts/field_map.json
@@ -1174,6 +1174,14 @@
     "target": "company_mailing_address",
     "type": "object"
   },
+  "business_industry_naics": {
+    "aliases": [
+      "business.industry.naics",
+      "industry.naics"
+    ],
+    "target": "business_industry_naics",
+    "type": "object"
+  },
   "company_naics": {
     "aliases": ["company.naics", "business.naics"],
     "target": "company_naics",

--- a/eligibility-engine/grants/california_smallbiz.json
+++ b/eligibility-engine/grants/california_smallbiz.json
@@ -2,6 +2,7 @@
   "name": "California Small Business Grant (2025)",
   "year": 2025,
   "description": "Collection of California state and regional programs supporting small businesses.",
+  "eligible_industries": [],
   "general_eligibility": "Applicants must be California-based small businesses meeting program-specific size, revenue and training requirements and submit W-9, business license, proof of income and an action plan where applicable.",
   "required_fields": [
     "business_location_state",

--- a/eligibility-engine/grants/erc.json
+++ b/eligibility-engine/grants/erc.json
@@ -2,6 +2,7 @@
   "name": "Employee Retention Credit",
   "year": 2021,
   "description": "Federal tax credit encouraging businesses to retain employees during the COVID-19 pandemic",
+  "eligible_industries": [],
   "required_fields": [
     "w2_employee_count",
     "revenue_drop_percent",

--- a/eligibility-engine/grants/green_energy_state_incentive.json
+++ b/eligibility-engine/grants/green_energy_state_incentive.json
@@ -2,6 +2,7 @@
   "name": "Green Energy State Incentive",
   "year": 2025,
   "description": "State and city level grants, tax credits, and rebates for renewable energy projects",
+  "eligible_industries": ["236", "237", "238", "325", "334"],
   "required_fields": [
     "state",
     "applicant_type",

--- a/eligibility-engine/grants/urban_small_business_grants_2025.json
+++ b/eligibility-engine/grants/urban_small_business_grants_2025.json
@@ -2,6 +2,7 @@
   "name": "Urban Small Business Grants (2025)",
   "year": 2025,
   "description": "Composite of city-level grant programs supporting small businesses recovering from COVID-19 or structural damage.",
+  "eligible_industries": ["445", "448", "452", "453", "454", "722"],
   "general_eligibility": "Businesses must be located within city limits, demonstrate COVID-19 or related structural damage impacts, meet size limits, and submit official applications with tax, financial and recovery documentation.",
   "required_fields": [
     "city",

--- a/eligibility-engine/grants/women_owned_tech.json
+++ b/eligibility-engine/grants/women_owned_tech.json
@@ -2,6 +2,7 @@
   "name": "Women-Owned Tech Grant",
   "year": 2025,
   "description": "Support for tech companies owned by women",
+  "eligible_industries": ["334", "518", "541"],
   "required_fields": [
     "sba_small_business",
     "women_ownership_percent",

--- a/eligibility-engine/industries.json
+++ b/eligibility-engine/industries.json
@@ -1,0 +1,182 @@
+[
+  {
+    "naics_code": "111",
+    "name": "Crop Production",
+    "description": "Fruits, vegetables, grains, plants",
+    "aliases": ["farming", "crops", "agriculture", "horticulture"]
+  },
+  {
+    "naics_code": "112",
+    "name": "Animal Production",
+    "description": "Livestock, poultry, aquaculture",
+    "aliases": ["farm animals", "cattle", "chickens", "fish farming"]
+  },
+  {
+    "naics_code": "236",
+    "name": "Construction of Buildings",
+    "description": "Building contractors, real estate development",
+    "aliases": ["construction", "building", "real estate development"]
+  },
+  {
+    "naics_code": "237",
+    "name": "Heavy and Civil Engineering Construction",
+    "description": "Roads, bridges, infrastructure",
+    "aliases": ["infrastructure", "civil works", "bridge", "highway"]
+  },
+  {
+    "naics_code": "238",
+    "name": "Specialty Trade Contractors",
+    "description": "Electrical, plumbing, renovation",
+    "aliases": ["electrician", "plumber", "remodeling", "renovation"]
+  },
+  {
+    "naics_code": "311",
+    "name": "Food Manufacturing",
+    "description": "Food factories, bakeries",
+    "aliases": ["food factory", "bakery", "snack production"]
+  },
+  {
+    "naics_code": "312",
+    "name": "Beverage & Tobacco",
+    "description": "Wine, beer, soft drinks, tobacco",
+    "aliases": ["brewery", "winery", "tobacco", "beverages"]
+  },
+  {
+    "naics_code": "323",
+    "name": "Printing & Related",
+    "description": "Printing houses, graphic print services",
+    "aliases": ["printing", "press", "publishing services"]
+  },
+  {
+    "naics_code": "325",
+    "name": "Chemical Manufacturing",
+    "description": "Industrial chemicals, plastics",
+    "aliases": ["chemicals", "plastics", "industrial production"]
+  },
+  {
+    "naics_code": "334",
+    "name": "Computer & Electronic Product Manufacturing",
+    "description": "Computers, components, chips",
+    "aliases": ["electronics", "semiconductors", "computers", "hardware"]
+  },
+  {
+    "naics_code": "336",
+    "name": "Transportation Equipment Manufacturing",
+    "description": "Cars, planes, trains",
+    "aliases": ["automobiles", "aircraft", "rail"]
+  },
+  {
+    "naics_code": "423",
+    "name": "Wholesale Trade, Durable Goods",
+    "description": "Wholesale industrial equipment",
+    "aliases": ["wholesale durable", "industrial wholesale"]
+  },
+  {
+    "naics_code": "424",
+    "name": "Wholesale Trade, Nondurable Goods",
+    "description": "Food, clothing, consumer goods",
+    "aliases": ["wholesale nondurable", "food wholesale", "clothing wholesale"]
+  },
+  {
+    "naics_code": "441",
+    "name": "Motor Vehicle Dealers",
+    "description": "Car sales, auto parts",
+    "aliases": ["car dealer", "auto sales", "motor vehicles"]
+  },
+  {
+    "naics_code": "445",
+    "name": "Food & Beverage Stores",
+    "description": "Grocery, supermarkets",
+    "aliases": ["grocery store", "supermarket", "food store"]
+  },
+  {
+    "naics_code": "448",
+    "name": "Clothing & Accessories Stores",
+    "description": "Clothing, shoes",
+    "aliases": ["clothing store", "apparel", "fashion"]
+  },
+  {
+    "naics_code": "452",
+    "name": "General Merchandise Stores",
+    "description": "Walmart, Target, general retail",
+    "aliases": ["retail chain", "general store", "merchandise"]
+  },
+  {
+    "naics_code": "453",
+    "name": "Miscellaneous Store Retailers",
+    "description": "Specialty shops (toys, art)",
+    "aliases": ["toy store", "gift shop", "art store"]
+  },
+  {
+    "naics_code": "454",
+    "name": "Nonstore Retail (E-commerce)",
+    "description": "Online shops, delivery",
+    "aliases": ["ecommerce", "online shop", "marketplace"]
+  },
+  {
+    "naics_code": "481",
+    "name": "Air Transportation",
+    "description": "Airlines, cargo",
+    "aliases": ["airline", "cargo airline", "aviation"]
+  },
+  {
+    "naics_code": "484",
+    "name": "Truck Transportation",
+    "description": "Trucking, logistics",
+    "aliases": ["trucking", "freight", "logistics"]
+  },
+  {
+    "naics_code": "492",
+    "name": "Couriers & Messengers",
+    "description": "FedEx, UPS, deliveries",
+    "aliases": ["delivery", "courier", "parcel service"]
+  },
+  {
+    "naics_code": "511",
+    "name": "Publishing Industries",
+    "description": "Books, newspapers, digital media",
+    "aliases": ["publisher", "media publishing", "newspapers"]
+  },
+  {
+    "naics_code": "517",
+    "name": "Telecommunications",
+    "description": "Internet, phone, cellular",
+    "aliases": ["telecom", "ISP", "cellular provider"]
+  },
+  {
+    "naics_code": "518",
+    "name": "Data Processing & Hosting",
+    "description": "Data centers, SaaS",
+    "aliases": ["data hosting", "SaaS", "cloud services"]
+  },
+  {
+    "naics_code": "522",
+    "name": "Credit Intermediation",
+    "description": "Banks, credit, mortgages",
+    "aliases": ["bank", "credit union", "lending"]
+  },
+  {
+    "naics_code": "523",
+    "name": "Securities & Investments",
+    "description": "Brokers, investments",
+    "aliases": ["investment", "brokerage", "stock market"]
+  },
+  {
+    "naics_code": "541",
+    "name": "Professional, Scientific & Technical Services",
+    "description": "Lawyers, accountants, consultants",
+    "aliases": ["professional services", "law firm", "accounting"]
+  },
+  {
+    "naics_code": "621",
+    "name": "Ambulatory Health Care",
+    "description": "Doctors, clinics, dentists",
+    "aliases": ["clinic", "doctor office", "dental"]
+  },
+  {
+    "naics_code": "722",
+    "name": "Food Services & Drinking Places",
+    "description": "Restaurants, cafes, bars",
+    "aliases": ["restaurant", "cafe", "bar", "food service"]
+  }
+]

--- a/eligibility-engine/industry_classifier.py
+++ b/eligibility-engine/industry_classifier.py
@@ -1,0 +1,199 @@
+"""Utilities to map businesses to NAICS industries."""
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+CATALOG_PATH = Path(__file__).resolve().parent / "industries.json"
+
+
+def _normalize_code(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        raw = str(int(raw))
+    code = str(raw).strip()
+    if not code:
+        return None
+    digits = re.sub(r"[^0-9]", "", code)
+    if not digits:
+        return None
+    if len(digits) >= 3:
+        digits = digits[:3]
+    return digits
+
+
+def _coerce_entry(value: Any, *, default_source: str) -> Optional[Dict[str, Any]]:
+    if isinstance(value, dict):
+        code = _normalize_code(value.get("code") or value.get("naics_code"))
+        if not code:
+            return None
+        confidence = value.get("confidence")
+        if confidence is None:
+            confidence = 1.0
+        source = value.get("source") or default_source
+        entry = {**value, "code": code, "confidence": float(confidence), "source": source}
+        return entry
+    code = _normalize_code(value)
+    if not code:
+        return None
+    return {"code": code, "confidence": 1.0, "source": default_source}
+
+
+@lru_cache()
+def load_catalog() -> List[Dict[str, Any]]:
+    with CATALOG_PATH.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+        return data
+
+
+@lru_cache()
+def catalog_by_code() -> Dict[str, Dict[str, Any]]:
+    return {item["naics_code"]: item for item in load_catalog()}
+
+
+def _iter_naics_values(value: Any, *, default_source: str) -> Iterable[Dict[str, Any]]:
+    if isinstance(value, list):
+        for item in value:
+            entry = _coerce_entry(item, default_source=default_source)
+            if entry:
+                yield entry
+    else:
+        entry = _coerce_entry(value, default_source=default_source)
+        if entry:
+            yield entry
+
+
+def _collect_textual_evidence(data: Dict[str, Any]) -> List[str]:
+    fields: Sequence[str] = (
+        "industry",
+        "business_description",
+        "business_activity",
+        "executive_summary",
+        "service_description",
+        "project_description",
+        "business_name",
+        "company_name",
+    )
+    snippets: List[str] = []
+    for field in fields:
+        value = data.get(field)
+        if not value:
+            continue
+        if isinstance(value, str):
+            snippets.append(value)
+        elif isinstance(value, dict):
+            snippets.extend(str(v) for v in value.values() if isinstance(v, str))
+        elif isinstance(value, list):
+            snippets.extend(str(item) for item in value if isinstance(item, str))
+    tags = data.get("tags")
+    if isinstance(tags, list):
+        snippets.extend(str(tag) for tag in tags if isinstance(tag, str))
+    return snippets
+
+
+def _find_direct_code(text: str) -> Optional[str]:
+    for match in re.findall(r"naics\s*(\d{3,6})", text):
+        code = _normalize_code(match)
+        if code and code in catalog_by_code():
+            return code
+    return None
+
+
+def _contains(text: str, phrase: str) -> bool:
+    if not phrase:
+        return False
+    pattern = rf"(?<!\w){re.escape(phrase)}(?!\w)"
+    return re.search(pattern, text) is not None
+
+
+def _score_industry(entry: Dict[str, Any], *, text: str, keywords: Sequence[str]):
+    lowered_keywords = {k.lower() for k in keywords}
+    alias_matches: List[str] = []
+    alias_bonus = 0
+    for alias in entry.get("aliases", []):
+        alias_l = alias.lower()
+        if alias_l in lowered_keywords or alias_l in text:
+            alias_matches.append(alias)
+            alias_bonus += 5
+    name = entry.get("name", "").lower()
+    name_match = name in text
+    description = entry.get("description", "").lower()
+    desc_terms = [term.strip() for term in re.split(r"[,/]| and ", description) if term.strip()]
+    desc_bonus = sum(1 for term in desc_terms if term and term in text)
+    score = alias_bonus
+    if name_match:
+        score += 3
+    score += desc_bonus
+    return score, alias_matches, name_match, desc_bonus
+
+
+def _infer_from_text(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    snippets = _collect_textual_evidence(data)
+    if not snippets:
+        return None
+    text = " ".join(snippet.lower() for snippet in snippets if isinstance(snippet, str))
+    if not text.strip():
+        return None
+    direct = _find_direct_code(text)
+    if direct:
+        return {
+            "code": direct,
+            "confidence": 0.95,
+            "source": "text_naics",
+            "matched_aliases": [f"naics {direct}"],
+        }
+    best: Optional[Dict[str, Any]] = None
+    best_score = 0
+    best_aliases: List[str] = []
+    keywords = [snippet.lower() for snippet in snippets if isinstance(snippet, str)]
+    for entry in load_catalog():
+        score, aliases, name_match, desc_bonus = _score_industry(entry, text=text, keywords=keywords)
+        if score <= 0:
+            continue
+        if score > best_score:
+            best_score = score
+            best_aliases = aliases
+            confidence = 0.4 + 0.1 * len(aliases) + (0.1 if name_match else 0.0) + min(0.1, 0.05 * desc_bonus)
+            best = {
+                "code": entry["naics_code"],
+                "confidence": round(min(confidence, 0.95), 2),
+                "source": "inferred",
+                "matched_aliases": sorted(set(aliases)),
+            }
+    return best
+
+
+def assign_industry_naics(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Augment a normalized payload with an inferred NAICS code."""
+    enriched = dict(data)
+    existing = enriched.get("business_industry_naics")
+    normalized_existing = _coerce_entry(existing, default_source="provided") if existing else None
+    if not normalized_existing:
+        for entry in _iter_naics_values(enriched.get("company_naics"), default_source="company_naics"):
+            normalized_existing = entry
+            break
+    if not normalized_existing:
+        normalized_existing = _infer_from_text(enriched)
+    if normalized_existing:
+        enriched["business_industry_naics"] = normalized_existing
+    return enriched
+
+
+def list_naics_codes(data: Dict[str, Any]) -> List[str]:
+    """Return all known NAICS codes for a business, normalized to 3 digits."""
+    codes: List[str] = []
+    entry = data.get("business_industry_naics")
+    normalized_entry = _coerce_entry(entry, default_source="provided") if entry else None
+    if normalized_entry:
+        codes.append(normalized_entry["code"])
+    for extra in _iter_naics_values(data.get("company_naics"), default_source="company_naics"):
+        code = extra["code"]
+        if code not in codes:
+            codes.append(code)
+    return codes
+
+
+__all__ = ["assign_industry_naics", "list_naics_codes", "load_catalog"]

--- a/eligibility-engine/normalization/ingest.py
+++ b/eligibility-engine/normalization/ingest.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any
 
+from industry_classifier import assign_industry_naics
+
 FIELD_MAP_PATH = Path(__file__).resolve().parent.parent / "contracts" / "field_map.json"
 
 
@@ -16,6 +18,7 @@ def normalize_payload(analyzer_payload: Dict[str, Any]) -> Dict[str, Any]:
     field_map = load_field_map()
     data = fill_aliases(analyzer_payload, field_map)
     data = coerce_types_and_units(data, field_map)
+    data = assign_industry_naics(data)
     return data
 
 

--- a/eligibility-engine/tests/test_industry_eligibility.py
+++ b/eligibility-engine/tests/test_industry_eligibility.py
@@ -1,0 +1,106 @@
+import pytest
+
+from engine import analyze_eligibility
+from normalization.ingest import normalize_payload
+
+
+def _find_result(results, name: str):
+    for result in results:
+        if result["name"] == name:
+            return result
+    raise AssertionError(f"Grant {name!r} not found in results")
+
+
+def test_restaurant_maps_to_food_services_and_matches_urban_grant():
+    payload = {
+        "business_name": "Loop Bistro",
+        "industry": "Restaurant",
+        "tags": ["restaurant", "food", "hospitality"],
+        "city": "Chicago",
+        "employee_count": 4,
+        "annual_revenue": 320000,
+        "revenue_decline_percent": 30,
+        "business_age_years": 6,
+        "owner_veteran": False,
+        "owner_minority": False,
+        "covid_impact": True,
+        "structural_damage": False,
+        "geographic_zone": "loop",
+    }
+
+    normalized = normalize_payload(payload)
+    normalized["employee_count"] = normalized.get("number_of_employees")
+    naics = normalized.get("business_industry_naics")
+    assert naics and naics["code"] == "722"
+
+    results = analyze_eligibility(normalized, explain=True)
+    urban = _find_result(results, "Urban Small Business Grants (2025)")
+    assert urban["eligible"] is True
+    assert urban["status"] == "eligible"
+    assert any("business_industry_naics" in step for step in urban["reasoning"])
+
+
+def test_construction_business_matches_green_energy_incentive():
+    payload = {
+        "business_name": "SolarBuild Co.",
+        "industry": "Construction and solar installation",
+        "tags": ["construction", "solar"],
+        "state": "CA",
+        "applicant_type": "business",
+        "project_type": "battery_storage",
+        "project_cost": 250000,
+        "system_size_kw": 150,
+        "certified_installer": True,
+        "approved_equipment": True,
+        "equity_eligible_contractor": False,
+    }
+
+    normalized = normalize_payload(payload)
+    normalized["state"] = normalized.get("business_location_state")
+    naics = normalized.get("business_industry_naics")
+    assert naics and naics["code"] == "236"
+
+    results = analyze_eligibility(normalized, explain=True)
+    green = _find_result(results, "Green Energy State Incentive")
+    assert green["eligible"] is True
+    assert green["status"] == "eligible"
+    assert green["debug"].get("industry", {}).get("matched") == ["236"]
+
+
+def test_tech_startup_qualifies_for_women_owned_tech_grant():
+    payload = {
+        "business_name": "CloudOptima Labs",
+        "industry": "Technology startup providing SaaS analytics",
+        "business_description": "SaaS platform for supply chain analytics",
+        "tags": ["software", "SaaS", "women led"],
+        "sba_small_business": True,
+        "women_ownership_percent": 80,
+        "women_us_citizen_residents": True,
+        "women_controlled": True,
+        "woman_leader_full_time": True,
+        "for_profit": True,
+        "entity_type": "llc",
+        "owner_debarred": False,
+        "federal_litigation": False,
+        "us_based_or_impact": True,
+        "owner_net_worths": [500000],
+        "owner_avg_incomes": [200000],
+        "owner_total_assets": [3000000],
+        "num_employees": 45,
+        "us_ownership_percent": 80,
+        "institutional_investor_controlled": False,
+        "research_location": "us",
+        "has_research_institution_partner": True,
+        "sam_registered": True,
+        "self_certified": True,
+    }
+
+    normalized = normalize_payload(payload)
+    naics = normalized.get("business_industry_naics")
+    assert naics and naics["code"] in {"334", "518"}
+
+    results = analyze_eligibility(normalized, explain=True)
+    women_tech = _find_result(results, "Women-Owned Tech Grant")
+    assert women_tech["eligible"] is True
+    assert women_tech["status"] == "eligible"
+    assert women_tech["debug"].get("industry", {}).get("matched")


### PR DESCRIPTION
## Summary
- add a NAICS industry catalog and classifier to infer business industries from payload text and company metadata
- invoke the classifier during normalization and enforce eligible industry constraints when evaluating grants
- annotate relevant grants with eligible industry codes and add tests covering restaurant, construction, and tech startup scenarios

## Testing
- pytest eligibility-engine/tests

------
https://chatgpt.com/codex/tasks/task_b_68d9a582e5ec8327bba896ec35439191