### PR TITLE
Fix OCR fallback with pdf2image

### DIFF
--- a/ai-analyzer/ocr_utils.py
+++ b/ai-analyzer/ocr_utils.py
@@ -21,33 +21,57 @@ except Exception:  # pragma: no cover - gracefully handle missing libs
     pytesseract = None  # type: ignore
     Image = None  # type: ignore
 
+try:  # pragma: no cover - external dependency may be missing
+    from pdf2image import convert_from_bytes  # type: ignore
+except Exception:  # pragma: no cover - gracefully handle missing libs
+    convert_from_bytes = None  # type: ignore
+
 
 def extract_text(file_bytes: bytes) -> str:
-    """Return extracted text using PDF or image OCR when available.
-
-    Raises:
-        OCRExtractionError: If PDF or image OCR fails.
-    """
+    """Return extracted text using PDF or image OCR when available."""
     if pdfplumber and file_bytes.lstrip()[:4] == b"%PDF":
         try:  # pragma: no cover - depends on external library
             with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
                 text = "\n".join(page.extract_text() or "" for page in pdf.pages)
             if text.strip():
-                return text.strip()
-        except Exception as exc:
-            raise OCRExtractionError("Failed to extract text from PDF") from exc
+                text = text.strip()
+                print(f"OCR extracted {len(text)} characters")
+                return text
+        except Exception:
+            pass
+
+    if pytesseract and convert_from_bytes and file_bytes.lstrip()[:4] == b"%PDF":
+        try:  # pragma: no cover - relies on external binaries
+            pages = convert_from_bytes(file_bytes)
+            text_chunks = []
+            for page in pages:
+                page_text = pytesseract.image_to_string(page)
+                if page_text:
+                    text_chunks.append(page_text)
+            text = "\n".join(text_chunks).strip()
+            if text:
+                print(f"OCR extracted {len(text)} characters")
+                return text
+        except Exception:
+            pass
 
     if pytesseract and Image:
         try:  # pragma: no cover - relies on external binaries
             image = Image.open(io.BytesIO(file_bytes))
-            text = pytesseract.image_to_string(image)
-            return text.strip()
-        except Exception as exc:
-            raise OCRExtractionError("Failed to extract text from image") from exc
+            text = pytesseract.image_to_string(image).strip()
+            if text:
+                print(f"OCR extracted {len(text)} characters")
+                return text
+        except Exception:
+            pass
 
-    # Fallback to simple decoding
     try:
-        return file_bytes.decode("utf-8", errors="ignore").strip()
-    except Exception as exc:
-        raise OCRExtractionError("Failed to decode content") from exc
+        text = file_bytes.decode("utf-8", errors="ignore").strip()
+        if text:
+            print(f"OCR extracted {len(text)} characters")
+            return text
+    except Exception:
+        pass
+
+    return ""
 


### PR DESCRIPTION
## Summary
- add pdf2image-based OCR fallback to process scanned PDF pages with pytesseract
- retain existing pdfplumber extraction and safe decoding fallbacks while avoiding hard failures
- emit simple debug output indicating extracted character counts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2c5d2df8c83279c44cd50b3d79ea9