### PR TITLE
feat: add bank statement extractor coverage

### DIFF
--- a/ai-analyzer/pytest.ini
+++ b/ai-analyzer/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = tests
-pythonpath = .
+pythonpath =
+    .
+    ..

--- a/ai-analyzer/src/extractors/bank_statement.py
+++ b/ai-analyzer/src/extractors/bank_statement.py
@@ -1,0 +1,179 @@
+"""Field extraction logic for bank statement documents."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Tuple
+
+from document_library.aliases import get_aliases_for
+
+DATE_TOKEN = r"(?:[A-Za-z]{3,9}\s+\d{1,2},?\s*\d{2,4}|\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}|\d{4}-\d{1,2}-\d{1,2})"
+RANGE_SEPARATOR = r"(?:to|through|thru|\-|–|—)"
+
+COMBINED_PERIOD_PATTERNS = [
+    re.compile(
+        rf"(?i)(?:statement|billing)\s+(?:period|cycle)[:\-\s]*"
+        rf"(?P<start>{DATE_TOKEN})\s*{RANGE_SEPARATOR}\s*(?P<end>{DATE_TOKEN})"
+    ),
+    re.compile(
+        rf"(?i)period\s+covered(?:\s+by)?[:\-\s]*"
+        rf"(?P<start>{DATE_TOKEN})\s*{RANGE_SEPARATOR}\s*(?P<end>{DATE_TOKEN})"
+    ),
+]
+
+
+def _normalize_numeric_token(token: str | None) -> str | None:
+    if not token:
+        return None
+    cleaned = token.strip()
+    if not cleaned:
+        return None
+    negative = False
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        negative = True
+        cleaned = cleaned[1:-1]
+    cleaned = cleaned.replace("$", "").replace(",", "").replace(" ", "")
+    cleaned = cleaned.replace("−", "-").replace("—", "-")
+    if cleaned.startswith("-"):
+        negative = True
+        cleaned = cleaned[1:]
+    cleaned = re.sub(r"[^0-9.]", "", cleaned)
+    if not cleaned:
+        return None
+    if cleaned.startswith("."):
+        cleaned = f"0{cleaned}"
+    value = cleaned
+    return f"-{value}" if negative and value not in {"0", "0.0", "0.00"} else value
+
+
+def _extract_numeric_field(text: str, aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        pattern = re.compile(
+            rf"{re.escape(alias)}[:\-\s]*\$?\s*(\(?-?[0-9][0-9,]*(?:\.[0-9]+)?\)?)",
+            re.IGNORECASE,
+        )
+        match = pattern.search(text)
+        if match:
+            normalized = _normalize_numeric_token(match.group(1))
+            if normalized is not None:
+                return normalized
+    return None
+
+
+def _extract_text_field(text: str, aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        pattern = re.compile(rf"{re.escape(alias)}[:\-\s]*([^\n]+)", re.IGNORECASE)
+        match = pattern.search(text)
+        if match:
+            value = match.group(1).strip()
+            if value:
+                return value
+    return None
+
+
+def _extract_account_last4(text: str, aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        pattern = re.compile(
+            rf"{re.escape(alias)}[:\-\s]*(?:[xX\*#\s-]+)?([0-9]{{4,}})",
+            re.IGNORECASE,
+        )
+        match = pattern.search(text)
+        if match:
+            digits = re.sub(r"[^0-9]", "", match.group(1))
+            if digits:
+                return digits[-4:]
+    fallback = re.search(
+        r"(?i)account\s+(?:number|ending\s+in|no\.?|#)[:\-\s]*(?:[xX\*#\s-]+)?([0-9]{4,})",
+        text,
+    )
+    if fallback:
+        digits = re.sub(r"[^0-9]", "", fallback.group(1))
+        if digits:
+            return digits[-4:]
+    return None
+
+
+def _extract_currency(text: str, aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        alias_text = alias.strip()
+        if not alias_text:
+            continue
+        pattern = re.compile(rf"{re.escape(alias_text)}[:\-\s]*([A-Z]{{3}})", re.IGNORECASE)
+        match = pattern.search(text)
+        if match:
+            return match.group(1).upper()
+        if len(alias_text) == 3 and alias_text.isalpha():
+            code_match = re.search(rf"\b{re.escape(alias_text)}\b", text, re.IGNORECASE)
+            if code_match:
+                return alias_text.upper()
+    fallback = re.search(r"\b(USD|EUR|GBP|CAD|AUD)\b", text, re.IGNORECASE)
+    if fallback:
+        return fallback.group(1).upper()
+    return None
+
+
+def _extract_date_with_aliases(text: str, aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        pattern = re.compile(rf"{re.escape(alias)}[:\-\s]*({DATE_TOKEN})", re.IGNORECASE)
+        match = pattern.search(text)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def _extract_statement_period(
+    text: str, start_aliases: Iterable[str], end_aliases: Iterable[str]
+) -> Tuple[str | None, str | None]:
+    for pattern in COMBINED_PERIOD_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group("start").strip(), match.group("end").strip()
+
+    start = _extract_date_with_aliases(text, start_aliases)
+    end = _extract_date_with_aliases(text, end_aliases)
+    return start, end
+
+
+def extract_fields(text: str) -> dict:
+    if not text:
+        text = ""
+
+    aliases = get_aliases_for("Bank_Statements")
+
+    start_date, end_date = _extract_statement_period(
+        text,
+        aliases.get("statement_period.start", []),
+        aliases.get("statement_period.end", []),
+    )
+
+    return {
+        "bank_name": _extract_text_field(text, aliases.get("bank_name", [])),
+        "account_holder_name": _extract_text_field(
+            text, aliases.get("account_holder_name", [])
+        ),
+        "account_number_last4": _extract_account_last4(
+            text, aliases.get("account_number_last4", [])
+        ),
+        "statement_period": {
+            "start": start_date,
+            "end": end_date,
+        },
+        "beginning_balance": _extract_numeric_field(
+            text, aliases.get("beginning_balance", [])
+        ),
+        "ending_balance": _extract_numeric_field(
+            text, aliases.get("ending_balance", [])
+        ),
+        "totals": {
+            "deposits": _extract_numeric_field(
+                text, aliases.get("totals.deposits", [])
+            ),
+            "withdrawals": _extract_numeric_field(
+                text, aliases.get("totals.withdrawals", [])
+            ),
+        },
+        "currency": _extract_currency(text, aliases.get("currency", [])),
+    }
+
+
+__all__ = ["extract_fields"]
+

--- a/ai-analyzer/tests/test_bank_statement_extractor.py
+++ b/ai-analyzer/tests/test_bank_statement_extractor.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.extractors.bank_statement import extract_fields
+
+
+@pytest.fixture
+def sample_bank_pdf_text() -> str:
+    return (
+        "Bank of America Business Checking Statement\n"
+        "Financial Institution: Bank of America\n"
+        "Account Owner: Paulsson Inc.\n"
+        "Account Number: ****1234\n"
+        "Statement Period: 06/01/2025 - 06/30/2025\n"
+        "Opening Balance: $12,540.00\n"
+        "Total Credits Posted: $9,500.00\n"
+        "Total Debits Posted: $3,300.00\n"
+        "Closing Balance: $18,750.25\n"
+        "Currency: USD\n"
+    )
+
+
+def test_extract_bank_statement_fields(sample_bank_pdf_text: str) -> None:
+    result = extract_fields(sample_bank_pdf_text)
+    assert result["bank_name"] == "Bank of America"
+    assert result["account_holder_name"] == "Paulsson Inc."
+    assert result["account_number_last4"] == "1234"
+    assert result["statement_period"]["start"] == "06/01/2025"
+    assert result["statement_period"]["end"] == "06/30/2025"
+    assert result["beginning_balance"] == "12540.00"
+    assert result["ending_balance"] == "18750.25"
+    assert result["totals"]["deposits"] == "9500.00"
+    assert result["totals"]["withdrawals"] == "3300.00"
+    assert result["currency"] == "USD"

--- a/document_library/aliases.json
+++ b/document_library/aliases.json
@@ -82,6 +82,82 @@
     "w2": "W2_Form",
     "w9": "W9_Form"
   },
+  "field_aliases": {
+    "Bank_Statements": {
+      "bank_name": [
+        "Bank Name",
+        "Financial Institution",
+        "Bank",
+        "Issued By"
+      ],
+      "account_number_last4": [
+        "Account Number",
+        "Acct No",
+        "A/C No",
+        "Account #",
+        "Account Ending In",
+        "Account ID"
+      ],
+      "statement_period.start": [
+        "Statement Start Date",
+        "From Date",
+        "Period Start",
+        "Start of Cycle",
+        "Period Covered From"
+      ],
+      "statement_period.end": [
+        "Statement End Date",
+        "To Date",
+        "Period End",
+        "End of Cycle",
+        "Period Covered To"
+      ],
+      "beginning_balance": [
+        "Beginning Balance",
+        "Opening Balance",
+        "Balance Brought Forward",
+        "Prior Balance"
+      ],
+      "ending_balance": [
+        "Ending Balance",
+        "Closing Balance",
+        "Available Balance",
+        "Final Balance",
+        "End of Period Balance"
+      ],
+      "totals.deposits": [
+        "Total Deposits",
+        "Credits",
+        "Total Inflows",
+        "Deposits Summary",
+        "Total Credits Posted",
+        "Incoming Transfers"
+      ],
+      "totals.withdrawals": [
+        "Total Withdrawals",
+        "Debits",
+        "Total Outflows",
+        "Withdrawals Summary",
+        "Total Debits Posted",
+        "Outgoing Transfers"
+      ],
+      "account_holder_name": [
+        "Account Holder",
+        "Account Owner",
+        "Customer Name",
+        "Business Name",
+        "Company Name"
+      ],
+      "currency": [
+        "Currency",
+        "Denomination",
+        "USD",
+        "EUR",
+        "GBP",
+        "CAD"
+      ]
+    }
+  },
   "family_aliases": {
     "tax return": "TaxReturn",
     "tax": "TaxReturn",

--- a/document_library/aliases.py
+++ b/document_library/aliases.py
@@ -1,0 +1,81 @@
+"""Helpers for working with document field aliases."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Dict, Iterable, List
+
+from . import ALIAS_PATH, catalog_index
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        lowered = text.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        ordered.append(text)
+    return ordered
+
+
+def _default_alias(field_name: str) -> str | None:
+    if not field_name:
+        return None
+    parts = field_name.split(".")
+    if len(parts) == 1:
+        base = parts[0]
+    else:
+        base = f"{parts[-2]} {parts[-1]}"
+    label = base.replace("_", " ").strip()
+    if not label:
+        return None
+    return " ".join(word.capitalize() for word in label.split())
+
+
+@lru_cache(maxsize=1)
+def _load_field_alias_payload() -> Dict[str, Dict[str, List[str]]]:
+    if not ALIAS_PATH.exists():
+        return {}
+    data = json.loads(ALIAS_PATH.read_text(encoding="utf-8"))
+    raw_field_aliases = data.get("field_aliases") or {}
+    normalized: Dict[str, Dict[str, List[str]]] = {}
+    for doc_key, mapping in raw_field_aliases.items():
+        field_map: Dict[str, List[str]] = {}
+        for field_name, aliases in (mapping or {}).items():
+            field_map[str(field_name)] = _dedupe(aliases or [])
+        normalized[str(doc_key)] = field_map
+    return normalized
+
+
+def get_aliases_for(doc_key: str | None) -> Dict[str, List[str]]:
+    """Return field alias lists for the requested document key."""
+
+    if not doc_key:
+        return {}
+    document_key = str(doc_key)
+    payload = _load_field_alias_payload()
+    doc_aliases = dict(payload.get(document_key, {}))
+
+    definition = catalog_index().get(document_key)
+    if definition:
+        for field_name in definition.schema_fields:
+            doc_aliases.setdefault(field_name, [])
+
+    for field_name, aliases in list(doc_aliases.items()):
+        default = _default_alias(field_name)
+        if default:
+            aliases = [default, *aliases]
+        doc_aliases[field_name] = _dedupe(aliases)
+
+    return doc_aliases
+
+
+__all__ = ["get_aliases_for"]
+

