### PR TITLE
Fix ai-analyzer import path for document_library

### DIFF
--- a/ai-analyzer/main.py
+++ b/ai-analyzer/main.py
@@ -1,8 +1,14 @@
+import sys
+import os
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
 from fastapi import FastAPI, UploadFile, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.concurrency import run_in_threadpool
-import sys
 from pathlib import Path
 from typing import Any
 import io

--- a/ai-analyzer/src/verify_import.py
+++ b/ai-analyzer/src/verify_import.py
@@ -1,0 +1,12 @@
+"""Utility to verify shared document_library import."""
+
+import os
+import sys
+
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
+
+import document_library
+
+print("\u2705 document_library import successful:", document_library.__file__)


### PR DESCRIPTION
## Summary
- ensure the ai-analyzer service adds the project root to sys.path so document_library can be imported
- add a verify_import utility script to confirm the shared document_library package resolves correctly

## Testing
- python src/verify_import.py
- python -m uvicorn main:app --port 8001 --reload


------
https://chatgpt.com/codex/tasks/task_b_68e2bb3100688327a05e184296f6cfe4