--- a/document_library/catalog.json
+++ b/document_library/catalog.json
@@ -101,16 +101,45 @@
       ],
       "core_level": "Core",
       "used_in_grants": [],
-      "schema_fields": [],
+      "schema_fields": [
+        "bank_name",
+        "account_number_last4",
+        "statement_period.start",
+        "statement_period.end",
+        "beginning_balance",
+        "ending_balance",
+        "totals.deposits",
+        "totals.withdrawals",
+        "account_holder_name",
+        "currency"
+      ],
       "detector": {
-        "filename_contains": [],
+        "filename_contains": [
+          "statement",
+          "bank"
+        ],
         "text_contains": [
           "Statement Date",
           "Ending Balance",
-          "Account Number"
+          "Account Number",
+          "Statement Period",
+          "Period Covered",
+          "Closing Balance",
+          "Available Balance",
+          "Bank of America",
+          "Chase Bank",
+          "Wells Fargo",
+          "CitiBank",
+          "Capital One"
         ],
-        "text_regex": []
-      }
+        "text_regex": [
+          "(?i)(ending|closing)\\s+balance",
+          "(?i)account\\s+(number|no|#)",
+          "(?i)statement\\s+(period|date)",
+          "(?i)period\\s+(covered|from|to)"
+        ]
+      },
+      "description": "Monthly or quarterly bank account statement used for business grants and refund validations, verifying active operations, balances, and transaction activity."
     },
     {
       "key": "Basic_Tax_Return",


### PR DESCRIPTION
## Summary
- add shared bank statement field aliases for multi-bank label variants
- enrich the bank statement catalog entry with detection hints and schema fields
- implement a bank statement extractor with pytest coverage and ensure tests can access shared libraries

## Testing
- pytest ai-analyzer/tests/test_bank_statement_extractor.py

------
https://chatgpt.com/codex/tasks/task_b_68e2f63ae6ec832794ef9374f8fd3c23